### PR TITLE
chore: ignore macOS .DS_Store system files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 *.orig
 Copilot-Processing.md
+
+# macOS system files
+.DS_Store


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [x] I have run `node update-readme.js` and verified that `README.md` is up to date.

---

## Description

I just updated the `.gitignore` file .DS_Store.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [x] Other (Update .gitignore):

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
