### PR TITLE
Remove unused note section from conventional-commit prompt template

### DIFF
--- a/prompts/conventional-commit.prompt.md
+++ b/prompts/conventional-commit.prompt.md
@@ -7,7 +7,6 @@ tools: ['execute/runInTerminal', 'execute/getTerminalOutput']
 
 ```xml
 	<description>This file contains a prompt template for generating conventional commit messages. It provides instructions, examples, and formatting guidelines to help users write standardized, descriptive commit messages in accordance with the Conventional Commits specification.</description>
-	<note>
 ```
 
 ### Workflow


### PR DESCRIPTION
Removed a note section from the conventional commit prompt template.

## Pull Request Checklist

- [X] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] ~~My contribution adds a new instruction, prompt, agent, or skill file in the correct directory.~~
- [ ] ~~The file follows the required naming convention.~~
- [X] The content is clearly structured and follows the example format.
- [X] I have tested my instructions, prompt, agent, or skill with GitHub Copilot.
- [X] I have run `npm start` and verified that `README.md` is up to date.

---

## Description

Removes an unused `<note>` block

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New collection file.
- [ ] New skill file.
- [X] Update to existing instruction, prompt, agent, collection or skill.
- [ ] Other (please specify):

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
