### PR TITLE
feat: add cli-mastery skill — interactive Copilot CLI training

### DIFF
--- a/skills/cli-mastery/SKILL.md
+++ b/skills/cli-mastery/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: cli-mastery
+description: >
+  Interactive training for the GitHub Copilot CLI. Guided lessons, quizzes,
+  scenario challenges, and a full reference covering slash commands, shortcuts,
+  modes, agents, skills, MCP, and configuration. Say "cliexpert" to start.
+metadata:
+  version: 1.1.0
+license: MIT
+---
+
+# Copilot CLI Mastery
+
+**UTILITY SKILL** — interactive Copilot CLI trainer.
+INVOKES: `ask_user`, `sql`, `view`
+USE FOR: "cliexpert", "teach me the Copilot CLI", "quiz me on slash commands", "CLI cheat sheet", "copilot CLI final exam"
+DO NOT USE FOR: general coding, non-CLI questions, IDE-only features
+
+## Routing and Content
+
+| Trigger | Action |
+|---------|--------|
+| "cliexpert", "teach me" | Read next `curriculum/module-N-*.md`, teach |
+| "quiz me", "test me" | Read current module, 5+ questions via `ask_user` |
+| "scenario", "challenge" | Read `curriculum/scenarios.md` |
+| "reference" | Read relevant module, summarize |
+| "final exam" | Read `curriculum/final-exam.md` |
+
+Specific CLI questions get direct answers without curriculum.
+Curriculum in `curriculum/` dir. Read on demand with `view`.
+
+## Behavior
+
+On first interaction, initialize progress tracking:
+```sql
+CREATE TABLE IF NOT EXISTS mastery_progress (key TEXT PRIMARY KEY, value TEXT);
+CREATE TABLE IF NOT EXISTS mastery_completed (module TEXT PRIMARY KEY, completed_at TEXT DEFAULT (datetime('now')));
+INSERT OR IGNORE INTO mastery_progress (key,value) VALUES ('xp','0'),('level','Newcomer'),('module','0');
+```
+XP: lesson +20, correct +15, perfect quiz +50, scenario +30.
+Levels: 0=Newcomer 100=Apprentice 300=Navigator 600=Practitioner 1000=Specialist 1500=Expert 2200=Virtuoso 3000=Architect 4000=Grandmaster 5000=Wizard.
+
+Rules: `ask_user` with `choices` for ALL quizzes/scenarios. Show XP after correct answers. One concept at a time; offer quiz or review after each lesson.

--- a/skills/cli-mastery/curriculum/final-exam.md
+++ b/skills/cli-mastery/curriculum/final-exam.md
@@ -1,0 +1,24 @@
+# Final Exam
+
+Present a 10-question comprehensive exam using `ask_user` with 4 choices each. Require 80%+ to pass. Vary the selection each time.
+
+## Question Bank
+
+1. Which command initializes Copilot CLI in a new project? → `/init`
+2. What shortcut cycles through modes? → `Shift+Tab`
+3. Where are repo-level custom agents stored? → `.github/agents/*.md`
+4. What does MCP stand for? → Model Context Protocol
+5. Which agent is safe to run in parallel? → `explore`
+6. How do you add a file to AI context? → `@ + filename`
+7. What file has the highest instruction precedence? → `CLAUDE.md` / `AGENTS.md`
+8. Which command compresses conversation history? → `/compact`
+9. Where is MCP configured at project level? → `.github/mcp-config.json`
+10. What does `--yolo` do? → Same as `--allow-all` (skip all confirmations)
+11. What does `/delegate` do? → Spawns a coding agent for a complex task
+12. Which shortcut opens input in $EDITOR? → `Ctrl+X → Ctrl+E`
+13. What does `/reset-allowed-tools` do? → Re-enables confirmation prompts
+14. What does triple-pressing Ctrl+C do? → Exits the CLI
+15. What does `/compact` do? → Summarizes conversation to free context
+
+On pass (80%+): Award "CLI Wizard" title, congratulate enthusiastically!
+On fail: Show which they got wrong, encourage retry.

--- a/skills/cli-mastery/curriculum/module-1-slash-commands.md
+++ b/skills/cli-mastery/curriculum/module-1-slash-commands.md
@@ -1,0 +1,87 @@
+# Module 1: Slash Commands
+
+Teach these categories one at a time, with examples and "when to use" guidance.
+
+## Getting Started
+
+| Command | What it does | When to use |
+|---------|-------------|-------------|
+| `/login` | Authenticate with GitHub | First launch or expired session |
+| `/logout` | Sign out | Switching accounts |
+| `/help` | Show all commands | When lost |
+| `/exit` `/quit` | Exit CLI | Done working |
+| `/init` | Bootstrap copilot-instructions.md | New repo setup |
+| `/terminal-setup` | Configure multiline input | First-time setup |
+
+## Models & Agents
+
+| Command | What it does | When to use |
+|---------|-------------|-------------|
+| `/model` | Switch AI model | Need different capability/speed |
+| `/agent` | Browse/select agents | Delegate to specialist |
+| `/fleet` | Enable parallel subagents | Complex multi-part tasks |
+| `/tasks` | View background tasks | Check on running subagents |
+
+## Code & Review
+
+| Command | What it does | When to use |
+|---------|-------------|-------------|
+| `/diff` | Review changes in current dir | Before committing |
+| `/review` | Run code review agent | Get feedback on changes |
+| `/lsp` | Manage language servers | Need go-to-def, diagnostics |
+| `/ide` | Connect to IDE workspace | Want IDE integration |
+
+## Session & Context
+
+| Command | What it does | When to use |
+|---------|-------------|-------------|
+| `/context` | Show token usage visualization | Context getting large |
+| `/usage` | Display session metrics | Check premium request count |
+| `/compact` | Compress conversation history | Near context limit |
+| `/session` | Show session info | Need session details |
+| `/resume` | Switch to different session | Continue previous work |
+| `/rename` | Rename current session | Better organization |
+| `/share` | Export session to markdown/gist | Share with team |
+| `/clear` | Clear conversation history | Fresh start |
+
+## Permissions & Directories
+
+| Command | What it does | When to use |
+|---------|-------------|-------------|
+| `/allow-all` | Enable all permissions | Trusted environment, move fast |
+| `/add-dir` | Add trusted directory | Working across projects |
+| `/list-dirs` | Show allowed directories | Check access scope |
+| `/cwd` | Change working directory | Switch project context |
+| `/reset-allowed-tools` | Revoke tool approvals | Tighten security |
+
+## Configuration & Customization
+
+| Command | What it does | When to use |
+|---------|-------------|-------------|
+| `/instructions` | View active instruction files | Debug custom behavior |
+| `/experimental` | Toggle experimental features | Try autopilot mode |
+| `/theme` | Change terminal theme | Personalize |
+| `/streamer-mode` | Hide sensitive info | Livestreaming/demos |
+| `/changelog` | Show release notes | After update |
+| `/update` | Update CLI | New version available |
+| `/feedback` | Submit feedback | Report bug or request |
+
+## Extensibility
+
+| Command | What it does | When to use |
+|---------|-------------|-------------|
+| `/skills` | Manage skills | Browse/enable capabilities |
+| `/mcp` | Manage MCP servers | Add external tools |
+| `/plugin` | Manage plugins | Extend functionality |
+
+## Workflows
+
+| Command | What it does | When to use |
+|---------|-------------|-------------|
+| `/plan` | Create implementation plan | Before complex changes |
+| `/delegate` | Hand off to coding agent | Long-running background tasks |
+| `/user` | Manage GitHub user list | Team context |
+
+## Quiz (5+ questions, use ask_user with 4 choices each)
+
+Ask "Which command would you use to [scenario]?" style questions.

--- a/skills/cli-mastery/curriculum/module-2-keyboard-shortcuts.md
+++ b/skills/cli-mastery/curriculum/module-2-keyboard-shortcuts.md
@@ -1,0 +1,38 @@
+# Module 2: Keyboard Shortcuts
+
+## Navigation & Editing
+
+| Shortcut | Action |
+|----------|--------|
+| `@` | Mention files — include their contents as context |
+| `Ctrl+S` | Submit prompt while preserving input text |
+| `Shift+Tab` | Cycle modes: Interactive → Plan |
+| `Ctrl+T` | Toggle model reasoning display |
+| `Ctrl+O` | Expand recent timeline (when no input) |
+| `Ctrl+E` | Expand all timeline / move to end of line |
+| `↑` `↓` | Navigate command history |
+| `!` | Execute shell command directly (bypass AI) |
+| `Esc` | Cancel current operation |
+| `Ctrl+C` | Cancel operation / clear input / exit |
+| `Ctrl+D` | Shutdown session |
+| `Ctrl+L` | Clear the screen |
+| `Ctrl+X` → `Ctrl+E` | Edit prompt in $EDITOR |
+
+## Line Editing
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+A` | Move to beginning of line |
+| `Ctrl+H` | Delete previous character |
+| `Ctrl+W` | Delete previous word |
+| `Ctrl+U` | Delete from cursor to beginning of line |
+| `Ctrl+K` | Delete from cursor to end of line |
+| `Meta+←` `Meta+→` | Move cursor by word |
+
+## Pro tips to teach
+
+- `@` is THE most important shortcut — it's how you give precise context
+- `!git status` runs git directly without AI processing
+- `Shift+Tab` into Plan mode BEFORE complex tasks
+- `Ctrl+X → Ctrl+E` opens your $EDITOR for long prompts — game changer
+- `Ctrl+S` lets you iterate on a prompt without retyping

--- a/skills/cli-mastery/curriculum/module-3-modes.md
+++ b/skills/cli-mastery/curriculum/module-3-modes.md
@@ -1,0 +1,33 @@
+# Module 3: Interaction Modes
+
+## Interactive Mode (default)
+
+- AI acts immediately on your prompts
+- Asks permission for risky operations
+- Best for: quick tasks, debugging, exploring code
+- 80% of your time will be here
+
+## Plan Mode (`Shift+Tab` or `/plan`)
+
+- AI creates a step-by-step plan FIRST
+- You review and approve before execution
+- Best for: complex refactoring, architecture changes, risky operations
+- Key insight: Use this when mistakes are expensive
+
+## Autopilot Mode (experimental, `/experimental`)
+
+- AI acts without asking for confirmation
+- Best for: trusted environments, long-running tasks
+- Use with caution — pair with `/allow-all` or `--yolo`
+
+## Mode Comparison
+
+| Feature | Interactive | Plan | Autopilot |
+|---------|------------|------|-----------|
+| Speed | Fast | Slower | Fastest |
+| Safety | Medium | Highest | Lowest |
+| Control | You approve each action | You approve the plan | Full AI autonomy |
+| Best for | Daily tasks | Complex changes | Repetitive/trusted work |
+| Switch | Default | Shift+Tab or /plan | /experimental |
+
+Teaching point: The right mode at the right time = 10x productivity.

--- a/skills/cli-mastery/curriculum/module-4-agents.md
+++ b/skills/cli-mastery/curriculum/module-4-agents.md
@@ -1,0 +1,42 @@
+# Module 4: Agent System
+
+## Built-in Agents
+
+| Agent | Model | Best For | Key Trait |
+|-------|-------|----------|-----------|
+| `explore` | Haiku | Fast codebase Q&A | Read-only, <300 words, safe to parallelize |
+| `task` | Haiku | Running commands (tests, builds, lints) | Brief on success, verbose on failure |
+| `general-purpose` | Sonnet | Complex multi-step tasks | Full toolset, separate context window |
+| `code-review` | All CLI tools | Analyzing code changes | Never modifies code, high signal-to-noise |
+
+## Custom Agents — define your own in Markdown
+
+| Level | Location | Scope |
+|-------|----------|-------|
+| Personal | `~/.copilot/agents/*.md` | All your projects |
+| Project | `.github/agents/*.md` | Everyone on this repo |
+| Organization | `.github-private/agents/` in org repo | Entire org |
+
+## Agent file anatomy
+
+```markdown
+---
+name: my-agent
+description: What this agent does
+tools:
+  - bash
+  - edit
+  - view
+---
+
+# Agent Instructions
+Your detailed behavior instructions here.
+```
+
+## Agent orchestration patterns
+
+1. **Fan-out exploration** — Launch multiple `explore` agents in parallel to answer different questions simultaneously
+2. **Pipeline** — `explore` → understand → `general-purpose` → implement → `code-review` → verify
+3. **Specialist handoff** — Identify task → `/delegate` to custom agent → review with `/fleet` or `/tasks`
+
+Key insight: The AI automatically delegates to subagents when appropriate.

--- a/skills/cli-mastery/curriculum/module-5-skills.md
+++ b/skills/cli-mastery/curriculum/module-5-skills.md
@@ -1,0 +1,33 @@
+# Module 5: Skills System
+
+## What are skills?
+
+- Specialized capability packages the AI can invoke
+- Think of them as "expert modes" with domain-specific knowledge
+- Managed via `/skills` command
+
+## Skill locations
+
+| Level | Location |
+|-------|----------|
+| User | `~/.copilot/skills/<name>/SKILL.md` |
+| Repo | `.github/skills/<name>/SKILL.md` |
+| Org | Shared via org-level config |
+
+## Creating a custom skill
+
+1. Create the directory: `mkdir -p ~/.copilot/skills/my-skill/`
+2. Create `SKILL.md` with YAML frontmatter (`name`, `description`, optional `tools`)
+3. Write detailed instructions for the AI's behavior
+4. Verify with `/skills`
+
+## Skill design best practices
+
+- **Clear description** — helps the AI match tasks to your skill automatically
+- **Focused scope** — each skill should do ONE thing well
+- **Include instructions** — specify exactly how the skill should operate
+- **Test thoroughly** — use `/skills` to verify, then invoke and check results
+
+## Auto-matching
+
+When you describe a task, the AI checks if any skill matches and suggests using it.

--- a/skills/cli-mastery/curriculum/module-6-mcp.md
+++ b/skills/cli-mastery/curriculum/module-6-mcp.md
@@ -1,0 +1,50 @@
+# Module 6: MCP Integration
+
+## What is MCP?
+
+- Model Context Protocol — a standard for connecting AI to external tools
+- Think of it as "USB ports for AI" — plug in any compatible tool
+- The GitHub MCP server is **built-in** (search repos, issues, PRs, actions)
+
+## Key commands
+
+| Command | What it does |
+|---------|-------------|
+| `/mcp` | List connected MCP servers |
+| `/mcp add <name> <command>` | Add a new MCP server |
+
+## Popular MCP servers
+
+- `@modelcontextprotocol/server-postgres` — Query PostgreSQL databases
+- `@modelcontextprotocol/server-sqlite` — Query SQLite databases
+- `@modelcontextprotocol/server-filesystem` — Access local files with permissions
+- `@modelcontextprotocol/server-memory` — Persistent knowledge graph
+- `@modelcontextprotocol/server-puppeteer` — Browser automation
+
+## Configuration
+
+| Level | File |
+|-------|------|
+| User | `~/.copilot/mcp-config.json` |
+| Project | `.github/mcp-config.json` |
+
+## Config file format
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-postgres", "{{env.DATABASE_URL}}"],
+      "env": { "NODE_ENV": "development" }
+    }
+  }
+}
+```
+
+## Security best practices
+
+- Never put credentials directly in config files
+- Use environment variable references: `{{env.SECRET}}`
+- Review MCP server source before using
+- Only connect servers you actually need

--- a/skills/cli-mastery/curriculum/module-7-advanced.md
+++ b/skills/cli-mastery/curriculum/module-7-advanced.md
@@ -1,0 +1,37 @@
+# Module 7: Advanced Techniques
+
+1. **`@ file mentions`** — Always give precise context, don't rely on the AI finding files
+   - `@src/auth.ts` — single file
+   - `@src/components/` — directory listing
+   - "Fix @src/auth.ts to match @tests/auth.test.ts" — multi-file context
+
+2. **`! shell bypass`** — `!git log --oneline -5` runs instantly, no AI overhead
+
+3. **`/delegate`** — Hand off to GitHub's cloud coding agent + open a PR
+
+4. **`/resume` + `--continue`** — Session continuity across CLI launches
+
+5. **`/compact`** — Compress history when context gets large (auto at 95%)
+   - Check with `/context` first
+   - Best used at natural task boundaries
+   - Warning signs: AI contradicting earlier statements, token usage >80%
+
+6. **`/context`** — Visualize what's eating your token budget
+
+7. **Custom instructions precedence** (highest to lowest):
+   - `CLAUDE.md` / `GEMINI.md` / `AGENTS.md` (git root + cwd)
+   - `.github/instructions/**/*.instructions.md` (path-specific!)
+   - `.github/copilot-instructions.md`
+   - `~/.copilot/copilot-instructions.md`
+
+8. **Path-specific instructions:**
+   - `.github/instructions/backend.instructions.md` with `applyTo: "src/api/**"`
+   - Different coding standards for different parts of the codebase
+
+9. **LSP config** — `~/.copilot/lsp-config.json` or `.github/lsp.json`
+
+10. **`/review`** — Get code review without leaving terminal
+
+11. **`--allow-all` / `--yolo`** — Full trust mode (use responsibly!)
+
+12. **`Ctrl+T`** — Watch the AI think (learn its reasoning patterns)

--- a/skills/cli-mastery/curriculum/module-8-configuration.md
+++ b/skills/cli-mastery/curriculum/module-8-configuration.md
@@ -1,0 +1,34 @@
+# Module 8: Configuration
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `~/.copilot/config.json` | Main settings (model, theme, logging, experimental flags) |
+| `~/.copilot/mcp-config.json` | MCP servers |
+| `~/.copilot/lsp-config.json` | Language servers (user-level) |
+| `.github/lsp.json` | Language servers (repo-level) |
+| `~/.copilot/copilot-instructions.md` | Global custom instructions |
+| `.github/copilot-instructions.md` | Repo-level custom instructions |
+
+## Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `EDITOR` | Text editor for `Ctrl+X→Ctrl+E` |
+| `COPILOT_LOG_LEVEL` | Logging verbosity (error/warn/info/debug/trace) |
+| `GH_TOKEN` | GitHub authentication token |
+| `COPILOT_MODEL` | Default AI model |
+
+## Permissions model
+
+- Default: confirmation required for edits, creates, shell commands
+- `/allow-all` or `--yolo`: skip all confirmations for the session
+- `/reset-allowed-tools`: re-enable confirmations
+- Directory allowlists, tool approval gates, MCP server trust
+
+## Logging levels
+
+error, warn, info, debug, trace (`COPILOT_LOG_LEVEL=debug copilot`)
+
+Use debug/trace for: MCP connection issues, tool failures, unexpected behavior, bug reports

--- a/skills/cli-mastery/curriculum/scenarios.md
+++ b/skills/cli-mastery/curriculum/scenarios.md
@@ -1,0 +1,44 @@
+# Scenario Challenges
+
+Present these as real-world situations. Ask the user what commands/shortcuts they'd use.
+Use `ask_user` with choices for each step.
+
+## Scenario 1: Hotfix Review Under Pressure
+> A production bug fix is ready. You need to inspect the diff, run code review, and keep sensitive data hidden because you're on a livestream.
+
+**Answer:** `/streamer-mode` → `/diff` → `/review @src/payment.ts`
+
+## Scenario 2: Context Window Rescue
+> Your session is huge and model quality is dropping. Keep continuity while shrinking noise.
+
+**Answer:** `/context` → `/compact` → `/resume` (or restart with `--continue`)
+
+## Scenario 3: Autonomous Refactor Sprint
+> You want an agent to execute a refactor with minimal prompts, but only after reviewing a plan and setting permissions.
+
+**Answer:** `Shift+Tab` (Plan mode) → validate plan → `/delegate` → optionally `/allow-all`
+
+## Scenario 4: Enterprise Onboarding
+> Set up custom agents, repo instructions, and MCP integration for a new team repository.
+
+**Answer:** Add agent profiles to `.github/agents/`, verify `/instructions`, then `/mcp add`
+
+## Scenario 5: Power Editing Session
+> You're crafting a long prompt and need to edit quickly without losing context.
+
+**Answer:** `Ctrl+X → Ctrl+E` (open in editor), `Ctrl+A` (jump to start), `Ctrl+K` (trim)
+
+## Scenario 6: Agent Orchestration
+> You're leading a complex project: understand code, run tests, refactor, then review.
+
+**Answer:** `explore` agent (understand) → `task` agent (tests) → `general-purpose` (refactor) → `code-review` (verify)
+
+## Scenario 7: New Project Setup
+> You cloned a new repo and need to set up Copilot CLI for max productivity.
+
+**Answer:** `/init` → `/model` → `/mcp add` (if needed) → `Shift+Tab` to Plan mode for first task
+
+## Scenario 8: Production Safety
+> Switching from boilerplate work to production deployment scripts.
+
+**Answer:** `/reset-allowed-tools` → Plan mode → `/review` before every commit


### PR DESCRIPTION
## New Skill: cli-mastery

**What it does:** An 8-module interactive training skill that teaches users to master the GitHub Copilot CLI through guided lessons, quizzes, scenario challenges, and a comprehensive reference.

**Modules covered:**
1. Slash Commands (41 commands across 8 categories)
2. Keyboard Shortcuts (19 shortcuts)
3. Modes (ask, edit, agent)
4. Agents (task, explore, general-purpose, code-review)
5. Skills (creating, registering, debugging)
6. MCP (Model Context Protocol servers & tools)
7. Advanced Techniques (prompt engineering, multi-agent, CI/CD)
8. Configuration (settings, themes, keybindings)

**How to invoke:** Just say `cliexpert` or ask about any Copilot CLI topic.

**Architecture:** Slim SKILL.md router (492/500 tokens) + 10 bundled curriculum files loaded on demand.

**Validation:**
- ✅ `npm run skill:validate` — passes (198/198 skills valid)
- ✅ `waza check` — 8/8 spec, 492/500 tokens, eval suite present
- ✅ Includes XP/leveling system, achievements, and progress tracking via SQL

**Source repo:** https://github.com/DUBSOpenHub/copilot-cli-mastery