### PR TITLE
Fix typo in README.md for custom agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To make it easy to add these customizations to your editor, we have created a [M
 
 ### 🤖 Custom Agents
 
-Custom agents can be used in Copilot coding agent (CCA), VS Code, and Copilot CLI (coming soon). For CCA, when assingning an issue to Copilot, select the custom agent from the provided list. In VS Code, you can activate the custom agent in the agents session, alongside built-in agents like Plan and Agent.
+Custom agents can be used in Copilot coding agent (CCA), VS Code, and Copilot CLI (coming soon). For CCA, when assigning an issue to Copilot, select the custom agent from the provided list. In VS Code, you can activate the custom agent in the agents session, alongside built-in agents like Plan and Agent.
 
 ### 🎯 Prompts
 


### PR DESCRIPTION

## Description

Just fixing a little typo on the readme.

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [ ] New collection file.
- [ ] Update to existing instruction, prompt, chat mode, or collection.
- [x] Other (please specify): typo on readme

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
