### PR TITLE
Add support for compose.yaml in Docker best practices

### DIFF
--- a/instructions/containerization-docker-best-practices.instructions.md
+++ b/instructions/containerization-docker-best-practices.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: '**/Dockerfile,**/Dockerfile.*,**/*.dockerfile,**/docker-compose*.yml,**/docker-compose*.yaml,**/compose.yml,**/compose*.yaml'
+applyTo: '**/Dockerfile,**/Dockerfile.*,**/*.dockerfile,**/docker-compose*.yml,**/docker-compose*.yaml,**/compose*.yml,**/compose*.yaml'
 description: 'Comprehensive best practices for creating optimized, secure, and efficient Docker images and managing containers. Covers multi-stage builds, image layer optimization, security scanning, and runtime best practices.'
 ---
 


### PR DESCRIPTION
This PR updates the Docker Best Practices instructions by extending the `applyTo` configuration to include `compose.yaml` and `compose.yml`. The previously used `docker-compose.ya?ml` pattern refers to the legacy Compose file format, while `compose.yaml` (and its `.yml` variant) is now the default according to the [Compose Specification](https://docs.docker.com/compose/intro/compose-application-model/#the-compose-file).