### PR TITLE
Fix `gh pr review` body parameter

### DIFF
--- a/skills/gh-cli/SKILL.md
+++ b/skills/gh-cli/SKILL.md
@@ -1148,8 +1148,7 @@ gh pr comment 123 --delete 456789
 gh pr review 123
 
 # Approve PR
-gh pr review 123 --approve \
-  --approve-body "LGTM!"
+gh pr review 123 --approve --body "LGTM!"
 
 # Request changes
 gh pr review 123 --request-changes \


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, agent, or skill file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, or skill with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.

---

## Description

<!-- Briefly describe your contribution and its purpose. Include any relevant context or usage notes. -->
The gh pr review command doesn’t support --approve-body. The CLI uses --body to set the review body text.

https://cli.github.com/manual/gh_pr_review

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New collection file.
- [ ] New skill file.
- [x] Update to existing instruction, prompt, agent, collection or skill.
- [ ] Other (please specify):

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
