### PR TITLE
Remove text gradients from website

### DIFF
--- a/website/public/styles/global.css
+++ b/website/public/styles/global.css
@@ -361,10 +361,7 @@ a:hover {
   font-size: 56px;
   font-weight: 800;
   letter-spacing: -0.02em;
-  background: var(--gradient-primary);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--color-primary);
   margin-bottom: 20px;
   position: relative;
 }
@@ -535,10 +532,7 @@ a:hover {
   flex-shrink: 0;
   font-size: 28px;
   font-weight: 700;
-  background: var(--gradient-primary);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--color-primary);
   line-height: 1;
   min-width: 40px;
   text-align: right;


### PR DESCRIPTION
Simplifies the website design by replacing gradient-clipped text with a solid `var(--color-primary)` color.

### Changes
- **Hero h1**: Replaced gradient text with solid primary color
- **Card count numbers**: Replaced gradient text with solid primary color

Background gradients on sections and decorative elements are unchanged — this only affects text that used `background-clip: text` for the gradient effect.