### PR TITLE
[azure-devops-cli] Add note for legacy URL replacement in SKILL.md

### DIFF
--- a/skills/azure-devops-cli/SKILL.md
+++ b/skills/azure-devops-cli/SKILL.md
@@ -27,7 +27,7 @@ az extension add --name azure-devops
 az devops login --organization https://dev.azure.com/{org} --token YOUR_PAT_TOKEN
 
 # Set default organization and project (avoids repeating --org/--project)
-# PS: Legacy url {org}.visualstudio.com should be replace with dev.azure.com/{org}
+# Note: Legacy URL https://{org}.visualstudio.com should be replaced with https://dev.azure.com/{org}
 az devops configure --defaults organization=https://dev.azure.com/{org} project={project}
 
 # List current configuration


### PR DESCRIPTION
Added note about replacing legacy URL with dev.azure.com.

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.

---

## Description

Some companies are still using the legacy Azure DevOps URLs. When running the CLI command, there will be a warning message which is not token efficient.

<img width="1962" height="286" alt="image" src="https://github.com/user-attachments/assets/d96f7100-4df2-4677-802a-0aaa3d62d942" />


> `dev.azure.com` and `visualstudio.com` both point to the same Azure DevOps services, but `dev.azure.com` is the newer, standard domain, while `visualstudio.com` is the legacy domain from the VSTS era. Using `dev.azure.com` provides a more stable, modern URL structure (`dev.azure.com/{org}/{project}`), whereas `visualstudio.com` may lead to authentication issues, broken image links in PRs, or redirection behavior.


---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [x] Update to existing instruction, prompt, agent, plugin, skill, or workflow.
- [ ] Other (please specify):

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
