### PR TITLE
Fix: Update editFiles tool reference to edit/editFiles

### DIFF
--- a/chatmodes/accesibility.chatmode.md
+++ b/chatmodes/accesibility.chatmode.md
@@ -1,7 +1,7 @@
 ---
 description: 'Accessibility mode.'
 model: GPT-4.1
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 title: 'Accessibility mode'
 ---
 

--- a/chatmodes/azure-logic-apps-expert.chatmode.md
+++ b/chatmodes/azure-logic-apps-expert.chatmode.md
@@ -1,7 +1,7 @@
 ---
 description: 'Expert guidance for Azure Logic Apps development focusing on workflow design, integration patterns, and JSON-based Workflow Definition Language.'
 model: 'gpt-4'
-tools: ['codebase', 'changes', 'editFiles', 'search', 'runCommands', 'microsoft.docs.mcp', 'azure_get_code_gen_best_practices', 'azure_query_learn']
+tools: ['codebase', 'changes', 'edit/editFiles', 'search', 'runCommands', 'microsoft.docs.mcp', 'azure_get_code_gen_best_practices', 'azure_query_learn']
 ---
 
 # Azure Logic Apps Expert Mode

--- a/chatmodes/azure-principal-architect.chatmode.md
+++ b/chatmodes/azure-principal-architect.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Provide expert Azure Principal Architect guidance using Azure Well-Architected Framework principles and Microsoft best practices.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'azure_design_architecture', 'azure_get_code_gen_best_practices', 'azure_get_deployment_best_practices', 'azure_get_swa_best_practices', 'azure_query_learn']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'azure_design_architecture', 'azure_get_code_gen_best_practices', 'azure_get_deployment_best_practices', 'azure_get_swa_best_practices', 'azure_query_learn']
 ---
 # Azure Principal Architect mode instructions
 

--- a/chatmodes/azure-saas-architect.chatmode.md
+++ b/chatmodes/azure-saas-architect.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Provide expert Azure SaaS Architect guidance focusing on multitenant applications using Azure Well-Architected SaaS principles and Microsoft best practices.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'azure_design_architecture', 'azure_get_code_gen_best_practices', 'azure_get_deployment_best_practices', 'azure_get_swa_best_practices', 'azure_query_learn']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'azure_design_architecture', 'azure_get_code_gen_best_practices', 'azure_get_deployment_best_practices', 'azure_get_swa_best_practices', 'azure_query_learn']
 ---
 # Azure SaaS Architect mode instructions
 

--- a/chatmodes/azure-verified-modules-bicep.chatmode.md
+++ b/chatmodes/azure-verified-modules-bicep.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Create, update, or review Azure IaC in Bicep using Azure Verified Modules (AVM).'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'azure_get_deployment_best_practices', 'azure_get_schema_for_Bicep']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'azure_get_deployment_best_practices', 'azure_get_schema_for_Bicep']
 ---
 # Azure AVM Bicep mode
 

--- a/chatmodes/azure-verified-modules-terraform.chatmode.md
+++ b/chatmodes/azure-verified-modules-terraform.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Create, update, or review Azure IaC in Terraform using Azure Verified Modules (AVM).'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'azure_get_deployment_best_practices', 'azure_get_schema_for_Bicep']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'azure_get_deployment_best_practices', 'azure_get_schema_for_Bicep']
 ---
 
 # Azure AVM Terraform mode

--- a/chatmodes/bicep-implement.chatmode.md
+++ b/chatmodes/bicep-implement.chatmode.md
@@ -1,7 +1,7 @@
 ---
 description: 'Act as an Azure Bicep Infrastructure as Code coding specialist that creates Bicep templates.'
 tools:
-  [ 'editFiles', 'fetch', 'runCommands', 'terminalLastCommand', 'get_bicep_best_practices', 'azure_get_azure_verified_module', 'todos' ]
+  [ 'edit/editFiles', 'fetch', 'runCommands', 'terminalLastCommand', 'get_bicep_best_practices', 'azure_get_azure_verified_module', 'todos' ]
 ---
 
 # Azure Bicep Infrastructure as Code coding Specialist

--- a/chatmodes/bicep-plan.chatmode.md
+++ b/chatmodes/bicep-plan.chatmode.md
@@ -1,7 +1,7 @@
 ---
 description: 'Act as implementation planner for your Azure Bicep Infrastructure as Code task.'
 tools:
-  [ 'editFiles', 'fetch', 'microsoft-docs', 'azure_design_architecture', 'get_bicep_best_practices', 'bestpractices', 'bicepschema', 'azure_get_azure_verified_module', 'todos' ]
+  [ 'edit/editFiles', 'fetch', 'microsoft-docs', 'azure_design_architecture', 'get_bicep_best_practices', 'bestpractices', 'bicepschema', 'azure_get_azure_verified_module', 'todos' ]
 ---
 
 # Azure Bicep Infrastructure Planning

--- a/chatmodes/csharp-dotnet-janitor.chatmode.md
+++ b/chatmodes/csharp-dotnet-janitor.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Perform janitorial tasks on C#/.NET code including cleanup, modernization, and tech debt remediation.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github']
 ---
 # C#/.NET Janitor
 

--- a/chatmodes/debug.chatmode.md
+++ b/chatmodes/debug.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Debug your application to find and fix a bug'
-tools: ['editFiles', 'search', 'runCommands', 'usages', 'problems', 'testFailure', 'fetch', 'githubRepo', 'runTests']
+tools: ['edit/editFiles', 'search', 'runCommands', 'usages', 'problems', 'testFailure', 'fetch', 'githubRepo', 'runTests']
 ---
 
 # Debug Mode Instructions

--- a/chatmodes/expert-cpp-software-engineer.chatmode.md
+++ b/chatmodes/expert-cpp-software-engineer.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Provide expert C++ software engineering guidance using modern C++ and industry best practices.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp']
 ---
 # Expert C++ software engineer mode instructions
 

--- a/chatmodes/expert-dotnet-software-engineer.chatmode.md
+++ b/chatmodes/expert-dotnet-software-engineer.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Provide expert .NET software engineering guidance using modern software design patterns.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp']
 ---
 # Expert .NET software engineer mode instructions
 

--- a/chatmodes/expert-react-frontend-engineer.chatmode.md
+++ b/chatmodes/expert-react-frontend-engineer.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Provide expert React frontend engineering guidance using modern TypeScript and design patterns.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp']
 ---
 # Expert React Frontend Engineer Mode Instructions
 

--- a/chatmodes/hlbpa.chatmode.md
+++ b/chatmodes/hlbpa.chatmode.md
@@ -4,7 +4,7 @@ model: 'claude-sonnet-4'
 tools:
   - 'codebase'
   - 'changes'
-  - 'editFiles'
+  - 'edit/editFiles'
   - 'fetch'
   - 'findTestFiles'
   - 'githubRepo'

--- a/chatmodes/implementation-plan.chatmode.md
+++ b/chatmodes/implementation-plan.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Generate an implementation plan for new features or refactoring existing code.'
-tools: ['codebase', 'usages', 'vscodeAPI', 'think', 'problems', 'changes', 'testFailure', 'terminalSelection', 'terminalLastCommand', 'openSimpleBrowser', 'fetch', 'findTestFiles', 'searchResults', 'githubRepo', 'extensions', 'editFiles', 'runNotebooks', 'search', 'new', 'runCommands', 'runTasks']
+tools: ['codebase', 'usages', 'vscodeAPI', 'think', 'problems', 'changes', 'testFailure', 'terminalSelection', 'terminalLastCommand', 'openSimpleBrowser', 'fetch', 'findTestFiles', 'searchResults', 'githubRepo', 'extensions', 'edit/editFiles', 'runNotebooks', 'search', 'new', 'runCommands', 'runTasks']
 ---
 # Implementation Plan Generation Mode
 

--- a/chatmodes/janitor.chatmode.md
+++ b/chatmodes/janitor.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Perform janitorial tasks on any codebase including cleanup, simplification, and tech debt remediation.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github']
 ---
 # Universal Janitor
 

--- a/chatmodes/meta-agentic-project-scaffold.chatmode.md
+++ b/chatmodes/meta-agentic-project-scaffold.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Meta agentic project creation assistant to help users create and manage project workflows effectively.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'readCellOutput', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'updateUserPreferences', 'usages', 'vscodeAPI', 'activePullRequest', 'copilotCodingAgent']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'readCellOutput', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'updateUserPreferences', 'usages', 'vscodeAPI', 'activePullRequest', 'copilotCodingAgent']
 model: 'GPT-4.1'
 ---
 

--- a/chatmodes/microsoft_learn_contributor.chatmode.md
+++ b/chatmodes/microsoft_learn_contributor.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Microsoft Learn Contributor chatmode for editing and writing Microsoft Learn documentation following Microsoft Writing Style Guide and authoring best practices.'
-tools: ['changes', 'codebase', 'editFiles', 'new', 'openSimpleBrowser', 'problems', 'search', 'searchResults', 'microsoft.docs.mcp']
+tools: ['changes', 'codebase', 'edit/editFiles', 'new', 'openSimpleBrowser', 'problems', 'search', 'searchResults', 'microsoft.docs.mcp']
 ---
 
 # Microsoft Learn Contributor

--- a/chatmodes/ms-sql-dba.chatmode.md
+++ b/chatmodes/ms-sql-dba.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Work with Microsoft SQL Server databases using the MS SQL extension.'
-tools: ['codebase', 'editFiles', 'githubRepo', 'extensions', 'runCommands', 'database', 'mssql_connect', 'mssql_query', 'mssql_listServers', 'mssql_listDatabases', 'mssql_disconnect', 'mssql_visualizeSchema']
+tools: ['codebase', 'edit/editFiles', 'githubRepo', 'extensions', 'runCommands', 'database', 'mssql_connect', 'mssql_query', 'mssql_listServers', 'mssql_listDatabases', 'mssql_disconnect', 'mssql_visualizeSchema']
 ---
 
 # MS-SQL Database Administrator

--- a/chatmodes/playwright-tester.chatmode.md
+++ b/chatmodes/playwright-tester.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Testing mode for Playwright tests'
-tools: ['changes', 'codebase', 'editFiles', 'fetch', 'findTestFiles', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'playwright']
+tools: ['changes', 'codebase', 'edit/editFiles', 'fetch', 'findTestFiles', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'playwright']
 model: Claude Sonnet 4
 ---
 

--- a/chatmodes/postgresql-dba.chatmode.md
+++ b/chatmodes/postgresql-dba.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Work with PostgreSQL databases using the PostgreSQL extension.'
-tools: ['codebase', 'editFiles', 'githubRepo', 'extensions', 'runCommands', 'database', 'pgsql_bulkLoadCsv', 'pgsql_connect', 'pgsql_describeCsv', 'pgsql_disconnect', 'pgsql_listDatabases', 'pgsql_listServers', 'pgsql_modifyDatabase', 'pgsql_open_script', 'pgsql_query', 'pgsql_visualizeSchema']
+tools: ['codebase', 'edit/editFiles', 'githubRepo', 'extensions', 'runCommands', 'database', 'pgsql_bulkLoadCsv', 'pgsql_connect', 'pgsql_describeCsv', 'pgsql_disconnect', 'pgsql_listDatabases', 'pgsql_listServers', 'pgsql_modifyDatabase', 'pgsql_open_script', 'pgsql_query', 'pgsql_visualizeSchema']
 ---
 
 # PostgreSQL Database Administrator

--- a/chatmodes/prd.chatmode.md
+++ b/chatmodes/prd.chatmode.md
@@ -1,7 +1,7 @@
 ---
 
 description: 'Generate a comprehensive Product Requirements Document (PRD) in Markdown, detailing user stories, acceptance criteria, technical considerations, and metrics. Optionally create GitHub issues upon user confirmation.'
-tools: ['codebase', 'editFiles', 'fetch', 'findTestFiles', 'list_issues', 'githubRepo', 'search', 'add_issue_comment', 'create_issue', 'update_issue', 'get_issue', 'search_issues']
+tools: ['codebase', 'edit/editFiles', 'fetch', 'findTestFiles', 'list_issues', 'githubRepo', 'search', 'add_issue_comment', 'create_issue', 'update_issue', 'get_issue', 'search_issues']
 ---
 
 # Create PRD Chat Mode

--- a/chatmodes/principal-software-engineer.chatmode.md
+++ b/chatmodes/principal-software-engineer.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Provide principal-level software engineering guidance with focus on engineering excellence, technical leadership, and pragmatic implementation.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'github']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'github']
 ---
 # Principal software engineer mode instructions
 

--- a/chatmodes/prompt-builder.chatmode.md
+++ b/chatmodes/prompt-builder.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Expert prompt engineering and validation system for creating high-quality prompts - Brought to you by microsoft/edge-ai'
-tools: ['codebase', 'editFiles', 'fetch', 'githubRepo', 'problems', 'runCommands', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'usages', 'terraform', 'Microsoft Docs', 'context7']
+tools: ['codebase', 'edit/editFiles', 'fetch', 'githubRepo', 'problems', 'runCommands', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'usages', 'terraform', 'Microsoft Docs', 'context7']
 ---
 
 # Prompt Builder Instructions

--- a/chatmodes/semantic-kernel-dotnet.chatmode.md
+++ b/chatmodes/semantic-kernel-dotnet.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Create, update, refactor, explain or work with code using the .NET version of Semantic Kernel.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github']
 ---
 # Semantic Kernel .NET mode instructions
 

--- a/chatmodes/semantic-kernel-python.chatmode.md
+++ b/chatmodes/semantic-kernel-python.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Create, update, refactor, explain or work with code using the Python version of Semantic Kernel.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github', 'configurePythonEnvironment', 'getPythonEnvironmentInfo', 'getPythonExecutableCommand', 'installPythonPackage']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github', 'configurePythonEnvironment', 'getPythonEnvironmentInfo', 'getPythonExecutableCommand', 'installPythonPackage']
 ---
 # Semantic Kernel Python mode instructions
 

--- a/chatmodes/software-engineer-agent-v1.chatmode.md
+++ b/chatmodes/software-engineer-agent-v1.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Expert-level software engineering agent. Deliver production-ready, maintainable code. Execute systematically and specification-driven. Document comprehensively. Operate autonomously and adaptively.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'github']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'github']
 ---
 # Software Engineer Agent v1
 

--- a/chatmodes/specification.chatmode.md
+++ b/chatmodes/specification.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Generate or update specification documents for new or existing functionality.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github']
 ---
 # Specification mode instructions
 

--- a/chatmodes/task-planner.chatmode.md
+++ b/chatmodes/task-planner.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Task planner for creating actionable implementation plans - Brought to you by microsoft/edge-ai'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'terraform', 'Microsoft Docs', 'azure_get_schema_for_Bicep', 'context7']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'terraform', 'Microsoft Docs', 'azure_get_schema_for_Bicep', 'context7']
 ---
 
 # Task Planner Instructions

--- a/chatmodes/task-researcher.chatmode.md
+++ b/chatmodes/task-researcher.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Task research specialist for comprehensive project analysis - Brought to you by microsoft/edge-ai'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'terraform', 'Microsoft Docs', 'azure_get_schema_for_Bicep', 'context7']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'terraform', 'Microsoft Docs', 'azure_get_schema_for_Bicep', 'context7']
 ---
 
 # Task Researcher Instructions

--- a/chatmodes/tdd-green.chatmode.md
+++ b/chatmodes/tdd-green.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Implement minimal code to satisfy GitHub issue requirements and make failing tests pass without over-engineering.'
-tools: ['github', 'findTestFiles', 'editFiles', 'runTests', 'runCommands', 'codebase', 'filesystem', 'search', 'problems', 'testFailure', 'terminalLastCommand']
+tools: ['github', 'findTestFiles', 'edit/editFiles', 'runTests', 'runCommands', 'codebase', 'filesystem', 'search', 'problems', 'testFailure', 'terminalLastCommand']
 ---
 # TDD Green Phase - Make Tests Pass Quickly
 

--- a/chatmodes/tdd-red.chatmode.md
+++ b/chatmodes/tdd-red.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Guide test-first development by writing failing tests that describe desired behaviour from GitHub issue context before implementation exists.'
-tools: ['github', 'findTestFiles', 'editFiles', 'runTests', 'runCommands', 'codebase', 'filesystem', 'search', 'problems', 'testFailure', 'terminalLastCommand']
+tools: ['github', 'findTestFiles', 'edit/editFiles', 'runTests', 'runCommands', 'codebase', 'filesystem', 'search', 'problems', 'testFailure', 'terminalLastCommand']
 ---
 # TDD Red Phase - Write Failing Tests First
 

--- a/chatmodes/tdd-refactor.chatmode.md
+++ b/chatmodes/tdd-refactor.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Improve code quality, apply security best practices, and enhance design whilst maintaining green tests and GitHub issue compliance.'
-tools: ['github', 'findTestFiles', 'editFiles', 'runTests', 'runCommands', 'codebase', 'filesystem', 'search', 'problems', 'testFailure', 'terminalLastCommand']
+tools: ['github', 'findTestFiles', 'edit/editFiles', 'runTests', 'runCommands', 'codebase', 'filesystem', 'search', 'problems', 'testFailure', 'terminalLastCommand']
 ---
 # TDD Refactor Phase - Improve Quality & Security
 

--- a/chatmodes/tech-debt-remediation-plan.chatmode.md
+++ b/chatmodes/tech-debt-remediation-plan.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Generate technical debt remediation plans for code, tests, and documentation.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'github']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'github']
 ---
 # Technical Debt Remediation Plan
 

--- a/chatmodes/terraform-azure-implement.chatmode.md
+++ b/chatmodes/terraform-azure-implement.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Act as an Azure Terraform Infrastructure as Code coding specialist that creates and reviews Terraform for Azure resources.'
-tools: ['editFiles', 'search', 'runCommands', 'fetch', 'todos', 'azureterraformbestpractices', 'documentation', 'get_bestpractices', 'microsoft-docs']
+tools: ['edit/editFiles', 'search', 'runCommands', 'fetch', 'todos', 'azureterraformbestpractices', 'documentation', 'get_bestpractices', 'microsoft-docs']
 ---
 
 # Azure Terraform Infrastructure as Code Implementation Specialist

--- a/chatmodes/terraform-azure-planning.chatmode.md
+++ b/chatmodes/terraform-azure-planning.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Act as implementation planner for your Azure Terraform Infrastructure as Code task.'
-tools: ['editFiles', 'fetch', 'todos', 'azureterraformbestpractices', 'cloudarchitect', 'documentation', 'get_bestpractices', 'microsoft-docs']
+tools: ['edit/editFiles', 'fetch', 'todos', 'azureterraformbestpractices', 'cloudarchitect', 'documentation', 'get_bestpractices', 'microsoft-docs']
 ---
 
 # Azure Terraform Infrastructure Planning

--- a/chatmodes/voidbeast-gpt41enhanced.chatmode.md
+++ b/chatmodes/voidbeast-gpt41enhanced.chatmode.md
@@ -1,7 +1,7 @@
 ---
 description: '4.1 voidBeast_GPT41Enhanced 1.0 : a advanced autonomous developer agent, designed for elite full-stack development with enhanced multi-mode capabilities. This latest evolution features sophisticated mode detection, comprehensive research capabilities, and never-ending problem resolution. Plan/Act/Deep Research/Analyzer/Checkpoints(Memory)/Prompt Generator Modes.
 '
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'readCellOutput', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'updateUserPreferences', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'readCellOutput', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'updateUserPreferences', 'usages', 'vscodeAPI']
 
 ---
 

--- a/chatmodes/wg-code-alchemist.chatmode.md
+++ b/chatmodes/wg-code-alchemist.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Ask WG Code Alchemist to transform your code with Clean Code principles and SOLID design'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 
 You are WG Code Alchemist, an expert software engineer specializing in Clean Code practices and SOLID principles. You communicate with the precision and helpfulness of JARVIS from Iron Man.

--- a/chatmodes/wg-code-sentinel.chatmode.md
+++ b/chatmodes/wg-code-sentinel.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Ask WG Code Sentinel to review your code for security issues.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 
 You are WG Code Sentinel, an expert security reviewer specializing in identifying and mitigating code vulnerabilities. You communicate with the precision and helpfulness of JARVIS from Iron Man.

--- a/prompts/aspnet-minimal-api-openapi.prompt.md
+++ b/prompts/aspnet-minimal-api-openapi.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
 description: 'Create ASP.NET Minimal API endpoints with proper OpenAPI documentation'
 ---
 

--- a/prompts/containerize-aspnet-framework.prompt.md
+++ b/prompts/containerize-aspnet-framework.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['codebase', 'editFiles', 'terminalCommand']
+tools: ['codebase', 'edit/editFiles', 'terminalCommand']
 description: 'Containerize an ASP.NET .NET Framework project by creating Dockerfile and .dockerfile files customized for the project.'
 ---
 

--- a/prompts/containerize-aspnetcore.prompt.md
+++ b/prompts/containerize-aspnetcore.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['codebase', 'editFiles', 'terminalCommand']
+tools: ['codebase', 'edit/editFiles', 'terminalCommand']
 description: 'Containerize an ASP.NET Core project by creating Dockerfile and .dockerfile files customized for the project.'
 ---
 

--- a/prompts/create-architectural-decision-record.prompt.md
+++ b/prompts/create-architectural-decision-record.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create an Architectural Decision Record (ADR) document for AI-optimized decision documentation.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Create Architectural Decision Record
 

--- a/prompts/create-github-action-workflow-specification.prompt.md
+++ b/prompts/create-github-action-workflow-specification.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create a formal specification for an existing GitHub Actions CI/CD workflow, optimized for AI consumption and workflow maintenance.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runInTerminal2', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github', 'Microsoft Docs']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runInTerminal2', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github', 'Microsoft Docs']
 ---
 # Create GitHub Actions Workflow Specification
 

--- a/prompts/create-implementation-plan.prompt.md
+++ b/prompts/create-implementation-plan.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create a new implementation plan file for new features, refactoring existing code or upgrading packages, design, architecture or infrastructure.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Create Implementation Plan
 

--- a/prompts/create-llms.prompt.md
+++ b/prompts/create-llms.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create an llms.txt file from scratch based on repository structure following the llms.txt specification at https://llmstxt.org/'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Create LLMs.txt File from Repository Structure
 

--- a/prompts/create-oo-component-documentation.prompt.md
+++ b/prompts/create-oo-component-documentation.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create comprehensive, standardized documentation for object-oriented components following industry best practices and architectural documentation standards.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Generate Standard OO Component Documentation
 

--- a/prompts/create-specification.prompt.md
+++ b/prompts/create-specification.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create a new specification file for the solution, optimized for Generative AI consumption.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Create Specification
 

--- a/prompts/csharp-async.prompt.md
+++ b/prompts/csharp-async.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
 description: 'Get best practices for C# async programming'
 ---
 

--- a/prompts/csharp-docs.prompt.md
+++ b/prompts/csharp-docs.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
 description: 'Ensure that C# types are documented with XML comments and follow best practices for documentation.'
 ---
 

--- a/prompts/csharp-mstest.prompt.md
+++ b/prompts/csharp-mstest.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems', 'search']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for MSTest unit testing, including data-driven tests'
 ---
 

--- a/prompts/csharp-nunit.prompt.md
+++ b/prompts/csharp-nunit.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems', 'search']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for NUnit unit testing, including data-driven tests'
 ---
 

--- a/prompts/csharp-tunit.prompt.md
+++ b/prompts/csharp-tunit.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems', 'search']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for TUnit unit testing, including data-driven tests'
 ---
 

--- a/prompts/csharp-xunit.prompt.md
+++ b/prompts/csharp-xunit.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems', 'search']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for XUnit unit testing, including data-driven tests'
 ---
 

--- a/prompts/documentation-writer.prompt.md
+++ b/prompts/documentation-writer.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['editFiles', 'search', 'fetch']
+tools: ['edit/editFiles', 'search', 'fetch']
 description: 'Diátaxis Documentation Expert. An expert technical writer specializing in creating high-quality software documentation, guided by the principles and structure of the Diátaxis technical documentation authoring framework.'
 ---
 

--- a/prompts/ef-core.prompt.md
+++ b/prompts/ef-core.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems', 'runCommands']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'runCommands']
 description: 'Get best practices for Entity Framework Core'
 ---
 

--- a/prompts/java-docs.prompt.md
+++ b/prompts/java-docs.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
 description: 'Ensure that Java types are documented with Javadoc comments and follow best practices for documentation.'
 ---
 

--- a/prompts/java-junit.prompt.md
+++ b/prompts/java-junit.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems', 'search']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for JUnit 5 unit testing, including data-driven tests'
 ---
 

--- a/prompts/java-springboot.prompt.md
+++ b/prompts/java-springboot.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems', 'search']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for developing applications with Spring Boot.'
 ---
 

--- a/prompts/kotlin-springboot.prompt.md
+++ b/prompts/kotlin-springboot.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems', 'search']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for developing applications with Spring Boot and Kotlin.'
 ---
 

--- a/prompts/mkdocs-translations.prompt.md
+++ b/prompts/mkdocs-translations.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: agent
 description: 'Generate a language translation for a mkdocs documentation stack.'
-tools: ['codebase', 'usages', 'problems', 'changes', 'terminalSelection', 'terminalLastCommand', 'searchResults', 'extensions', 'editFiles', 'search', 'runCommands', 'runTasks']
+tools: ['codebase', 'usages', 'problems', 'changes', 'terminalSelection', 'terminalLastCommand', 'searchResults', 'extensions', 'edit/editFiles', 'search', 'runCommands', 'runTasks']
 model: Claude Sonnet 4
 ---
 

--- a/prompts/next-intl-add-language.prompt.md
+++ b/prompts/next-intl-add-language.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes','codebase', 'editFiles', 'findTestFiles', 'search', 'writeTest']
+tools: ['changes','codebase', 'edit/editFiles', 'findTestFiles', 'search', 'writeTest']
 description: 'Add new language to a Next.js + next-intl application'
 ---
 

--- a/prompts/playwright-explore-website.prompt.md
+++ b/prompts/playwright-explore-website.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: agent
 description: 'Website exploration for testing using Playwright MCP'
-tools: ['changes', 'codebase', 'editFiles', 'fetch', 'findTestFiles', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'playwright']
+tools: ['changes', 'codebase', 'edit/editFiles', 'fetch', 'findTestFiles', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'playwright']
 model: 'Claude Sonnet 4'
 ---
 

--- a/prompts/playwright-generate-test.prompt.md
+++ b/prompts/playwright-generate-test.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: agent
 description: 'Generate a Playwright test based on a scenario using Playwright MCP'
-tools: ['changes', 'codebase', 'editFiles', 'fetch', 'findTestFiles', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'playwright']
+tools: ['changes', 'codebase', 'edit/editFiles', 'fetch', 'findTestFiles', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'playwright']
 model: 'Claude Sonnet 4'
 ---
 

--- a/prompts/postgresql-code-review.prompt.md
+++ b/prompts/postgresql-code-review.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
 description: 'PostgreSQL-specific code review assistant focusing on PostgreSQL best practices, anti-patterns, and unique quality standards. Covers JSONB operations, array usage, custom types, schema design, function optimization, and PostgreSQL-exclusive security features like Row Level Security (RLS).'
 tested_with: 'GitHub Copilot Chat (GPT-4o) - Validated July 20, 2025'
 ---

--- a/prompts/postgresql-optimization.prompt.md
+++ b/prompts/postgresql-optimization.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
 description: 'PostgreSQL-specific development assistant focusing on unique PostgreSQL features, advanced data types, and PostgreSQL-exclusive capabilities. Covers JSONB operations, array types, custom types, range/geometric types, full-text search, window functions, and PostgreSQL extensions ecosystem.'
 tested_with: 'GitHub Copilot Chat (GPT-4o) - Validated July 20, 2025'
 ---

--- a/prompts/power-apps-code-app-scaffold.prompt.md
+++ b/prompts/power-apps-code-app-scaffold.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: 'Scaffold a complete Power Apps Code App project with PAC CLI setup, SDK integration, and connector configuration'
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems', 'search']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
 model: GPT-4.1
 ---
 

--- a/prompts/prompt-builder.prompt.md
+++ b/prompts/prompt-builder.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['codebase', 'editFiles', 'search']
+tools: ['codebase', 'edit/editFiles', 'search']
 description: 'Guide users through creating high-quality GitHub Copilot prompts with proper structure, tools, and best practices.'
 ---
 

--- a/prompts/repo-story-time.prompt.md
+++ b/prompts/repo-story-time.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Generate a comprehensive repository summary and narrative story from commit history'
-tools: ['changes', 'codebase', 'editFiles', 'githubRepo', 'runCommands', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection']
+tools: ['changes', 'codebase', 'edit/editFiles', 'githubRepo', 'runCommands', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection']
 ---
 
 

--- a/prompts/sql-code-review.prompt.md
+++ b/prompts/sql-code-review.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
 description: 'Universal SQL code review assistant that performs comprehensive security, maintainability, and code quality analysis across all SQL databases (MySQL, PostgreSQL, SQL Server, Oracle). Focuses on SQL injection prevention, access control, code standards, and anti-pattern detection. Complements SQL optimization prompt for complete development coverage.'
 tested_with: 'GitHub Copilot Chat (GPT-4o) - Validated July 20, 2025'
 ---

--- a/prompts/sql-optimization.prompt.md
+++ b/prompts/sql-optimization.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems']
+tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
 description: 'Universal SQL performance optimization assistant for comprehensive query tuning, indexing strategies, and database performance analysis across all SQL databases (MySQL, PostgreSQL, SQL Server, Oracle). Provides execution plan analysis, pagination optimization, batch operations, and performance monitoring guidance.'
 tested_with: 'GitHub Copilot Chat (GPT-4o) - Validated July 20, 2025'
 ---

--- a/prompts/update-avm-modules-in-bicep.prompt.md
+++ b/prompts/update-avm-modules-in-bicep.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Update Azure Verified Modules (AVM) to latest versions in Bicep files.'
-tools: ['codebase', 'think', 'changes', 'fetch', 'searchResults', 'todos', 'editFiles', 'search', 'runCommands', 'bicepschema', 'azure_get_schema_for_Bicep']
+tools: ['codebase', 'think', 'changes', 'fetch', 'searchResults', 'todos', 'edit/editFiles', 'search', 'runCommands', 'bicepschema', 'azure_get_schema_for_Bicep']
 ---
 # Update Azure Verified Modules in Bicep Files
 

--- a/prompts/update-implementation-plan.prompt.md
+++ b/prompts/update-implementation-plan.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Update an existing implementation plan file with new or update requirements to provide new features, refactoring existing code or upgrading packages, design, architecture or infrastructure.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Update Implementation Plan
 

--- a/prompts/update-llms.prompt.md
+++ b/prompts/update-llms.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Update the llms.txt file in the root folder to reflect changes in documentation or specifications following the llms.txt specification at https://llmstxt.org/'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Update LLMs.txt File
 

--- a/prompts/update-markdown-file-index.prompt.md
+++ b/prompts/update-markdown-file-index.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Update a markdown file section with an index/table of files from a specified folder.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Update Markdown File Index
 

--- a/prompts/update-oo-component-documentation.prompt.md
+++ b/prompts/update-oo-component-documentation.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Update existing object-oriented component documentation following industry best practices and architectural documentation standards.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Update Standard OO Component Documentation
 

--- a/prompts/update-specification.prompt.md
+++ b/prompts/update-specification.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Update an existing specification file for the solution, optimized for Generative AI consumption based on new requirements or updates to any existing code.'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Update Specification
 


### PR DESCRIPTION
## Summary
This PR fixes a tool naming issue in the documentation-writer prompt where `editFiles` has been renamed to `edit/editFiles`.

## Changes
- Updated tool reference from `'editFiles'` to `'edit/editFiles'` in the tools array

## Error Fixed
```
Tool or toolset 'editFiles' has been renamed, use 'edit/editFiles' instead.
```

## Screenshot
![Error screenshot showing the tool naming issue](https://github.com/user-attachments/assets/uploaded-screenshot.png)

The error was preventing the prompt from working correctly due to the deprecated tool name.
