### PR TITLE
fix: Update link to CONTRIBUTING.md in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Pull Request Checklist
 
-- [ ] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
+- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
 - [ ] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
 - [ ] The file follows the required naming convention.
 - [ ] The content is clearly structured and follows the example format.


### PR DESCRIPTION
## Pull Request Checklist

- [X] I have read and followed the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [X] The file follows the required naming convention.
- [X] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [ ] I have run `node update-readme.js` and verified that `README.md` is up to date.

---

## Description

- Generated link in PRs is broken (example: https://github.com/github/awesome-copilot/pull/348, and this MR)
- We _could_ link to `../blobs/main/CONTRIBUTING.md`, but then I think that isn't evaluated correctly in all views

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [X] Other (please specify):
  - Link fix

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
