### PR TITLE
fix: update plugin source paths in marketplace.json generation

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -12,271 +12,271 @@
   "plugins": [
     {
       "name": "awesome-copilot",
-      "source": "./plugins/awesome-copilot",
+      "source": "awesome-copilot",
       "description": "Meta prompts that help you discover and generate curated GitHub Copilot agents, instructions, prompts, and skills.",
       "version": "1.0.0"
     },
     {
       "name": "azure-cloud-development",
-      "source": "./plugins/azure-cloud-development",
+      "source": "azure-cloud-development",
       "description": "Comprehensive Azure cloud development tools including Infrastructure as Code, serverless functions, architecture patterns, and cost optimization for building scalable cloud applications.",
       "version": "1.0.0"
     },
     {
       "name": "cast-imaging",
-      "source": "./plugins/cast-imaging",
+      "source": "cast-imaging",
       "description": "A comprehensive collection of specialized agents for software analysis, impact assessment, structural quality advisories, and architectural review using CAST Imaging.",
       "version": "1.0.0"
     },
     {
       "name": "clojure-interactive-programming",
-      "source": "./plugins/clojure-interactive-programming",
+      "source": "clojure-interactive-programming",
       "description": "Tools for REPL-first Clojure workflows featuring Clojure instructions, the interactive programming chat mode and supporting guidance.",
       "version": "1.0.0"
     },
     {
       "name": "context-engineering",
-      "source": "./plugins/context-engineering",
+      "source": "context-engineering",
       "description": "Tools and techniques for maximizing GitHub Copilot effectiveness through better context management. Includes guidelines for structuring code, an agent for planning multi-file changes, and prompts for context-aware development.",
       "version": "1.0.0"
     },
     {
       "name": "copilot-sdk",
-      "source": "./plugins/copilot-sdk",
+      "source": "copilot-sdk",
       "description": "Build applications with the GitHub Copilot SDK across multiple programming languages. Includes comprehensive instructions for C#, Go, Node.js/TypeScript, and Python to help you create AI-powered applications.",
       "version": "1.0.0"
     },
     {
       "name": "csharp-dotnet-development",
-      "source": "./plugins/csharp-dotnet-development",
+      "source": "csharp-dotnet-development",
       "description": "Essential prompts, instructions, and chat modes for C# and .NET development including testing, documentation, and best practices.",
       "version": "1.1.0"
     },
     {
       "name": "csharp-mcp-development",
-      "source": "./plugins/csharp-mcp-development",
+      "source": "csharp-mcp-development",
       "description": "Complete toolkit for building Model Context Protocol (MCP) servers in C# using the official SDK. Includes instructions for best practices, a prompt for generating servers, and an expert chat mode for guidance.",
       "version": "1.0.0"
     },
     {
       "name": "database-data-management",
-      "source": "./plugins/database-data-management",
+      "source": "database-data-management",
       "description": "Database administration, SQL optimization, and data management tools for PostgreSQL, SQL Server, and general database development best practices.",
       "version": "1.0.0"
     },
     {
       "name": "dataverse-sdk-for-python",
-      "source": "./plugins/dataverse-sdk-for-python",
+      "source": "dataverse-sdk-for-python",
       "description": "Comprehensive collection for building production-ready Python integrations with Microsoft Dataverse. Includes official documentation, best practices, advanced features, file operations, and code generation prompts.",
       "version": "1.0.0"
     },
     {
       "name": "devops-oncall",
-      "source": "./plugins/devops-oncall",
+      "source": "devops-oncall",
       "description": "A focused set of prompts, instructions, and a chat mode to help triage incidents and respond quickly with DevOps tools and Azure resources.",
       "version": "1.0.0"
     },
     {
       "name": "edge-ai-tasks",
-      "source": "./plugins/edge-ai-tasks",
+      "source": "edge-ai-tasks",
       "description": "Task Researcher and Task Planner for intermediate to expert users and large codebases - Brought to you by microsoft/edge-ai",
       "version": "1.0.0"
     },
     {
       "name": "frontend-web-dev",
-      "source": "./plugins/frontend-web-dev",
+      "source": "frontend-web-dev",
       "description": "Essential prompts, instructions, and chat modes for modern frontend web development including React, Angular, Vue, TypeScript, and CSS frameworks.",
       "version": "1.0.0"
     },
     {
       "name": "gem-team",
-      "source": "./plugins/gem-team",
+      "source": "gem-team",
       "description": "A modular multi-agent team for complex project execution with DAG-based planning, parallel execution, TDD verification, and automated testing.",
       "version": "1.1.0"
     },
     {
       "name": "go-mcp-development",
-      "source": "./plugins/go-mcp-development",
+      "source": "go-mcp-development",
       "description": "Complete toolkit for building Model Context Protocol (MCP) servers in Go using the official github.com/modelcontextprotocol/go-sdk. Includes instructions for best practices, a prompt for generating servers, and an expert chat mode for guidance.",
       "version": "1.0.0"
     },
     {
       "name": "java-development",
-      "source": "./plugins/java-development",
+      "source": "java-development",
       "description": "Comprehensive collection of prompts and instructions for Java development including Spring Boot, Quarkus, testing, documentation, and best practices.",
       "version": "1.0.0"
     },
     {
       "name": "java-mcp-development",
-      "source": "./plugins/java-mcp-development",
+      "source": "java-mcp-development",
       "description": "Complete toolkit for building Model Context Protocol servers in Java using the official MCP Java SDK with reactive streams and Spring Boot integration.",
       "version": "1.0.0"
     },
     {
       "name": "kotlin-mcp-development",
-      "source": "./plugins/kotlin-mcp-development",
+      "source": "kotlin-mcp-development",
       "description": "Complete toolkit for building Model Context Protocol (MCP) servers in Kotlin using the official io.modelcontextprotocol:kotlin-sdk library. Includes instructions for best practices, a prompt for generating servers, and an expert chat mode for guidance.",
       "version": "1.0.0"
     },
     {
       "name": "mcp-m365-copilot",
-      "source": "./plugins/mcp-m365-copilot",
+      "source": "mcp-m365-copilot",
       "description": "Comprehensive collection for building declarative agents with Model Context Protocol integration for Microsoft 365 Copilot",
       "version": "1.0.0"
     },
     {
       "name": "openapi-to-application-csharp-dotnet",
-      "source": "./plugins/openapi-to-application-csharp-dotnet",
+      "source": "openapi-to-application-csharp-dotnet",
       "description": "Generate production-ready .NET applications from OpenAPI specifications. Includes ASP.NET Core project scaffolding, controller generation, entity framework integration, and C# best practices.",
       "version": "1.0.0"
     },
     {
       "name": "openapi-to-application-go",
-      "source": "./plugins/openapi-to-application-go",
+      "source": "openapi-to-application-go",
       "description": "Generate production-ready Go applications from OpenAPI specifications. Includes project scaffolding, handler generation, middleware setup, and Go best practices for REST APIs.",
       "version": "1.0.0"
     },
     {
       "name": "openapi-to-application-java-spring-boot",
-      "source": "./plugins/openapi-to-application-java-spring-boot",
+      "source": "openapi-to-application-java-spring-boot",
       "description": "Generate production-ready Spring Boot applications from OpenAPI specifications. Includes project scaffolding, REST controller generation, service layer organization, and Spring Boot best practices.",
       "version": "1.0.0"
     },
     {
       "name": "openapi-to-application-nodejs-nestjs",
-      "source": "./plugins/openapi-to-application-nodejs-nestjs",
+      "source": "openapi-to-application-nodejs-nestjs",
       "description": "Generate production-ready NestJS applications from OpenAPI specifications. Includes project scaffolding, controller and service generation, TypeScript best practices, and enterprise patterns.",
       "version": "1.0.0"
     },
     {
       "name": "openapi-to-application-python-fastapi",
-      "source": "./plugins/openapi-to-application-python-fastapi",
+      "source": "openapi-to-application-python-fastapi",
       "description": "Generate production-ready FastAPI applications from OpenAPI specifications. Includes project scaffolding, route generation, dependency injection, and Python best practices for async APIs.",
       "version": "1.0.0"
     },
     {
       "name": "ospo-sponsorship",
-      "source": "./plugins/ospo-sponsorship",
+      "source": "ospo-sponsorship",
       "description": "Tools and resources for Open Source Program Offices (OSPOs) to identify, evaluate, and manage sponsorship of open source dependencies through GitHub Sponsors, Open Collective, and other funding platforms.",
       "version": "1.0.0"
     },
     {
       "name": "partners",
-      "source": "./plugins/partners",
+      "source": "partners",
       "description": "Custom agents that have been created by GitHub partners",
       "version": "1.0.0"
     },
     {
       "name": "pcf-development",
-      "source": "./plugins/pcf-development",
+      "source": "pcf-development",
       "description": "Complete toolkit for developing custom code components using Power Apps Component Framework for model-driven and canvas apps",
       "version": "1.0.0"
     },
     {
       "name": "php-mcp-development",
-      "source": "./plugins/php-mcp-development",
+      "source": "php-mcp-development",
       "description": "Comprehensive resources for building Model Context Protocol servers using the official PHP SDK with attribute-based discovery, including best practices, project generation, and expert assistance",
       "version": "1.0.0"
     },
     {
       "name": "polyglot-test-agent",
-      "source": "./plugins/polyglot-test-agent",
+      "source": "polyglot-test-agent",
       "description": "Multi-agent pipeline for generating comprehensive unit tests across any programming language. Orchestrates research, planning, and implementation phases using specialized agents to produce tests that compile, pass, and follow project conventions.",
       "version": "1.0.0"
     },
     {
       "name": "power-apps-code-apps",
-      "source": "./plugins/power-apps-code-apps",
+      "source": "power-apps-code-apps",
       "description": "Complete toolkit for Power Apps Code Apps development including project scaffolding, development standards, and expert guidance for building code-first applications with Power Platform integration.",
       "version": "1.0.0"
     },
     {
       "name": "power-bi-development",
-      "source": "./plugins/power-bi-development",
+      "source": "power-bi-development",
       "description": "Comprehensive Power BI development resources including data modeling, DAX optimization, performance tuning, visualization design, security best practices, and DevOps/ALM guidance for building enterprise-grade Power BI solutions.",
       "version": "1.0.0"
     },
     {
       "name": "power-platform-mcp-connector-development",
-      "source": "./plugins/power-platform-mcp-connector-development",
+      "source": "power-platform-mcp-connector-development",
       "description": "Complete toolkit for developing Power Platform custom connectors with Model Context Protocol integration for Microsoft Copilot Studio",
       "version": "1.0.0"
     },
     {
       "name": "project-planning",
-      "source": "./plugins/project-planning",
+      "source": "project-planning",
       "description": "Tools and guidance for software project planning, feature breakdown, epic management, implementation planning, and task organization for development teams.",
       "version": "1.0.0"
     },
     {
       "name": "python-mcp-development",
-      "source": "./plugins/python-mcp-development",
+      "source": "python-mcp-development",
       "description": "Complete toolkit for building Model Context Protocol (MCP) servers in Python using the official SDK with FastMCP. Includes instructions for best practices, a prompt for generating servers, and an expert chat mode for guidance.",
       "version": "1.0.0"
     },
     {
       "name": "ruby-mcp-development",
-      "source": "./plugins/ruby-mcp-development",
+      "source": "ruby-mcp-development",
       "description": "Complete toolkit for building Model Context Protocol servers in Ruby using the official MCP Ruby SDK gem with Rails integration support.",
       "version": "1.0.0"
     },
     {
       "name": "rug-agentic-workflow",
-      "source": "./plugins/rug-agentic-workflow",
+      "source": "rug-agentic-workflow",
       "description": "Three-agent workflow for orchestrated software delivery with an orchestrator plus implementation and QA subagents.",
       "version": "1.0.0"
     },
     {
       "name": "rust-mcp-development",
-      "source": "./plugins/rust-mcp-development",
+      "source": "rust-mcp-development",
       "description": "Build high-performance Model Context Protocol servers in Rust using the official rmcp SDK with async/await, procedural macros, and type-safe implementations.",
       "version": "1.0.0"
     },
     {
       "name": "security-best-practices",
-      "source": "./plugins/security-best-practices",
+      "source": "security-best-practices",
       "description": "Security frameworks, accessibility guidelines, performance optimization, and code quality best practices for building secure, maintainable, and high-performance applications.",
       "version": "1.0.0"
     },
     {
       "name": "software-engineering-team",
-      "source": "./plugins/software-engineering-team",
+      "source": "software-engineering-team",
       "description": "7 specialized agents covering the full software development lifecycle from UX design and architecture to security and DevOps.",
       "version": "1.0.0"
     },
     {
       "name": "structured-autonomy",
-      "source": "./plugins/structured-autonomy",
+      "source": "structured-autonomy",
       "description": "Premium planning, thrifty implementation",
       "version": "1.0.0"
     },
     {
       "name": "swift-mcp-development",
-      "source": "./plugins/swift-mcp-development",
+      "source": "swift-mcp-development",
       "description": "Comprehensive collection for building Model Context Protocol servers in Swift using the official MCP Swift SDK with modern concurrency features.",
       "version": "1.0.0"
     },
     {
       "name": "technical-spike",
-      "source": "./plugins/technical-spike",
+      "source": "technical-spike",
       "description": "Tools for creation, management and research of technical spikes to reduce unknowns and assumptions before proceeding to specification and implementation of solutions.",
       "version": "1.0.0"
     },
     {
       "name": "testing-automation",
-      "source": "./plugins/testing-automation",
+      "source": "testing-automation",
       "description": "Comprehensive collection for writing tests, test automation, and test-driven development including unit tests, integration tests, and end-to-end testing strategies.",
       "version": "1.0.0"
     },
     {
       "name": "typescript-mcp-development",
-      "source": "./plugins/typescript-mcp-development",
+      "source": "typescript-mcp-development",
       "description": "Complete toolkit for building Model Context Protocol (MCP) servers in TypeScript/Node.js using the official SDK. Includes instructions for best practices, a prompt for generating servers, and an expert chat mode for guidance.",
       "version": "1.0.0"
     },
     {
       "name": "typespec-m365-copilot",
-      "source": "./plugins/typespec-m365-copilot",
+      "source": "typespec-m365-copilot",
       "description": "Comprehensive collection of prompts, instructions, and resources for building declarative agents and API plugins using TypeSpec for Microsoft 365 Copilot extensibility.",
       "version": "1.0.0"
     }

--- a/eng/generate-marketplace.mjs
+++ b/eng/generate-marketplace.mjs
@@ -14,12 +14,12 @@ const MARKETPLACE_FILE = path.join(ROOT_FOLDER, ".github/plugin", "marketplace.j
  */
 function readPluginMetadata(pluginDir) {
   const pluginJsonPath = path.join(pluginDir, ".github/plugin", "plugin.json");
-  
+
   if (!fs.existsSync(pluginJsonPath)) {
     console.warn(`Warning: No plugin.json found for ${path.basename(pluginDir)}`);
     return null;
   }
-  
+
   try {
     const content = fs.readFileSync(pluginJsonPath, "utf8");
     return JSON.parse(content);
@@ -34,30 +34,30 @@ function readPluginMetadata(pluginDir) {
  */
 function generateMarketplace() {
   console.log("Generating marketplace.json...");
-  
+
   if (!fs.existsSync(PLUGINS_DIR)) {
     console.error(`Error: Plugins directory not found at ${PLUGINS_DIR}`);
     process.exit(1);
   }
-  
+
   // Read all plugin directories
   const pluginDirs = fs.readdirSync(PLUGINS_DIR, { withFileTypes: true })
     .filter(entry => entry.isDirectory())
     .map(entry => entry.name)
     .sort();
-  
+
   console.log(`Found ${pluginDirs.length} plugin directories`);
-  
+
   // Read metadata for each plugin
   const plugins = [];
   for (const dirName of pluginDirs) {
     const pluginPath = path.join(PLUGINS_DIR, dirName);
     const metadata = readPluginMetadata(pluginPath);
-    
+
     if (metadata) {
       plugins.push({
         name: metadata.name,
-        source: `./plugins/${dirName}`,
+        source: dirName,
         description: metadata.description,
         version: metadata.version || "1.0.0"
       });
@@ -66,7 +66,7 @@ function generateMarketplace() {
       console.log(`✗ Skipped: ${dirName} (no valid plugin.json)`);
     }
   }
-  
+
   // Create marketplace.json structure
   const marketplace = {
     name: "awesome-copilot",
@@ -81,16 +81,16 @@ function generateMarketplace() {
     },
     plugins: plugins
   };
-  
+
   // Ensure directory exists
   const marketplaceDir = path.dirname(MARKETPLACE_FILE);
   if (!fs.existsSync(marketplaceDir)) {
     fs.mkdirSync(marketplaceDir, { recursive: true });
   }
-  
+
   // Write marketplace.json
   fs.writeFileSync(MARKETPLACE_FILE, JSON.stringify(marketplace, null, 2) + "\n");
-  
+
   console.log(`\n✓ Successfully generated marketplace.json with ${plugins.length} plugins`);
   console.log(`  Location: ${MARKETPLACE_FILE}`);
 }


### PR DESCRIPTION
# fix(marketplace): normalize plugin source paths in marketplace.json

Related: #772 

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] My contribution adds a new instruction, prompt, agent, or skill file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, or skill with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.

---

## Description

Updated the marketplace generation script to emit bare plugin directory names instead of `./plugins/`-prefixed relative paths in the `source` field. This corrected the source path format across all 46 plugin entries in *marketplace.json*.

The generation logic in *eng/generate-marketplace.mjs* previously constructed source paths using a template string (`` `./plugins/${dirName}` ``), which produced paths like `./plugins/awesome-copilot`. The fix replaced this with the raw `dirName` value, yielding cleaner paths like `awesome-copilot`. The regenerated *marketplace.json* reflects this change uniformly across every plugin entry.

Trailing whitespace on blank lines in the generator script was also cleaned up as part of this change.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [x] Update to existing instruction, prompt, agent, plugin, or skill.
- [ ] Other (please specify):

---

## Additional Notes

- The `marketplace.json` output was verified as stable by running `npm start` and confirming no drift in tracked files.
- This is a focused build tooling fix; no new resources were added or removed.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
