### PR TITLE
Fix Go cookbook recipes to use correct SDK API

### DIFF
--- a/cookbook/copilot-sdk/go/multiple-sessions.md
+++ b/cookbook/copilot-sdk/go/multiple-sessions.md
@@ -18,47 +18,49 @@ You need to run multiple conversations in parallel, each with its own context an
 package main
 
 import (
+    "context"
     "fmt"
     "log"
-    "github.com/github/copilot-sdk/go"
+    copilot "github.com/github/copilot-sdk/go"
 )
 
 func main() {
-    client := copilot.NewClient()
+    ctx := context.Background()
+    client := copilot.NewClient(nil)
 
-    if err := client.Start(); err != nil {
+    if err := client.Start(ctx); err != nil {
         log.Fatal(err)
     }
     defer client.Stop()
 
     // Create multiple independent sessions
-    session1, err := client.CreateSession(copilot.SessionConfig{Model: "gpt-5"})
+    session1, err := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-5"})
     if err != nil {
         log.Fatal(err)
     }
     defer session1.Destroy()
 
-    session2, err := client.CreateSession(copilot.SessionConfig{Model: "gpt-5"})
+    session2, err := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-5"})
     if err != nil {
         log.Fatal(err)
     }
     defer session2.Destroy()
 
-    session3, err := client.CreateSession(copilot.SessionConfig{Model: "claude-sonnet-4.5"})
+    session3, err := client.CreateSession(ctx, &copilot.SessionConfig{Model: "claude-sonnet-4.5"})
     if err != nil {
         log.Fatal(err)
     }
     defer session3.Destroy()
 
     // Each session maintains its own conversation history
-    session1.Send(copilot.MessageOptions{Prompt: "You are helping with a Python project"})
-    session2.Send(copilot.MessageOptions{Prompt: "You are helping with a TypeScript project"})
-    session3.Send(copilot.MessageOptions{Prompt: "You are helping with a Go project"})
+    session1.Send(ctx, copilot.MessageOptions{Prompt: "You are helping with a Python project"})
+    session2.Send(ctx, copilot.MessageOptions{Prompt: "You are helping with a TypeScript project"})
+    session3.Send(ctx, copilot.MessageOptions{Prompt: "You are helping with a Go project"})
 
     // Follow-up messages stay in their respective contexts
-    session1.Send(copilot.MessageOptions{Prompt: "How do I create a virtual environment?"})
-    session2.Send(copilot.MessageOptions{Prompt: "How do I set up tsconfig?"})
-    session3.Send(copilot.MessageOptions{Prompt: "How do I initialize a module?"})
+    session1.Send(ctx, copilot.MessageOptions{Prompt: "How do I create a virtual environment?"})
+    session2.Send(ctx, copilot.MessageOptions{Prompt: "How do I set up tsconfig?"})
+    session3.Send(ctx, copilot.MessageOptions{Prompt: "How do I initialize a module?"})
 }
 ```
 
@@ -67,7 +69,7 @@ func main() {
 Use custom IDs for easier tracking:
 
 ```go
-session, err := client.CreateSession(copilot.SessionConfig{
+session, err := client.CreateSession(ctx, &copilot.SessionConfig{
     SessionID: "user-123-chat",
     Model:     "gpt-5",
 })
@@ -81,7 +83,7 @@ fmt.Println(session.SessionID) // "user-123-chat"
 ## Listing sessions
 
 ```go
-sessions, err := client.ListSessions()
+sessions, err := client.ListSessions(ctx)
 if err != nil {
     log.Fatal(err)
 }
@@ -95,7 +97,7 @@ for _, sessionInfo := range sessions {
 
 ```go
 // Delete a specific session
-if err := client.DeleteSession("user-123-chat"); err != nil {
+if err := client.DeleteSession(ctx, "user-123-chat"); err != nil {
     log.Printf("Failed to delete session: %v", err)
 }
 ```

--- a/cookbook/copilot-sdk/go/pr-visualization.md
+++ b/cookbook/copilot-sdk/go/pr-visualization.md
@@ -39,6 +39,7 @@ package main
 
 import (
     "bufio"
+    "context"
     "flag"
     "fmt"
     "log"
@@ -46,7 +47,7 @@ import (
     "os/exec"
     "regexp"
     "strings"
-    "github.com/github/copilot-sdk/go"
+    copilot "github.com/github/copilot-sdk/go"
 )
 
 // ============================================================================
@@ -94,6 +95,7 @@ func promptForRepo() string {
 // ============================================================================
 
 func main() {
+    ctx := context.Background()
     repoFlag := flag.String("repo", "", "GitHub repository (owner/repo)")
     flag.Parse()
 
@@ -126,18 +128,18 @@ func main() {
     parts := strings.SplitN(repo, "/", 2)
     owner, repoName := parts[0], parts[1]
 
-    // Create Copilot client - no custom tools needed!
-    client := copilot.NewClient(copilot.ClientConfig{LogLevel: "error"})
+    // Create Copilot client
+    client := copilot.NewClient(nil)
 
-    if err := client.Start(); err != nil {
+    if err := client.Start(ctx); err != nil {
         log.Fatal(err)
     }
     defer client.Stop()
 
     cwd, _ := os.Getwd()
-    session, err := client.CreateSession(copilot.SessionConfig{
+    session, err := client.CreateSession(ctx, &copilot.SessionConfig{
         Model: "gpt-5",
-        SystemMessage: copilot.SystemMessage{
+        SystemMessage: &copilot.SystemMessageConfig{
             Content: fmt.Sprintf(`
 <context>
 You are analyzing pull requests for the GitHub repository: %s/%s
@@ -159,12 +161,16 @@ The current working directory is: %s
     defer session.Destroy()
 
     // Set up event handling
-    session.On(func(event copilot.Event) {
-        switch e := event.(type) {
-        case copilot.AssistantMessageEvent:
-            fmt.Printf("\n🤖 %s\n\n", e.Data.Content)
-        case copilot.ToolExecutionStartEvent:
-            fmt.Printf("  ⚙️  %s\n", e.Data.ToolName)
+    session.On(func(event copilot.SessionEvent) {
+        switch event.Type {
+        case "assistant.message":
+            if event.Data.Content != nil {
+                fmt.Printf("\n🤖 %s\n\n", *event.Data.Content)
+            }
+        case "tool.execution_start":
+            if event.Data.ToolName != nil {
+                fmt.Printf("  ⚙️  %s\n", *event.Data.ToolName)
+            }
         }
     })
 
@@ -180,11 +186,9 @@ The current working directory is: %s
       Finally, summarize the PR health - average age, oldest PR, and how many might be considered stale.
     `, owner, repoName)
 
-    if err := session.Send(copilot.MessageOptions{Prompt: prompt}); err != nil {
+    if _, err := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: prompt}); err != nil {
         log.Fatal(err)
     }
-
-    session.WaitForIdle()
 
     // Interactive loop
     fmt.Println("\n💡 Ask follow-up questions or type \"exit\" to quit.\n")
@@ -209,11 +213,9 @@ The current working directory is: %s
             break
         }
 
-        if err := session.Send(copilot.MessageOptions{Prompt: input}); err != nil {
+        if _, err := session.SendAndWait(ctx, copilot.MessageOptions{Prompt: input}); err != nil {
             log.Printf("Error: %v", err)
         }
-
-        session.WaitForIdle()
     }
 }
 ```

--- a/cookbook/copilot-sdk/go/recipe/multiple-sessions.go
+++ b/cookbook/copilot-sdk/go/recipe/multiple-sessions.go
@@ -1,34 +1,36 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
-	"github.com/github/copilot-sdk/go"
+	copilot "github.com/github/copilot-sdk/go"
 )
 
 func main() {
-	client := copilot.NewClient()
+	ctx := context.Background()
+	client := copilot.NewClient(nil)
 
-	if err := client.Start(); err != nil {
+	if err := client.Start(ctx); err != nil {
 		log.Fatal(err)
 	}
 	defer client.Stop()
 
 	// Create multiple independent sessions
-	session1, err := client.CreateSession(copilot.SessionConfig{Model: "gpt-5"})
+	session1, err := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-5"})
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer session1.Destroy()
 
-	session2, err := client.CreateSession(copilot.SessionConfig{Model: "gpt-5"})
+	session2, err := client.CreateSession(ctx, &copilot.SessionConfig{Model: "gpt-5"})
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer session2.Destroy()
 
-	session3, err := client.CreateSession(copilot.SessionConfig{Model: "claude-sonnet-4.5"})
+	session3, err := client.CreateSession(ctx, &copilot.SessionConfig{Model: "claude-sonnet-4.5"})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -37,16 +39,16 @@ func main() {
 	fmt.Println("Created 3 independent sessions")
 
 	// Each session maintains its own conversation history
-	session1.Send(copilot.MessageOptions{Prompt: "You are helping with a Python project"})
-	session2.Send(copilot.MessageOptions{Prompt: "You are helping with a TypeScript project"})
-	session3.Send(copilot.MessageOptions{Prompt: "You are helping with a Go project"})
+	session1.Send(ctx, copilot.MessageOptions{Prompt: "You are helping with a Python project"})
+	session2.Send(ctx, copilot.MessageOptions{Prompt: "You are helping with a TypeScript project"})
+	session3.Send(ctx, copilot.MessageOptions{Prompt: "You are helping with a Go project"})
 
 	fmt.Println("Sent initial context to all sessions")
 
 	// Follow-up messages stay in their respective contexts
-	session1.Send(copilot.MessageOptions{Prompt: "How do I create a virtual environment?"})
-	session2.Send(copilot.MessageOptions{Prompt: "How do I set up tsconfig?"})
-	session3.Send(copilot.MessageOptions{Prompt: "How do I initialize a module?"})
+	session1.Send(ctx, copilot.MessageOptions{Prompt: "How do I create a virtual environment?"})
+	session2.Send(ctx, copilot.MessageOptions{Prompt: "How do I set up tsconfig?"})
+	session3.Send(ctx, copilot.MessageOptions{Prompt: "How do I initialize a module?"})
 
 	fmt.Println("Sent follow-up questions to each session")
 	fmt.Println("All sessions will be destroyed on exit")

--- a/cookbook/copilot-sdk/go/recipe/persisting-sessions.go
+++ b/cookbook/copilot-sdk/go/recipe/persisting-sessions.go
@@ -1,68 +1,68 @@
 package main
 
 import (
-    "fmt"
-    "log"
+	"context"
+	"fmt"
+	"log"
 
-    "github.com/github/copilot-sdk/go"
+	copilot "github.com/github/copilot-sdk/go"
 )
 
 func main() {
-    client := copilot.NewClient()
-    if err := client.Start(); err != nil {
-        log.Fatal(err)
-    }
-    defer client.Stop()
+	ctx := context.Background()
+	client := copilot.NewClient(nil)
+	if err := client.Start(ctx); err != nil {
+		log.Fatal(err)
+	}
+	defer client.Stop()
 
-    // Create session with a memorable ID
-    session, err := client.CreateSession(copilot.SessionConfig{
-        SessionID: "user-123-conversation",
-        Model:     "gpt-5",
-    })
-    if err != nil {
-        log.Fatal(err)
-    }
+	// Create session with a memorable ID
+	session, err := client.CreateSession(ctx, &copilot.SessionConfig{
+		SessionID: "user-123-conversation",
+		Model:     "gpt-5",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    if err := session.Send(copilot.MessageOptions{Prompt: "Let's discuss TypeScript generics"}); err != nil {
-        log.Fatal(err)
-    }
-    fmt.Printf("Session created: %s\n", session.SessionID)
+	_, err = session.SendAndWait(ctx, copilot.MessageOptions{Prompt: "Let's discuss TypeScript generics"})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Session created: %s\n", session.SessionID)
 
-    // Destroy session but keep data on disk
-    if err := session.Destroy(); err != nil {
-        log.Fatal(err)
-    }
-    fmt.Println("Session destroyed (state persisted)")
+	// Destroy session but keep data on disk
+	session.Destroy()
+	fmt.Println("Session destroyed (state persisted)")
 
-    // Resume the previous session
-    resumed, err := client.ResumeSession("user-123-conversation")
-    if err != nil {
-        log.Fatal(err)
-    }
-    fmt.Printf("Resumed: %s\n", resumed.SessionID)
+	// Resume the previous session
+	resumed, err := client.ResumeSession(ctx, "user-123-conversation")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Resumed: %s\n", resumed.SessionID)
 
-    if err := resumed.Send(copilot.MessageOptions{Prompt: "What were we discussing?"}); err != nil {
-        log.Fatal(err)
-    }
+	_, err = resumed.SendAndWait(ctx, copilot.MessageOptions{Prompt: "What were we discussing?"})
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // List sessions
-    sessions, err := client.ListSessions()
-    if err != nil {
-        log.Fatal(err)
-    }
-    ids := make([]string, 0, len(sessions))
-    for _, s := range sessions {
-        ids = append(ids, s.SessionID)
-    }
-    fmt.Printf("Sessions: %v\n", ids)
+	// List sessions
+	sessions, err := client.ListSessions(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	ids := make([]string, 0, len(sessions))
+	for _, s := range sessions {
+		ids = append(ids, s.SessionID)
+	}
+	fmt.Printf("Sessions: %v\n", ids)
 
-    // Delete session permanently
-    if err := client.DeleteSession("user-123-conversation"); err != nil {
-        log.Fatal(err)
-    }
-    fmt.Println("Session deleted")
+	// Delete session permanently
+	if err := client.DeleteSession(ctx, "user-123-conversation"); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("Session deleted")
 
-    if err := resumed.Destroy(); err != nil {
-        log.Fatal(err)
-    }
+	resumed.Destroy()
 }


### PR DESCRIPTION
## Problem

All 5 Go cookbook recipes and their corresponding markdown documentation use incorrect SDK API patterns that don't compile against the real github.com/github/copilot-sdk/go v0.1.23.

### Issues found

- copilot.NewClient() takes *ClientOptions, should be copilot.NewClient(nil)
- All methods require context.Context as first param (Start, CreateSession, Send, etc.)
- SessionConfig must be passed as pointer: &copilot.SessionConfig{}
- Event handling uses non-existent copilot.Event interface with type assertions; real API uses copilot.SessionEvent with .Type string and .Data fields
- event.Data.Content is *string (pointer), must nil-check and dereference
- session.WaitForIdle() doesn't exist, use session.SendAndWait(ctx, ...)
- copilot.SystemMessage is a constant not a type; correct type is copilot.SystemMessageConfig
- Import needs alias: copilot "github.com/github/copilot-sdk/go"

### Files changed (10)

Recipes: error-handling.go, persisting-sessions.go, multiple-sessions.go, managing-local-files.go, pr-visualization.go

Documentation: error-handling.md, persisting-sessions.md, multiple-sessions.md, managing-local-files.md, pr-visualization.md

### Verification

All 5 recipes compile successfully against copilot-sdk/go v0.1.23.