### PR TITLE
Add guideline for trailing commas in initializers

### DIFF
--- a/instructions/csharp.instructions.md
+++ b/instructions/csharp.instructions.md
@@ -30,6 +30,7 @@ applyTo: '**/*.cs'
 - Use pattern matching and switch expressions wherever possible.
 - Use `nameof` instead of string literals when referring to member names.
 - Ensure that XML doc comments are created for any public APIs. When applicable, include `<example>` and `<code>` documentation in the comments.
+- Add a trailing comma after the last value in multi-line arrays, collection initializers, object initializers, and enum declarations to prevent MA0007 warnings.
 
 ## Project Setup and Structure
 


### PR DESCRIPTION
Added guideline to include trailing commas in multi-line initializers to avoid MA0007 warnings.

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.

---

## Description

<!-- Briefly describe your contribution and its purpose. Include any relevant context or usage notes. -->

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [ ] New collection file.
- [x] Update to existing instruction, prompt, chat mode, or collection.
- [ ] Other (please specify):

---

## Additional Notes

Added guideline to include trailing commas in multi-line initializers to avoid MA0007 warnings.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
