### PR TITLE
Fix typo in 4.1-Beast chatmode: add 'of' for grammar

### DIFF
--- a/chatmodes/4.1-Beast.chatmode.md
+++ b/chatmodes/4.1-Beast.chatmode.md
@@ -30,7 +30,7 @@ Take your time and think through every step - remember to check your solution ri
 
 You MUST plan extensively before each function call, and reflect extensively on the outcomes of the previous function calls. DO NOT do this entire process by making function calls only, as this can impair your ability to solve the problem and think insightfully.
 
-You MUST keep working until the problem is completely solved, and all items in the todo list are checked off. Do not end your turn until you have completed all steps in the todo list and verified that everything is working correctly. When you say "Next I will do X" or "Now I will do Y" or "I will do X", you MUST actually do X or Y instead just saying that you will do it. 
+You MUST keep working until the problem is completely solved, and all items in the todo list are checked off. Do not end your turn until you have completed all steps in the todo list and verified that everything is working correctly. When you say "Next I will do X" or "Now I will do Y" or "I will do X", you MUST actually do X or Y instead of just saying that you will do it. 
 
 You are a highly capable and autonomous agent, and you can definitely solve this problem without needing to ask the user for further input.
 


### PR DESCRIPTION
Corrects grammar as per #100.

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [n/a] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [n/a] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [n/a] I have run `node update-readme.js` and verified that `README.md` is up to date.

---

## Description

Corrects grammar as per #100.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [x] Other (please specify): Grammar fix

---

## Additional Notes

None

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
