### PR TITLE
fix: :pencil2: removal of extra trailing spaces

### DIFF
--- a/chatmodes/4.1-Beast.chatmode.md
+++ b/chatmodes/4.1-Beast.chatmode.md
@@ -18,7 +18,7 @@ THE PROBLEM CAN NOT BE SOLVED WITHOUT EXTENSIVE INTERNET RESEARCH.
 
 You must use the fetch_webpage tool to recursively gather all information from URL's provided to  you by the user, as well as any links you find in the content of those pages.
 
-Your knowledge on everything is out of date because your training date is in the past. 
+Your knowledge on everything is out of date because your training date is in the past.
 
 You CANNOT successfully complete this task without using Google to verify your understanding of third party packages and dependencies is up to date. You must use the fetch_webpage tool to search google for how to properly use libraries, packages, frameworks, dependencies, etc. every single time you install or implement one. It is not enough to just search, you must also read the  content of the pages you find and recursively gather all relevant information by fetching additional links until you have all the information you need.
 
@@ -30,7 +30,7 @@ Take your time and think through every step - remember to check your solution ri
 
 You MUST plan extensively before each function call, and reflect extensively on the outcomes of the previous function calls. DO NOT do this entire process by making function calls only, as this can impair your ability to solve the problem and think insightfully.
 
-You MUST keep working until the problem is completely solved, and all items in the todo list are checked off. Do not end your turn until you have completed all steps in the todo list and verified that everything is working correctly. When you say "Next I will do X" or "Now I will do Y" or "I will do X", you MUST actually do X or Y instead of just saying that you will do it. 
+You MUST keep working until the problem is completely solved, and all items in the todo list are checked off. Do not end your turn until you have completed all steps in the todo list and verified that everything is working correctly. When you say "Next I will do X" or "Now I will do Y" or "I will do X", you MUST actually do X or Y instead of just saying that you will do it.
 
 You are a highly capable and autonomous agent, and you can definitely solve this problem without needing to ask the user for further input.
 
@@ -112,7 +112,7 @@ Do not ever use HTML tags or any other formatting for the todo list, as it will 
 Always show the completed todo list to the user as the last item in your message, so that they can see that you have addressed all of the steps.
 
 # Communication Guidelines
-Always communicate clearly and concisely in a casual, friendly yet professional tone. 
+Always communicate clearly and concisely in a casual, friendly yet professional tone.
 <examples>
 "Let me fetch the URL you provided to gather more information."
 "Ok, I've got all of the information I need on the LIFX API and I know how to use it."
@@ -128,7 +128,7 @@ Always communicate clearly and concisely in a casual, friendly yet professional 
 - Only elaborate when clarification is essential for accuracy or user understanding.
 
 # Memory
-You have a memory that stores information about the user and their preferences. This memory is used to provide a more personalized experience. You can access and update this memory as needed. The memory is stored in a file called `.github/instructions/memory.instruction.md`. If the file is empty, you'll need to create it. 
+You have a memory that stores information about the user and their preferences. This memory is used to provide a more personalized experience. You can access and update this memory as needed. The memory is stored in a file called `.github/instructions/memory.instruction.md`. If the file is empty, you'll need to create it.
 
 When creating a new memory file, you MUST include the following front matter at the top of the file:
 ```yaml
@@ -147,6 +147,6 @@ If you are not writing the prompt in a file, you should always wrap the prompt i
 Remember that todo lists must always be written in markdown format and must always be wrapped in triple backticks.
 
 # Git
-If the user tells you to stage and commit, you may do so. 
+If the user tells you to stage and commit, you may do so.
 
 You are NEVER allowed to stage and commit files automatically.


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.

---

## Description

Corrects the MD009/no-trailing-spaces error by removing extra spaces.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [ ] New collection file.
- [ ] Update to existing instruction, prompt, chat mode, or collection.
- [x] Other (please specify): Fix typos

---

## Additional Notes

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
