### PR TITLE
Add commit SHA and build date to website footer

### DIFF
--- a/website/public/styles/global.css
+++ b/website/public/styles/global.css
@@ -688,6 +688,12 @@ a:hover {
   color: var(--color-accent);
 }
 
+.site-footer .build-info {
+  margin-top: 8px;
+  font-size: 12px;
+  opacity: 0.7;
+}
+
 /* Buttons */
 .btn {
   display: inline-flex;

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -1,4 +1,6 @@
 ---
+import { execSync } from "child_process";
+
 interface Props {
   title: string;
   description?: string;
@@ -11,6 +13,21 @@ const {
   activeNav = "",
 } = Astro.props;
 const base = import.meta.env.BASE_URL;
+
+// Get git commit SHA and build date at build time
+let commitSha = "unknown";
+let buildDate = new Date().toISOString().split("T")[0];
+try {
+  // Use GITHUB_SHA env var in GitHub Actions, fallback to git command locally
+  const githubSha = process.env.GITHUB_SHA;
+  if (githubSha) {
+    commitSha = githubSha.substring(0, 7);
+  } else {
+    commitSha = execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim();
+  }
+} catch {
+  // Fallback if git is not available
+}
 ---
 
 <!doctype html>
@@ -154,6 +171,13 @@ const base = import.meta.env.BASE_URL;
             target="_blank"
             rel="noopener">MIT License</a
           >
+        </p>
+        <p class="build-info">
+          Built from <a
+            href={`https://github.com/github/awesome-copilot/commit/${commitSha}`}
+            target="_blank"
+            rel="noopener">{commitSha}</a
+          > on {buildDate}
         </p>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
Adds build information to the website footer showing the commit SHA and build date.

## Changes
- Display short commit SHA with link to GitHub commit page
- Show build date in YYYY-MM-DD format
- Use `GITHUB_SHA` environment variable in GitHub Actions, fallback to `git rev-parse` locally
- Add subtle styling for build info text

## Screenshot
Footer will display: `Built from abc1234 on 2026-02-02`