### PR TITLE
Align JUnit class name example with the `Test` suffix

### DIFF
--- a/prompts/java-junit.prompt.md
+++ b/prompts/java-junit.prompt.md
@@ -17,7 +17,7 @@ Your goal is to help me write effective unit tests with JUnit 5, covering both s
 
 ## Test Structure
 
-- Test classes should have a `Test` suffix, e.g., `CalculatorTests` for a `Calculator` class.
+- Test classes should have a `Test` suffix, e.g., `CalculatorTest` for a `Calculator` class.
 - Use `@Test` for test methods.
 - Follow the Arrange-Act-Assert (AAA) pattern.
 - Name tests using a descriptive convention, like `methodName_should_expectedBehavior_when_scenario`.


### PR DESCRIPTION
Ensure that the JUnit class name is aligned with the `Test` suffix.

## Pull Request Checklist

- [ X] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [ ] I have run `node update-readme.js` and verified that `README.md` is up to date.

---

## Description

The example `CalculatorTests` was not aligned with the `Test` (and not `Tests` suffix).

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [ X] Other (please specify): minor / typo


---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
