### PR TITLE
Fix command for adding Awesome Copilot marketplace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Plugins are installable packages generated from collections. Each plugin contain
 First, add the Awesome Copilot marketplace to your Copilot CLI:
 
 ```bash
-copilot marketplace add github/awesome-copilot
+copilot plugin marketplace add github/awesome-copilot
 ```
 
 Then install any plugin from the collection:


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, agent, or skill file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, or skill with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.

---

## Description
Readme update.
<!-- Briefly describe your contribution and its purpose. Include any relevant context or usage notes. -->

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New collection file.
- [ ] New skill file.
- [ ] Update to existing instruction, prompt, agent, collection or skill.
- [x] Other (please specify): readme update.
---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->
Based on what I saw, the instructions in the readme were outdated. These are the commands available at the moment.
<img width="651" height="228" alt="image" src="https://github.com/user-attachments/assets/2354138e-ff85-47ce-9e21-570072c85e6e" />



---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
