### PR TITLE
Update rust.instructions.md - async fn in traits

### DIFF
--- a/instructions/rust.instructions.md
+++ b/instructions/rust.instructions.md
@@ -29,6 +29,7 @@ These instructions are based on [The Rust Book](https://doc.rust-lang.org/book/)
 - Use `serde` for serialization and `thiserror` or `anyhow` for custom errors.
 - Implement traits to abstract services or external dependencies.
 - Structure async code using `async/await` and `tokio` or `async-std`.
+- When implementing async functions in traits, use native async syntax (Rust 1.75+) by default. Only use the async-trait crate when object-safe traits with dynamic dispatch (dyn Trait) are required.
 - Prefer enums over flags and states for type safety.
 - Use builders for complex object creation.
 - Split binary and library code (`main.rs` vs `lib.rs`) for testability and reuse.


### PR DESCRIPTION
More specific about async fn in traits.

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [x] I have run `node update-readme.js` and verified that `README.md` is up to date.

---

## Description

<!-- Briefly describe your contribution and its purpose. Include any relevant context or usage notes. -->

Decision: Use native async traits by default, async-trait crate for dyn Trait
Rationale: Native async (Rust 1.75+) provides better performance with static dispatch; async-trait required for object-safe traits with dynamic dispatch
Impact: Improved performance for standard async traits, consistent approach for dynamic dispatch scenarios
Review: Re-evaluate when Rust adds native dyn async trait support

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [x] Other (please specify): update rust.instruction

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
