### PR TITLE
Fix codeowner-update auth: add github-token for PR creation

### DIFF
--- a/.github/workflows/codeowner-update.lock.yml
+++ b/.github/workflows/codeowner-update.lock.yml
@@ -23,7 +23,7 @@
 #
 # Updates the CODEOWNERS file when a maintainer comments #codeowner on a pull request
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"015ef8c7217fdc453ca70bfea824f686343207a99eebdccdb45f31e70700da45"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"edaff46e25ba674f8512347478438e0c356ed363be139c723815aa6381cca5fd"}
 
 name: "Codeowner Update Agent"
 "on":
@@ -1130,7 +1130,7 @@ jobs:
         if: ((!cancelled()) && (needs.agent.result != 'skipped')) && (contains(needs.agent.outputs.output_types, 'create_pull_request'))
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_AW_GITHUB_TOKEN }}
           persist-credentials: false
           fetch-depth: 1
       - name: Configure Git credentials
@@ -1138,7 +1138,7 @@ jobs:
         env:
           REPO_NAME: ${{ github.repository }}
           SERVER_URL: ${{ github.server_url }}
-          GIT_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GIT_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/codeowner-update.md
+++ b/.github/workflows/codeowner-update.md
@@ -16,6 +16,7 @@ safe-outputs:
     base-branch: staged
     title-prefix: "[codeowner] "
     draft: false
+    github-token: ${{ secrets.GH_AW_GITHUB_TOKEN }}
   add-comment:
     max: 1
   noop:


### PR DESCRIPTION
The `create-pull-request` safe output was failing with:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
```

The default `GITHUB_TOKEN` cannot push branches in this org. This adds `github-token: ${{ secrets.GH_AW_GITHUB_TOKEN }}` to the `create-pull-request` safe output so the compiled lock file uses a token with write permissions.

**Note:** The `GH_AW_GITHUB_TOKEN` secret must be configured in the repo with `contents: write` and `pull-requests: write` permissions.