### PR TITLE
fix: add missing meta tags for Twitter/X social card images

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -47,6 +47,9 @@ try {
     <meta property="og:title" content={`${title} | Awesome GitHub Copilot`} />
     <meta property="og:description" content={description} />
     <meta property="og:image" content={socialImageUrl.toString()} />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="2400" />
+    <meta property="og:image:height" content="1260" />
     <meta property="og:site_name" content="Awesome GitHub Copilot" />
 
     <!-- Twitter -->
@@ -54,6 +57,7 @@ try {
     <meta name="twitter:title" content={`${title} | Awesome GitHub Copilot`} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={socialImageUrl.toString()} />
+    <meta name="twitter:image:alt" content={`${title} | Awesome GitHub Copilot`} />
 
     <link rel="stylesheet" href={`${base}styles/global.css`} />
     <link


### PR DESCRIPTION
## Summary

Social card images display correctly on LinkedIn but not on X (Twitter). This adds the missing meta tags that Twitter's crawler needs to properly render the card image.

## Changes

Added to `website/src/layouts/BaseLayout.astro`:

- `og:image:width` and `og:image:height` — Twitter's crawler uses these to validate image dimensions without downloading the file. Without them, the crawl can timeout and skip the image.
- `og:image:type` — helps Twitter identify the image format during content negotiation.
- `twitter:image:alt` — provides alt text for the card image (accessibility best practice).

## Testing

After deploy, verify with [Twitter's Card Validator](https://cards-dev.twitter.com/validator) to confirm the image renders.