### PR TITLE
fix: Update playwright after tool name changes

### DIFF
--- a/prompts/playwright-generate-test.prompt.md
+++ b/prompts/playwright-generate-test.prompt.md
@@ -1,8 +1,8 @@
 ---
 mode: agent
 description: 'Generate a Playwright test based on a scenario using Playwright MCP'
-tools: ['changes', 'codebase', 'edit/editFiles', 'fetch', 'findTestFiles', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'playwright']
-model: 'Claude Sonnet 4'
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'fetch', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'playwright/*']
+model: 'Claude Sonnet 4.5'
 ---
 
 # Test Generation with Playwright MCP


### PR DESCRIPTION
## Pull Request Checklist

- [X] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [X] The file follows the required naming convention.
- [X] The content is clearly structured and follows the example format.
- [X] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [ ] I have run `node update-readme.js` and verified that `README.md` is up to date.

---

## Description

Update tool names after VSCode updates, screenshots:

### 1
<img width="1129" height="115" alt="image" src="https://github.com/user-attachments/assets/9ced0ef9-6a08-4793-bfaf-e276d0613aea" />

### 2

<img width="555" height="269" alt="image" src="https://github.com/user-attachments/assets/8e17d63e-f09e-4a53-af67-459e42da4eeb" />

### 3
<img width="411" height="137" alt="image" src="https://github.com/user-attachments/assets/fc5ce881-76e0-42c2-b5bc-3233211092c0" />


---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [X] Other (please specify):
  - Tool name update

---

## Additional Notes

Can look at other prompts, if this one is accepted

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
