### PR TITLE
fix: markdown formatting in code review examples

### DIFF
--- a/instructions/code-review-generic.instructions.md
+++ b/instructions/code-review-generic.instructions.md
@@ -265,10 +265,10 @@ stmt.setString(1, email);
 ```
 
 **Reference:** OWASP SQL Injection Prevention Cheat Sheet
-```
+````
 
 #### Important Issue
-```markdown
+````markdown
 **🟡 IMPORTANT - Testing: Missing test coverage for critical path**
 
 The `processPayment()` function handles financial transactions but has no tests


### PR DESCRIPTION
Updated markdown code blocks for example comments in the code review instructions.

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, agent, or skill file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, or skill with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.

---

## Description

<!-- Briefly describe your contribution and its purpose. Include any relevant context or usage notes. -->

The markdown code blocks are currently not well formatted in the "Example Comments" section. This also impacts the "Review Checklist" section.

This PR uses 4 ticks to create the example markdown templates, so that the code blocks (and text) of the markdown content blocks are correctly formatted.

Before:
<img width="1152" height="1335" alt="image" src="https://github.com/user-attachments/assets/334289f8-8fae-4798-991d-e3a80857caed" />

After:
<img width="1113" height="1159" alt="image" src="https://github.com/user-attachments/assets/14c58a3a-9888-4522-a0ca-5c5749e169c4" />


---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New collection file.
- [ ] New skill file.
- [x] Update to existing instruction, prompt, agent, collection or skill.
- [ ] Other (please specify):

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
