### PR TITLE
Fix typos and improve documentation clarity

### DIFF
--- a/chatmodes/clojure-interactive-programming.chatmode.md
+++ b/chatmodes/clojure-interactive-programming.chatmode.md
@@ -81,8 +81,8 @@ Before ANY file modification:
 #### Example: Bug Fix Workflow
 
 ```clojure
-(require '[namespace.with.issue :as issue])
-(require '[clojure.repl :refer [source]])
+(require '[namespace.with.issue :as issue] :reload)
+(require '[clojure.repl :refer [source]] :reload)
 ;; 1. Examine the current implementation
 ;; 2. Test current behavior
 (issue/problematic-function test-data)
@@ -99,16 +99,16 @@ Before ANY file modification:
 
 ```clojure
 ;; 1. Run the failing test
-(require '[clojure.test :refer [test-vars]])
+(require '[clojure.test :refer [test-vars]] :reload)
 (test-vars [#'my.namespace-test/failing-test])
 ;; 2. Extract test data from the test
-(require '[my.namespace-test :as test])
+(require '[my.namespace-test :as test] :reload)
 ;; Look at the test source
 (source test/failing-test)
 ;; 3. Create test data in REPL
 (def test-input {:id 123 :name \"test\"})
 ;; 4. Run the function being tested
-(require '[my.namespace :as my])
+(require '[my.namespace :as my] :reload)
 (my/process-data test-input)
 ;; => Unexpected result!
 ;; 5. Debug step by step

--- a/instructions/clojure.instructions.md
+++ b/instructions/clojure.instructions.md
@@ -189,21 +189,7 @@ Rich Comment Forms `(comment ...)` serve a different purpose than direct REPL ev
 - **Exploration preservation** - Keep useful REPL discoveries in the codebase
 - **Example scenarios** - Demonstrate edge cases and typical usage
 
-### Docstrings in `defn`
-Docstrings belong immediately after the function name and before the argument vector.
-
-```clojure
-(defn my-function
-  "This function does something."
-  [arg1 arg2]
-  ;; function body
-  )
-```
-
-- Define functions before they are used—prefer ordering over `declare` except when truly necessary.
-
 ### RCF Patterns
-
 RCF = Rich Comment Forms.
 
 When files are loaded code in RCFs is not evaluated, making them perfect for documenting example usage, since humans easily can evaluate the code in there at will.

--- a/instructions/clojure.instructions.md
+++ b/instructions/clojure.instructions.md
@@ -7,6 +7,11 @@ applyTo: '**/*.{clj,cljs,cljc,bb,edn.mdx?}'
 
 ## Code Evaluation Tool usage
 
+“Use the repl” means to use the **Evaluate Clojure Code** tool from Calva Backseat Driver. It connects you to the the same REPL as the user is connected to via Calva.
+
+- Always stay inside Calva's REPL instead of launching a second one from the terminal.
+- If there is no REPL connection, ask the user to connect the REPL instead of trying to start and connect it yourself.
+
 ### JSON Strings in REPL Tool Calls
 Do not over-escape JSON arguments when invoking REPL tools.
 

--- a/prompts/remember-interactive-programming.prompt.md
+++ b/prompts/remember-interactive-programming.prompt.md
@@ -3,7 +3,7 @@ description: 'A micro-prompt that reminds the agent that it is an interactive pr
 title: 'Interactive Programming Nudge'
 ---
 
-Remember that you are an interactive programmer with the system itself as your source of thruth. You use the REPL to explore the current system and to modify the current system in order to understand what changes need to be made.
+Remember that you are an interactive programmer with the system itself as your source of truth. You use the REPL to explore the current system and to modify the current system in order to understand what changes need to be made.
 
 Remember that the human does not see what you evaluate with the tool:
 * If you evaluate a large amount of code: describe in a succinct way what is being evaluated.


### PR DESCRIPTION
Attending to the Copilot review points on the PR that was merged:

- Fixed the word "thruth" to "truth."
- Eliminated redundant docstring placement instructions for clarity.

Also updated the instructions and the chatmode a tiny bit based on user feedback.

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [x] I have run `node update-readme.js` and verified that `README.md` is up to date.

---

## Description

<!-- Briefly describe your contribution and its purpose. Include any relevant context or usage notes. -->

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [x] Other (please specify): Tiny fixes

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
