### PR TITLE
Add cross-platform script to clean materialized plugin files

### DIFF
--- a/eng/clean-materialized-plugins.mjs
+++ b/eng/clean-materialized-plugins.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+import path from "path";
+import { ROOT_FOLDER } from "./constants.mjs";
+
+const PLUGINS_DIR = path.join(ROOT_FOLDER, "plugins");
+const MATERIALIZED_DIRS = ["agents", "commands", "skills"];
+
+function cleanPlugin(pluginPath) {
+  let removed = 0;
+  for (const subdir of MATERIALIZED_DIRS) {
+    const target = path.join(pluginPath, subdir);
+    if (fs.existsSync(target) && fs.statSync(target).isDirectory()) {
+      const count = countFiles(target);
+      fs.rmSync(target, { recursive: true, force: true });
+      removed += count;
+      console.log(`  Removed ${path.basename(pluginPath)}/${subdir}/ (${count} files)`);
+    }
+  }
+  return removed;
+}
+
+function countFiles(dir) {
+  let count = 0;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      count += countFiles(path.join(dir, entry.name));
+    } else {
+      count++;
+    }
+  }
+  return count;
+}
+
+function main() {
+  console.log("Cleaning materialized files from plugins...\n");
+
+  if (!fs.existsSync(PLUGINS_DIR)) {
+    console.error(`Error: plugins directory not found at ${PLUGINS_DIR}`);
+    process.exit(1);
+  }
+
+  const pluginDirs = fs.readdirSync(PLUGINS_DIR, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .sort();
+
+  let total = 0;
+  for (const dirName of pluginDirs) {
+    total += cleanPlugin(path.join(PLUGINS_DIR, dirName));
+  }
+
+  console.log();
+  if (total === 0) {
+    console.log("✅ No materialized files found. Plugins are already clean.");
+  } else {
+    console.log(`✅ Removed ${total} materialized file(s) from plugins.`);
+  }
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "plugin:create": "node ./eng/create-plugin.mjs",
     "skill:validate": "node ./eng/validate-skills.mjs",
     "skill:create": "node ./eng/create-skill.mjs",
+    "plugin:clean": "node ./eng/clean-materialized-plugins.mjs",
     "plugin:generate-marketplace": "node ./eng/generate-marketplace.mjs",
     "website:data": "node ./eng/generate-website-data.mjs",
     "website:dev": "npm run website:data && npm run --prefix website dev",


### PR DESCRIPTION
## Summary

Adds `eng/clean-materialized-plugins.mjs` — a cross-platform Node.js script that removes CI-materialized `agents/`, `commands/`, and `skills/` subdirectories from plugin folders.

Per CONTRIBUTING.md, plugin folders on `staged` should only contain `.github/plugin/plugin.json` and `README.md`. The materialized content is generated during publish by `eng/materialize-plugins.mjs`.

## Usage

```bash
npm run plugin:clean
```

## Changes

- **`eng/clean-materialized-plugins.mjs`** — New script following existing `eng/` conventions (ES modules, imports `ROOT_FOLDER` from `constants.mjs`)
- **`package.json`** — Added `plugin:clean` npm script