### PR TITLE
Fix formatting in task-planner.agent.md

### DIFF
--- a/agents/task-planner.agent.md
+++ b/agents/task-planner.agent.md
@@ -63,7 +63,7 @@ You WILL process user input as follows:
   - `{{specific_action}}` → "Create eventstream module with custom endpoint support"
 - **Final Output**: You WILL ensure NO template markers remain in final files
 
-**CRITICAL**: If you encounter invalid file references or broken line numbers, you WILL update the research file first using #file:./task-researcher.agent.md, then update all dependent planning files.
+**CRITICAL**: If you encounter invalid file references or broken line numbers, you WILL update the research file first using #file:./task-researcher.agent.md , then update all dependent planning files.
 
 ## File Naming Standards
 


### PR DESCRIPTION
Without the space before the comma, VS Code interpreted the comma as part of the file name, which caused the following error even though the target file was in the target location:

```
File './task-researcher.agent.md,' not found at 'C:\Users\hunte\AppData\Roaming\Code - Insiders\User\prompts\task-researcher.agent.md,'.
```

After adding the space, the yellow squiggles and error went away.

## Pull Request Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, or chat mode file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, or chat mode with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.

---

## Description

<!-- Briefly describe your contribution and its purpose. Include any relevant context or usage notes. -->

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New chat mode file.
- [ ] New collection file.
- [ ] New skill file.
- [ ] Update to existing instruction, prompt, chat mode, collection or skill.
- [ ] Other (please specify):

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
