### PR TITLE
Include .yaml files in applyTo for GitHub Actions instructions

### DIFF
--- a/instructions/github-actions-ci-cd-best-practices.instructions.md
+++ b/instructions/github-actions-ci-cd-best-practices.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: '.github/workflows/*.yml'
+applyTo: '.github/workflows/*.yml,.github/workflows/*.yaml'
 description: 'Comprehensive guide for building robust, secure, and efficient CI/CD pipelines using GitHub Actions. Covers workflow structure, jobs, steps, environment variables, secret management, caching, matrix strategies, testing, and deployment strategies.'
 ---
 


### PR DESCRIPTION
This PR updates the GitHub Actions CI/CD Best Practices instructions by extending the `applyTo` configuration to also cover `.github/workflows/*.yaml`. GitHub Actions workflows commonly use both `.yml` and `.yaml` extensions, so including this pattern ensures the configuration is applied consistently across all valid workflow files.