### PR TITLE
Add agentskill-learn as external plugin

### DIFF
--- a/plugins/external.json
+++ b/plugins/external.json
@@ -70,5 +70,22 @@
       "repo": "dotnet/skills",
       "path": "plugins/dotnet-diag"
     }
+  },
+  {
+    "name": "agentskill-learn",
+    "description": "Discover and install 110,000+ AI agent skills from agentskill.sh. Search by keyword, install mid-session, and rate skills after use.",
+    "version": "1.0.0",
+    "author": {
+      "name": "agentskill.sh",
+      "url": "https://agentskill.sh"
+    },
+    "homepage": "https://agentskill.sh",
+    "keywords": ["skills", "marketplace", "registry", "agent-skills", "learn", "install"],
+    "license": "MIT",
+    "repository": "https://github.com/agentskill-sh/learn",
+    "source": {
+      "source": "github",
+      "repo": "agentskill-sh/learn"
+    }
   }
 ]


### PR DESCRIPTION
## What

Adds agentskill.sh/learn as an external plugin in `plugins/external.json`, giving Copilot users access to 110,000+ community AI agent skills from [agentskill.sh](https://agentskill.sh).

## Why

agentskill.sh is the largest cross-platform skills directory (110k+ skills indexed from GitHub). Registering it as an external plugin lets users install directly from the source repo, always getting the latest version with no duplication or drift.

Users can install with: `/plugin marketplace add agentskill-sh/learn`

## Changes

- `plugins/external.json`: Added `agentskill-learn` entry pointing to `agentskill-sh/learn` repo
