### PR TITLE
Look for assets in subdirectories

### DIFF
--- a/eng/yaml-parser.mjs
+++ b/eng/yaml-parser.mjs
@@ -161,14 +161,26 @@ function parseSkillMetadata(skillPath) {
         return null;
       }
 
-      // List bundled assets (all files except SKILL.md)
-      const assets = fs
-        .readdirSync(skillPath)
-        .filter((file) => {
-          const filePath = path.join(skillPath, file);
-          return file !== "SKILL.md" && fs.statSync(filePath).isFile();
-        })
-        .sort();
+      // List bundled assets (all files except SKILL.md), recursing through subdirectories
+      const getAllFiles = (dirPath, arrayOfFiles = []) => {
+        const files = fs.readdirSync(dirPath);
+
+        files.forEach((file) => {
+          const filePath = path.join(dirPath, file);
+          if (fs.statSync(filePath).isDirectory()) {
+            arrayOfFiles = getAllFiles(filePath, arrayOfFiles);
+          } else {
+            const relativePath = path.relative(skillPath, filePath);
+            if (relativePath !== "SKILL.md") {
+              arrayOfFiles.push(relativePath);
+            }
+          }
+        });
+
+        return arrayOfFiles;
+      };
+
+      const assets = getAllFiles(skillPath).sort();
 
       return {
         name: frontmatter.name,


### PR DESCRIPTION
## Description

Fixes #503.

When running `npm start` the README.skills.md file will be updated to include any newly-added skills. This includes the name and description from the skill's frontmatter, but also a list of assets in the skill-- that is, files other than SKILL.md.

However, the code in yaml-parser.mjs to enumerate the asset files only looks in the immediate skill directory, not any subdirectories. Those files will be missing from README.skills.md.

Here we update yaml-parser.mjs to recurse through the subdirectories as well.

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [ ] New collection file.
- [ ] Update to existing instruction, prompt, chat mode, or collection.
- [x] Other (please specify): bug fix.

---

## Additional Notes

_N/A_

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
