### PR TITLE
Fix modal close button on samples page

### DIFF
--- a/website/src/scripts/pages/samples.ts
+++ b/website/src/scripts/pages/samples.ts
@@ -5,6 +5,7 @@
 import { FuzzySearch, type SearchableItem } from "../search";
 import { fetchData, escapeHtml } from "../utils";
 import { createChoices, getChoicesValues, type Choices } from "../choices";
+import { setupModal } from "../modal";
 
 // Types
 interface Language {
@@ -82,6 +83,7 @@ export async function initSamplesPage(): Promise<void> {
     search = new FuzzySearch(allRecipes);
 
     // Setup UI
+    setupModal();
     setupFilters();
     setupSearch();
     renderCookbooks();


### PR DESCRIPTION
## Problem

The modal dialog on the samples page cannot be dismissed — the close button, Escape key, and backdrop click all fail to close it.

## Root cause

The samples page (`samples.ts`) dynamically imports `openFileModal` to display recipe content, but never calls `setupModal()`. This function registers all the event handlers for closing the modal (close button click, Escape key, backdrop click). Every other page that uses the modal calls `setupModal()` during initialization.

## Fix

Add the missing `setupModal()` call to `initSamplesPage()`, matching the pattern used by all other pages (agents, prompts, instructions, collections, hooks, skills, index).

## Testing

Verified with Playwright:
1. Open samples page → click "View Recipe" → modal opens ✅
2. Click close button → modal dismisses, URL hash cleared ✅
3. Open modal → press Escape → modal dismisses ✅