### PR TITLE
docs(java): clarify Sonar, Java version, and code-style guidance

### DIFF
--- a/instructions/java.instructions.md
+++ b/instructions/java.instructions.md
@@ -8,8 +8,23 @@ applyTo: '**/*.java'
 ## General Instructions
 
 - First, prompt the user if they want to integrate static analysis tools (SonarQube, PMD, Checkstyle) into their project setup.
-  - If yes, document a recommended static-analysis setup. Prefer SonarQube/SonarCloud (SonarLint in IDE + `sonar-scanner` in CI). Include: creating a Sonar project key, storing the scanner token in CI secrets, and a sample CI job that runs the scanner. If the team declines Sonar, note this in project README and continue.
-  - If Sonar is bound to the project, use Sonar as the primary source of actionable issues and reference Sonar rule keys in remediation guidance. If Sonar is unavailable, perform up to 3 troubleshooting checks (1. verify project binding and token, 2. ensure SonarScanner runs in CI, 3. confirm SonarLint is installed and configured). If still failing after 3 attempts, enable SpotBugs/PMD/Checkstyle as CI fallbacks and open a short tracker issue documenting the blocker and next steps.
+  - If yes, document a recommended static-analysis setup. 
+    - Prefer SonarQube/SonarCloud (SonarLint in IDE + `sonar-scanner` in CI).
+    - Create a Sonar project key.
+    - Store the scanner token in CI secrets.
+    - Provide a sample CI job that runs the scanner.
+    - If the team declines Sonar, note this in the project README and continue.
+  - If Sonar is bound to the project:
+    - Use Sonar as the primary source of actionable issues.
+    - Reference Sonar rule keys in remediation guidance.
+  - If Sonar is unavailable:
+    - Perform up to 3 troubleshooting checks:
+      1. Verify project binding and token.
+      2. Ensure SonarScanner runs in CI.
+      3. Confirm SonarLint is installed and configured.
+    - If still failing after 3 attempts:
+      - Enable SpotBugs, PMD, or Checkstyle as CI fallbacks.
+      - Open a short tracker issue documenting the blocker and next steps.
 - If the user declines static analysis tools or wants to proceed without them, continue with implementing the Best practices, bug patterns and code smell prevention guidelines outlined below.
 - Address code smells proactively during development rather than accumulating technical debt.
 - Focus on readability, maintainability, and performance when refactoring identified issues.


### PR DESCRIPTION

 - Clarify SonarQube/SonarCloud setup, token handling, and CI scanner steps
 - Add guidance for Records, pattern matching, and `var` usage heuristics
 - Provide fallbacks when static analysis is unavailable and troubleshooting steps
 - Original rules are no longer included in the standard Sonar Way ruleset
 - Remove future dependency on Sonar by prompting to use when integrated or available
 - If not, the agent will now read Sonar rules as part of its analysis
 - Removed obsolete and redundant sections on Java version and code style

Generated-by: GitHub Copilot <github.copilot@github.com>

---

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [x] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [x] I have run `node update-readme.js` and verified that `README.md` is up to date.

---

## Description

Fix for #296 — only I decoupled that instruction entirely from Sonar, while keeping the spirit of the rules after omitting recent deprecations and unrelated SQL-style rules from the list.

**Before** — Copilot would encourage user to set up Sonar connections using available tools if none was found. If user declined, no obvious path forward for Copilot.

**Current** — Each question provides explicit true/false path logic. If a Sonar connection already exists or if the user agrees to configure a new one, then Copilot should prefer results queried directly via tool access. If neither is true, then the same list (minus deprecated rules or ones explicitly removed from Sonar's recommended list for Java) serves as a semantic reference for Copilot to work from. 

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [x] Other (please specify): instruction update to resolve #296 by eliminating explicit sonar dependency in favor of local extension or MCP.

---

## Additional Notes

> 🦄 This option really isn't as strong as it would be if the tool was available, but it also prevents broken logical path structures; and ambiguous instructions if no clear path forward exists.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
