### PR TITLE
fix vue3 instructions to use vitest instead of jest

### DIFF
--- a/instructions/vuejs3.instructions.md
+++ b/instructions/vuejs3.instructions.md
@@ -101,7 +101,7 @@ Instructions for building high-quality VueJS 3 applications with the Composition
 - Implement breadcrumb data via route meta fields
 
 ### Testing
-- Write unit tests with Vue Test Utils and Jest
+- Write unit tests with Vue Test Utils and Vitest
 - Focus on behavior, not implementation details
 - Use `mount` and `shallowMount` for component isolation
 - Mock global plugins (router, Pinia) as needed


### PR DESCRIPTION
jest is not supported with vite.

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.

---

## Description

<!-- Briefly describe your contribution and its purpose. Include any relevant context or usage notes. -->

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [ ] New collection file.
- [x] Update to existing instruction, prompt, chat mode, or collection.
- [ ] Other (please specify):

---

## Additional Notes

The Vue3 instructions suggest using Jest with Vite, which is not officially supported by jest and is inconsistent with the other guidelines in the file.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
