### PR TITLE
Fix frontmatter property value which is missing a trailing single-quote

### DIFF
--- a/chatmodes/gpt-5-beast-mode.chatmode.md
+++ b/chatmodes/gpt-5-beast-mode.chatmode.md
@@ -2,7 +2,7 @@
 description: 'Beast Mode 2.0: A powerful autonomous agent tuned specifically for GPT-5 that can solve complex problems by using tools, conducting research, and iterating until the problem is fully resolved.'
 model: GPT-5 (copilot)
 tools: ['edit/editFiles', 'runNotebooks', 'search', 'new', 'runCommands', 'runTasks', 'extensions', 'usages', 'vscodeAPI', 'think', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'todos']
-title: 'GPT 5 Beast Mode
+title: 'GPT 5 Beast Mode'
 ---
 
 # Operating principles


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [x] I have run `node update-readme.js` and verified that `README.md` is up to date.

---

## Description

<!-- Briefly describe your contribution and its purpose. Include any relevant context or usage notes. -->
Just found a small frontmatter issue in the gpt-5-beast-mode.chatmode.md file which needed a single-quote closed.  That's all.
<img width="1153" height="508" alt="image" src="https://github.com/user-attachments/assets/964da405-8216-41d6-affe-d3d4d4679913" />

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [x] Other (please specify): Fix a small frontmatter issue

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
