### PR TITLE
Replace mvn clean install with mvn clean package in springboot.instructions.md

### DIFF
--- a/instructions/springboot.instructions.md
+++ b/instructions/springboot.instructions.md
@@ -53,6 +53,6 @@ applyTo: '**/*.java, **/*.kt'
 ## Build and Verification
 
 - After adding or modifying code, verify the project continues to build successfully.
-- If the project uses Maven, run `mvn clean install`.
+- If the project uses Maven, run `mvn clean package`.
 - If the project uses Gradle, run `./gradlew build` (or `gradlew.bat build` on Windows).
 - Ensure all tests pass as part of the build.


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [x] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [x] I have run `node update-readme.js` and verified that `README.md` is up to date.

---

## Description

Replace `mvn clean install` with `mvn clean package` in springboot.instructions.md. This is a docs-only change to recommend building and running tests without installing artifacts to the local Maven repository.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [x] Other (docs update: change build verification command):

---

## Additional Notes

- File edited: springboot.instructions.md - line 56.
- Reason: reduce side effects for readers who only need to verify build/tests; keep install optional for consumers who need artifacts in ~/.m2.
- Validation: run `mvn clean package` to confirm build and tests succeed. No code changes or CI updates expected.
---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
