### PR TITLE
fix: use skillFile path in search index for skills

### DIFF
--- a/eng/generate-website-data.mjs
+++ b/eng/generate-website-data.mjs
@@ -579,7 +579,7 @@ function generateSearchIndex(
       id: skill.id,
       title: skill.title,
       description: skill.description,
-      path: skill.path,
+      path: skill.skillFile,
       searchText: `${skill.title} ${skill.description}`.toLowerCase(),
     });
   }


### PR DESCRIPTION
## Summary
Fixes an issue where searching for skills on the homepage and clicking a result would fail to load the skill content in the modal.

## Problem
The search index stored the skill folder path (e.g., `skills/my-skill`) instead of the actual file path (`skills/my-skill/SKILL.md`). When `fetchFileContent()` tried to fetch this path, it would fail because it was a directory, not a file.

## Solution
Changed the `path` property in the search index to use `skill.skillFile` which contains the correct path to the SKILL.md file.

## Testing
- Regenerated website data and verified skill paths now include `/SKILL.md` suffix
- Before: `skills/agentic-eval`
- After: `skills/agentic-eval/SKILL.md`