### PR TITLE
Remove mode from first-ask prompt

### DIFF
--- a/prompts/first-ask.prompt.md
+++ b/prompts/first-ask.prompt.md
@@ -1,6 +1,5 @@
 ---
 description: 'Interactive, input-tool powered, task refinement workflow: interrogates scope, deliverables, constraints before carrying out the task; Requires the Joyride extension.'
-mode: 'agent'
 ---
 
 # Act Informed: First understand together with the human, then do


### PR DESCRIPTION
Because the `mode` resets custom chat mode.

As per discussion: https://github.com/github/awesome-copilot/pull/198#discussion_r2284312608

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [x] I have run `node update-readme.js` and verified that `README.md` is up to date.

---

## Description

<!-- Briefly describe your contribution and its purpose. Include any relevant context or usage notes. -->

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [x] Other (please specify): Update to existing prompt file

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
