### PR TITLE
feat: update deprecated tool names to namespaced versions

### DIFF
--- a/chatmodes/accessibility.chatmode.md
+++ b/chatmodes/accessibility.chatmode.md
@@ -1,7 +1,7 @@
 ---
 description: 'Accessibility mode.'
 model: GPT-4.1
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 title: 'Accessibility mode'
 ---
 

--- a/chatmodes/azure-saas-architect.chatmode.md
+++ b/chatmodes/azure-saas-architect.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Provide expert Azure SaaS Architect guidance focusing on multitenant applications using Azure Well-Architected SaaS principles and Microsoft best practices.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'azure_design_architecture', 'azure_get_code_gen_best_practices', 'azure_get_deployment_best_practices', 'azure_get_swa_best_practices', 'azure_query_learn']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'azure_design_architecture', 'azure_get_code_gen_best_practices', 'azure_get_deployment_best_practices', 'azure_get_swa_best_practices', 'azure_query_learn']
 ---
 # Azure SaaS Architect mode instructions
 

--- a/chatmodes/hlbpa.chatmode.md
+++ b/chatmodes/hlbpa.chatmode.md
@@ -2,7 +2,7 @@
 description: Your perfect AI chat mode for high-level architectural documentation and review. Perfect for targeted updates after a story or researching that legacy system when nobody remembers what it's supposed to be doing.
 model: 'claude-sonnet-4'
 tools:
-  - 'codebase'
+  - 'search/codebase'
   - 'changes'
   - 'edit/editFiles'
   - 'fetch'
@@ -11,7 +11,7 @@ tools:
   - 'runCommands'
   - 'runTests'
   - 'search'
-  - 'searchResults'
+  - 'search/searchResults'
   - 'testFailure'
   - 'usages'
   - 'activePullRequest'

--- a/chatmodes/microsoft_learn_contributor.chatmode.md
+++ b/chatmodes/microsoft_learn_contributor.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Microsoft Learn Contributor chatmode for editing and writing Microsoft Learn documentation following Microsoft Writing Style Guide and authoring best practices.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'new', 'openSimpleBrowser', 'problems', 'search', 'searchResults', 'microsoft.docs.mcp']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'new', 'openSimpleBrowser', 'problems', 'search', 'search/searchResults', 'microsoft.docs.mcp']
 ---
 
 # Microsoft Learn Contributor

--- a/chatmodes/ms-sql-dba.chatmode.md
+++ b/chatmodes/ms-sql-dba.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Work with Microsoft SQL Server databases using the MS SQL extension.'
-tools: ['codebase', 'edit/editFiles', 'githubRepo', 'extensions', 'runCommands', 'database', 'mssql_connect', 'mssql_query', 'mssql_listServers', 'mssql_listDatabases', 'mssql_disconnect', 'mssql_visualizeSchema']
+tools: ['search/codebase', 'edit/editFiles', 'githubRepo', 'extensions', 'runCommands', 'database', 'mssql_connect', 'mssql_query', 'mssql_listServers', 'mssql_listDatabases', 'mssql_disconnect', 'mssql_visualizeSchema']
 ---
 
 # MS-SQL Database Administrator

--- a/chatmodes/power-bi-data-modeling-expert.chatmode.md
+++ b/chatmodes/power-bi-data-modeling-expert.chatmode.md
@@ -1,7 +1,7 @@
 ---
 description: 'Expert Power BI data modeling guidance using star schema principles, relationship design, and Microsoft best practices for optimal model performance and usability.'
 model: 'gpt-4.1'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp']
+tools: ['changes', 'search/codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp']
 ---
 # Power BI Data Modeling Expert Mode
 

--- a/chatmodes/power-bi-dax-expert.chatmode.md
+++ b/chatmodes/power-bi-dax-expert.chatmode.md
@@ -1,7 +1,7 @@
 ---
 description: 'Expert Power BI DAX guidance using Microsoft best practices for performance, readability, and maintainability of DAX formulas and calculations.'
 model: 'gpt-4.1'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp']
+tools: ['changes', 'search/codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp']
 ---
 # Power BI DAX Expert Mode
 

--- a/chatmodes/power-bi-visualization-expert.chatmode.md
+++ b/chatmodes/power-bi-visualization-expert.chatmode.md
@@ -1,7 +1,7 @@
 ---
 description: 'Expert Power BI report design and visualization guidance using Microsoft best practices for creating effective, performant, and user-friendly reports and dashboards.'
 model: 'gpt-4.1'
-tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp']
+tools: ['changes', 'search/codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp']
 ---
 # Power BI Visualization Expert Mode
 

--- a/chatmodes/principal-software-engineer.chatmode.md
+++ b/chatmodes/principal-software-engineer.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Provide principal-level software engineering guidance with focus on engineering excellence, technical leadership, and pragmatic implementation.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'github']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'github']
 ---
 # Principal software engineer mode instructions
 

--- a/chatmodes/semantic-kernel-python.chatmode.md
+++ b/chatmodes/semantic-kernel-python.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Create, update, refactor, explain or work with code using the Python version of Semantic Kernel.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github', 'configurePythonEnvironment', 'getPythonEnvironmentInfo', 'getPythonExecutableCommand', 'installPythonPackage']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github', 'configurePythonEnvironment', 'getPythonEnvironmentInfo', 'getPythonExecutableCommand', 'installPythonPackage']
 ---
 # Semantic Kernel Python mode instructions
 

--- a/chatmodes/specification.chatmode.md
+++ b/chatmodes/specification.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Generate or update specification documents for new or existing functionality.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github']
 ---
 # Specification mode instructions
 

--- a/chatmodes/task-planner.chatmode.md
+++ b/chatmodes/task-planner.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Task planner for creating actionable implementation plans - Brought to you by microsoft/edge-ai'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'terraform', 'Microsoft Docs', 'azure_get_schema_for_Bicep', 'context7']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTests', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'terraform', 'Microsoft Docs', 'azure_get_schema_for_Bicep', 'context7']
 ---
 
 # Task Planner Instructions

--- a/chatmodes/wg-code-alchemist.chatmode.md
+++ b/chatmodes/wg-code-alchemist.chatmode.md
@@ -1,6 +1,6 @@
 ---
 description: 'Ask WG Code Alchemist to transform your code with Clean Code principles and SOLID design'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runNotebooks', 'runTasks', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 
 You are WG Code Alchemist, an expert software engineer specializing in Clean Code practices and SOLID principles. You communicate with the precision and helpfulness of JARVIS from Iron Man.

--- a/prompts/aspnet-minimal-api-openapi.prompt.md
+++ b/prompts/aspnet-minimal-api-openapi.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems']
 description: 'Create ASP.NET Minimal API endpoints with proper OpenAPI documentation'
 ---
 

--- a/prompts/containerize-aspnet-framework.prompt.md
+++ b/prompts/containerize-aspnet-framework.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['codebase', 'edit/editFiles', 'terminalCommand']
+tools: ['search/codebase', 'edit/editFiles', 'terminalCommand']
 description: 'Containerize an ASP.NET .NET Framework project by creating Dockerfile and .dockerfile files customized for the project.'
 ---
 

--- a/prompts/containerize-aspnetcore.prompt.md
+++ b/prompts/containerize-aspnetcore.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['codebase', 'edit/editFiles', 'terminalCommand']
+tools: ['search/codebase', 'edit/editFiles', 'terminalCommand']
 description: 'Containerize an ASP.NET Core project by creating Dockerfile and .dockerfile files customized for the project.'
 ---
 

--- a/prompts/create-architectural-decision-record.prompt.md
+++ b/prompts/create-architectural-decision-record.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create an Architectural Decision Record (ADR) document for AI-optimized decision documentation.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Create Architectural Decision Record
 

--- a/prompts/create-github-action-workflow-specification.prompt.md
+++ b/prompts/create-github-action-workflow-specification.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create a formal specification for an existing GitHub Actions CI/CD workflow, optimized for AI consumption and workflow maintenance.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runInTerminal2', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github', 'Microsoft Docs']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'runCommands', 'runInTerminal2', 'runNotebooks', 'runTasks', 'runTests', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'microsoft.docs.mcp', 'github', 'Microsoft Docs']
 ---
 # Create GitHub Actions Workflow Specification
 

--- a/prompts/create-github-issue-feature-from-specification.prompt.md
+++ b/prompts/create-github-issue-feature-from-specification.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create GitHub Issue for feature request from specification file using feature_request.yml template.'
-tools: ['codebase', 'search', 'github', 'create_issue', 'search_issues', 'update_issue']
+tools: ['search/codebase', 'search', 'github', 'create_issue', 'search_issues', 'update_issue']
 ---
 # Create GitHub Issue from Specification
 

--- a/prompts/create-github-issues-feature-from-implementation-plan.prompt.md
+++ b/prompts/create-github-issues-feature-from-implementation-plan.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create GitHub Issues from implementation plan phases using feature_request.yml or chore_request.yml templates.'
-tools: ['codebase', 'search', 'github', 'create_issue', 'search_issues', 'update_issue']
+tools: ['search/codebase', 'search', 'github', 'create_issue', 'search_issues', 'update_issue']
 ---
 # Create GitHub Issue from Implementation Plan
 

--- a/prompts/create-github-issues-for-unmet-specification-requirements.prompt.md
+++ b/prompts/create-github-issues-for-unmet-specification-requirements.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create GitHub Issues for unimplemented requirements from specification files using feature_request.yml template.'
-tools: ['codebase', 'search', 'github', 'create_issue', 'search_issues', 'update_issue']
+tools: ['search/codebase', 'search', 'github', 'create_issue', 'search_issues', 'update_issue']
 ---
 # Create GitHub Issues for Unmet Specification Requirements
 

--- a/prompts/create-github-pull-request-from-specification.prompt.md
+++ b/prompts/create-github-pull-request-from-specification.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create GitHub Pull Request for feature request from specification file using pull_request_template.md template.'
-tools: ['codebase', 'search', 'github', 'create_pull_request', 'update_pull_request', 'get_pull_request_diff']
+tools: ['search/codebase', 'search', 'github', 'create_pull_request', 'update_pull_request', 'get_pull_request_diff']
 ---
 # Create GitHub Pull Request from Specification
 

--- a/prompts/create-implementation-plan.prompt.md
+++ b/prompts/create-implementation-plan.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create a new implementation plan file for new features, refactoring existing code or upgrading packages, design, architecture or infrastructure.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Create Implementation Plan
 

--- a/prompts/create-llms.prompt.md
+++ b/prompts/create-llms.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create an llms.txt file from scratch based on repository structure following the llms.txt specification at https://llmstxt.org/'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Create LLMs.txt File from Repository Structure
 

--- a/prompts/create-oo-component-documentation.prompt.md
+++ b/prompts/create-oo-component-documentation.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create comprehensive, standardized documentation for object-oriented components following industry best practices and architectural documentation standards.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Generate Standard OO Component Documentation
 

--- a/prompts/create-specification.prompt.md
+++ b/prompts/create-specification.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Create a new specification file for the solution, optimized for Generative AI consumption.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Create Specification
 

--- a/prompts/csharp-async.prompt.md
+++ b/prompts/csharp-async.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems']
 description: 'Get best practices for C# async programming'
 ---
 

--- a/prompts/csharp-docs.prompt.md
+++ b/prompts/csharp-docs.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems']
 description: 'Ensure that C# types are documented with XML comments and follow best practices for documentation.'
 ---
 

--- a/prompts/csharp-mstest.prompt.md
+++ b/prompts/csharp-mstest.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for MSTest unit testing, including data-driven tests'
 ---
 

--- a/prompts/csharp-nunit.prompt.md
+++ b/prompts/csharp-nunit.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for NUnit unit testing, including data-driven tests'
 ---
 

--- a/prompts/csharp-tunit.prompt.md
+++ b/prompts/csharp-tunit.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for TUnit unit testing, including data-driven tests'
 ---
 

--- a/prompts/csharp-xunit.prompt.md
+++ b/prompts/csharp-xunit.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for XUnit unit testing, including data-driven tests'
 ---
 

--- a/prompts/ef-core.prompt.md
+++ b/prompts/ef-core.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'runCommands']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems', 'runCommands']
 description: 'Get best practices for Entity Framework Core'
 ---
 

--- a/prompts/java-docs.prompt.md
+++ b/prompts/java-docs.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems']
 description: 'Ensure that Java types are documented with Javadoc comments and follow best practices for documentation.'
 ---
 

--- a/prompts/java-junit.prompt.md
+++ b/prompts/java-junit.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for JUnit 5 unit testing, including data-driven tests'
 ---
 

--- a/prompts/java-springboot.prompt.md
+++ b/prompts/java-springboot.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for developing applications with Spring Boot.'
 ---
 

--- a/prompts/kotlin-springboot.prompt.md
+++ b/prompts/kotlin-springboot.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems', 'search']
 description: 'Get best practices for developing applications with Spring Boot and Kotlin.'
 ---
 

--- a/prompts/mkdocs-translations.prompt.md
+++ b/prompts/mkdocs-translations.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: agent
 description: 'Generate a language translation for a mkdocs documentation stack.'
-tools: ['codebase', 'usages', 'problems', 'changes', 'terminalSelection', 'terminalLastCommand', 'searchResults', 'extensions', 'edit/editFiles', 'search', 'runCommands', 'runTasks']
+tools: ['search/codebase', 'usages', 'problems', 'changes', 'runCommands/terminalSelection', 'runCommands/terminalLastCommand', 'search/searchResults', 'extensions', 'edit/editFiles', 'search', 'runCommands', 'runTasks']
 model: Claude Sonnet 4
 ---
 

--- a/prompts/multi-stage-dockerfile.prompt.md
+++ b/prompts/multi-stage-dockerfile.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['codebase']
+tools: ['search/codebase']
 description: 'Create optimized multi-stage Dockerfiles for any language or framework'
 ---
 

--- a/prompts/next-intl-add-language.prompt.md
+++ b/prompts/next-intl-add-language.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes','codebase', 'edit/editFiles', 'findTestFiles', 'search', 'writeTest']
+tools: ['changes','search/codebase', 'edit/editFiles', 'findTestFiles', 'search', 'writeTest']
 description: 'Add new language to a Next.js + next-intl application'
 ---
 

--- a/prompts/playwright-explore-website.prompt.md
+++ b/prompts/playwright-explore-website.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: agent
 description: 'Website exploration for testing using Playwright MCP'
-tools: ['changes', 'codebase', 'edit/editFiles', 'fetch', 'findTestFiles', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'playwright']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'fetch', 'findTestFiles', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'playwright']
 model: 'Claude Sonnet 4'
 ---
 

--- a/prompts/postgresql-code-review.prompt.md
+++ b/prompts/postgresql-code-review.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems']
 description: 'PostgreSQL-specific code review assistant focusing on PostgreSQL best practices, anti-patterns, and unique quality standards. Covers JSONB operations, array usage, custom types, schema design, function optimization, and PostgreSQL-exclusive security features like Row Level Security (RLS).'
 tested_with: 'GitHub Copilot Chat (GPT-4o) - Validated July 20, 2025'
 ---

--- a/prompts/postgresql-optimization.prompt.md
+++ b/prompts/postgresql-optimization.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems']
 description: 'PostgreSQL-specific development assistant focusing on unique PostgreSQL features, advanced data types, and PostgreSQL-exclusive capabilities. Covers JSONB operations, array types, custom types, range/geometric types, full-text search, window functions, and PostgreSQL extensions ecosystem.'
 tested_with: 'GitHub Copilot Chat (GPT-4o) - Validated July 20, 2025'
 ---

--- a/prompts/power-apps-code-app-scaffold.prompt.md
+++ b/prompts/power-apps-code-app-scaffold.prompt.md
@@ -1,7 +1,7 @@
 ---
 description: 'Scaffold a complete Power Apps Code App project with PAC CLI setup, SDK integration, and connector configuration'
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems', 'search']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems', 'search']
 model: GPT-4.1
 ---
 

--- a/prompts/prompt-builder.prompt.md
+++ b/prompts/prompt-builder.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['codebase', 'edit/editFiles', 'search']
+tools: ['search/codebase', 'edit/editFiles', 'search']
 description: 'Guide users through creating high-quality GitHub Copilot prompts with proper structure, tools, and best practices.'
 ---
 

--- a/prompts/repo-story-time.prompt.md
+++ b/prompts/repo-story-time.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Generate a comprehensive repository summary and narrative story from commit history'
-tools: ['changes', 'codebase', 'edit/editFiles', 'githubRepo', 'runCommands', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'githubRepo', 'runCommands', 'runTasks', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection']
 ---
 
 

--- a/prompts/sql-code-review.prompt.md
+++ b/prompts/sql-code-review.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems']
 description: 'Universal SQL code review assistant that performs comprehensive security, maintainability, and code quality analysis across all SQL databases (MySQL, PostgreSQL, SQL Server, Oracle). Focuses on SQL injection prevention, access control, code standards, and anti-pattern detection. Complements SQL optimization prompt for complete development coverage.'
 tested_with: 'GitHub Copilot Chat (GPT-4o) - Validated July 20, 2025'
 ---

--- a/prompts/sql-optimization.prompt.md
+++ b/prompts/sql-optimization.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'agent'
-tools: ['changes', 'codebase', 'edit/editFiles', 'problems']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'problems']
 description: 'Universal SQL performance optimization assistant for comprehensive query tuning, indexing strategies, and database performance analysis across all SQL databases (MySQL, PostgreSQL, SQL Server, Oracle). Provides execution plan analysis, pagination optimization, batch operations, and performance monitoring guidance.'
 tested_with: 'GitHub Copilot Chat (GPT-4o) - Validated July 20, 2025'
 ---

--- a/prompts/update-avm-modules-in-bicep.prompt.md
+++ b/prompts/update-avm-modules-in-bicep.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Update Azure Verified Modules (AVM) to latest versions in Bicep files.'
-tools: ['codebase', 'think', 'changes', 'fetch', 'searchResults', 'todos', 'edit/editFiles', 'search', 'runCommands', 'bicepschema', 'azure_get_schema_for_Bicep']
+tools: ['search/codebase', 'think', 'changes', 'fetch', 'search/searchResults', 'todos', 'edit/editFiles', 'search', 'runCommands', 'bicepschema', 'azure_get_schema_for_Bicep']
 ---
 # Update Azure Verified Modules in Bicep Files
 

--- a/prompts/update-implementation-plan.prompt.md
+++ b/prompts/update-implementation-plan.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Update an existing implementation plan file with new or update requirements to provide new features, refactoring existing code or upgrading packages, design, architecture or infrastructure.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Update Implementation Plan
 

--- a/prompts/update-llms.prompt.md
+++ b/prompts/update-llms.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Update the llms.txt file in the root folder to reflect changes in documentation or specifications following the llms.txt specification at https://llmstxt.org/'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Update LLMs.txt File
 

--- a/prompts/update-markdown-file-index.prompt.md
+++ b/prompts/update-markdown-file-index.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Update a markdown file section with an index/table of files from a specified folder.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'openSimpleBrowser', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Update Markdown File Index
 

--- a/prompts/update-oo-component-documentation.prompt.md
+++ b/prompts/update-oo-component-documentation.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Update existing object-oriented component documentation following industry best practices and architectural documentation standards.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Update Standard OO Component Documentation
 

--- a/prompts/update-specification.prompt.md
+++ b/prompts/update-specification.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
 description: 'Update an existing specification file for the solution, optimized for Generative AI consumption based on new requirements or updates to any existing code.'
-tools: ['changes', 'codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
+tools: ['changes', 'search/codebase', 'edit/editFiles', 'extensions', 'fetch', 'githubRepo', 'openSimpleBrowser', 'problems', 'runTasks', 'search', 'search/searchResults', 'runCommands/terminalLastCommand', 'runCommands/terminalSelection', 'testFailure', 'usages', 'vscodeAPI']
 ---
 # Update Specification
 


### PR DESCRIPTION
## Description

VS Code Copilot has migrated from flat tool naming to a namespaced organization. This PR updates all configuration files across the project to use the new namespaced tool names, replacing the deprecated flat names.

## Changes

### Tool Name Mappings

The following deprecated tool names have been updated to their namespaced equivalents:

- `codebase` → `search/codebase`
- `searchResults` → `search/searchResults`
- `terminalLastCommand` → `runCommands/terminalLastCommand`
- `terminalSelection` → `runCommands/terminalSelection`

### Files Modified

-  13 chat mode configuration files (`chatmodes/*.chatmode.md`)
-  41 prompt template files (`prompts/*.prompt.md`)
- **Total: 54 files updated**

### Examples

**Before:**
```yaml
tools: ['codebase', 'searchResults', 'terminalLastCommand']
```

**After:**
```yaml
tools: ['search/codebase', 'search/searchResults', 'runCommands/terminalLastCommand']
```


