### PR TITLE
Add PlanetScale external plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -240,6 +240,32 @@
       "version": "1.0.0"
     },
     {
+      "name": "planetscale",
+      "description": "PlanetScale database tools — MCP server for querying schemas, running SQL, and getting performance insights, plus expert skills for MySQL, PostgreSQL, Vitess, and Postgres sharding.",
+      "version": "1.0.0",
+      "author": {
+        "name": "PlanetScale",
+        "url": "https://planetscale.com"
+      },
+      "homepage": "https://github.com/planetscale/vscode-agent-plugin",
+      "keywords": [
+        "database",
+        "mysql",
+        "postgresql",
+        "vitess",
+        "schema",
+        "sql",
+        "performance",
+        "planetscale"
+      ],
+      "license": "MIT",
+      "repository": "https://github.com/planetscale/vscode-agent-plugin",
+      "source": {
+        "source": "github",
+        "repo": "planetscale/vscode-agent-plugin"
+      }
+    },
+    {
       "name": "polyglot-test-agent",
       "source": "polyglot-test-agent",
       "description": "Multi-agent pipeline for generating comprehensive unit tests across any programming language. Orchestrates research, planning, and implementation phases using specialized agents to produce tests that compile, pass, and follow project conventions.",

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -16,5 +16,22 @@
       "repo": "microsoft/azure-skills",
       "path": ".github/plugins/azure-skills"
     }
+  },
+  {
+    "name": "planetscale",
+    "description": "PlanetScale database tools — MCP server for querying schemas, running SQL, and getting performance insights, plus expert skills for MySQL, PostgreSQL, Vitess, and Postgres sharding.",
+    "version": "1.0.0",
+    "author": {
+      "name": "PlanetScale",
+      "url": "https://planetscale.com"
+    },
+    "homepage": "https://github.com/planetscale/vscode-agent-plugin",
+    "keywords": ["database", "mysql", "postgresql", "vitess", "schema", "sql", "performance", "planetscale"],
+    "license": "MIT",
+    "repository": "https://github.com/planetscale/vscode-agent-plugin",
+    "source": {
+      "source": "github",
+      "repo": "planetscale/vscode-agent-plugin"
+    }
   }
 ]


### PR DESCRIPTION
## Add PlanetScale external plugin

Adds PlanetScale as an external plugin in `plugins/external.json`, sourced from [`planetscale/vscode-agent-plugin`](https://github.com/planetscale/vscode-agent-plugin).

### What it provides

- **MCP Server**: Authenticated access to PlanetScale organizations, databases, branches, schema, and query performance Insights via the hosted PlanetScale MCP endpoint (`https://mcp.pscale.dev/mcp/planetscale`). No local setup required.
- **4 Database Skills**:
  - `mysql` — Schema design, indexing, query tuning, transactions, and operations for MySQL/InnoDB
  - `postgres` — Best practices, query optimization, MVCC, connection pooling, and PlanetScale-specific Postgres tooling
  - `vitess` — VSchema, sharding, vindexes, online DDL, and VReplication for PlanetScale Vitess databases
  - `neki` — Sharding readiness for PostgreSQL (PlanetScale's sharded Postgres)

### Checklist

- [x] Added entry to `plugins/external.json`
- [x] Ran `npm run build` to regenerate `marketplace.json`
- [x] PR targets `staged` branch

### Source repository

https://github.com/planetscale/vscode-agent-plugin