### PR TITLE
fix: remove [skip ci] from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,5 +50,5 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
           git add -f plugins/*/agents/ plugins/*/skills/
-          git commit -m "chore: publish from staged [skip ci]" --allow-empty
+          git commit -m "chore: publish from staged" --allow-empty
           git push origin HEAD:main --force


### PR DESCRIPTION
The `[skip ci]` tag in the publish workflow's commit message was preventing downstream workflows (like `deploy-website.yml`) from triggering on the push to `main`.

This removes `[skip ci]` so the website deploy and any other `main`-branch workflows fire as expected. Verified no other workflows will be unintentionally triggered.