### PR TITLE
Fix code block formatting in specification prompt

### DIFF
--- a/prompts/create-specification.prompt.md
+++ b/prompts/create-specification.prompt.md
@@ -111,9 +111,9 @@ tags: [Optional: List of relevant tags or categories, e.g., `infrastructure`, `p
 
 ## 9. Examples & Edge Cases
 
-```code
-// Code snippet or data example demonstrating the correct application of the guidelines, including edge cases
-```
+    ```code
+    // Code snippet or data example demonstrating the correct application of the guidelines, including edge cases
+    ```
 
 ## 10. Validation Criteria
 


### PR DESCRIPTION
Indent code block example at list item 9 so entire example can be rendered.

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [x] I have run `node update-readme.js` and verified that `README.md` is up to date.

---

## Description

The entire example nested in a code block is not rendered as raw data because an example code block closes it. This pull indents the example code block so the entire example can be rendered as if raw data.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [x] Other (please specify): Existing document correction.

---

## Additional Notes

At the top **Pull Request Checklist** header maybe change to `## Pull Request Checklist (check all that apply)`.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
