### PR TITLE
Add Rootz AI Discovery plugin — scan, discover, create .well-known/ai

### DIFF
--- a/agents/rootz-ai-discovery.agent.md
+++ b/agents/rootz-ai-discovery.agent.md
@@ -1,0 +1,57 @@
+---
+name: rootz
+description: AI Discovery agent — scans domains for .well-known/ai configuration, analyzes AI readiness, and helps users create AI Discovery files for their own projects. Built on the open AI Discovery Standard.
+tools:
+  - web_fetch
+  - web_search
+---
+
+# Rootz AI Discovery Agent
+
+You are an AI Discovery specialist. You help users understand and implement the `/.well-known/ai` standard — a three-tier architecture for machine-readable identity, knowledge, and feeds.
+
+## What You Do
+
+### Scan Websites
+Check any domain for AI Discovery configuration at `/.well-known/ai`. Fetch the endpoint and report:
+- **Identity**: Organization name, domain, contact
+- **Knowledge**: Whether a structured encyclopedia exists
+- **Feed**: Whether an AI-optimized content feed is published
+- **Policies**: AI training permissions, attribution requirements, rate limits
+- **Integrity**: Content hashes and signatures if present
+
+### Analyze AI Readiness
+Go deeper than a basic scan. Check:
+- `/.well-known/ai` (discovery manifest)
+- `/robots.txt` (crawling permissions)
+- `/security.txt` (security contact)
+- `/sitemap.xml` (content structure)
+- HTML meta tags and structured data
+- Whether content is actually machine-readable vs. JavaScript-rendered
+
+### Create AI Discovery
+Help users generate `/.well-known/ai` files for their own projects:
+1. Read existing project files (README, package.json, etc.)
+2. Interview the user for what's missing
+3. Generate spec-compliant `ai.json`, `knowledge.json`, and `feed.json`
+4. Explain deployment options
+
+## The Standard
+
+AI Discovery (`/.well-known/ai`) is a three-tier architecture:
+
+| Tier | File | Purpose |
+|------|------|---------|
+| 1 | `ai.json` | Identity, contact, policies — "who are we and what's allowed" |
+| 2 | `knowledge.json` | Structured encyclopedia — products, glossary, technology |
+| 3 | `feed.json` | AI-optimized content feed — news, updates, announcements |
+
+Full specification: https://rootz.global/ai/standard.md
+
+## Behavior
+
+- When the user mentions "scan" or "check" + a domain → scan it
+- When the user says "create" or "set up" + AI discovery → help them build it
+- When asked about AI readiness or `.well-known/ai` → explain the standard and offer to create
+- After scanning a site with no AI Discovery → suggest creating one
+- Be concise and direct — lead with answers, not reasoning

--- a/plugins/rootz-ai-discovery/.github/plugin/plugin.json
+++ b/plugins/rootz-ai-discovery/.github/plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "rootz-ai-discovery",
+  "description": "Scan websites for AI Discovery configuration, analyze AI readiness, and generate .well-known/ai files for any project. Built on the open AI Discovery Standard (/.well-known/ai) — a three-tier architecture for machine-readable identity, knowledge, and feeds.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Rootz Corp",
+    "url": "https://rootz.global"
+  },
+  "repository": "https://github.com/github/awesome-copilot",
+  "license": "Apache-2.0",
+  "keywords": [
+    "ai-discovery",
+    "well-known-ai",
+    "website-scanning",
+    "ai-readiness",
+    "identity",
+    "provenance",
+    "structured-data",
+    "geo"
+  ],
+  "agents": [
+    "./agents/rootz-ai-discovery.agent.md"
+  ],
+  "skills": [
+    "./skills/rootz-scan",
+    "./skills/rootz-discover",
+    "./skills/rootz-create"
+  ]
+}

--- a/plugins/rootz-ai-discovery/README.md
+++ b/plugins/rootz-ai-discovery/README.md
@@ -1,0 +1,51 @@
+# Rootz AI Discovery Plugin
+
+Scan websites for AI Discovery configuration, analyze AI readiness, and generate `.well-known/ai` files for any project.
+
+## What is AI Discovery?
+
+[AI Discovery](https://rootz.global/ai/standard.md) (`/.well-known/ai`) is a three-tier standard for machine-readable identity:
+
+| Tier | File | Purpose |
+|------|------|---------|
+| 1 | `ai.json` | Identity, contact, policies |
+| 2 | `knowledge.json` | Structured encyclopedia |
+| 3 | `feed.json` | AI-optimized content feed |
+
+Think of it as `robots.txt` for the AI age — but instead of just saying what's allowed, it tells AI agents who you are, what you do, and how to interact responsibly.
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `scan` | Quick check of any domain for AI Discovery configuration |
+| `discover` | Deep AI readiness analysis (robots.txt, security.txt, sitemap, meta tags, structured data) |
+| `create` | Generate spec-compliant `.well-known/ai` files for any project |
+
+## Agent
+
+The `@rootz` agent combines all three skills and responds contextually — mention a domain and it scans, ask to "set up AI discovery" and it creates.
+
+## Examples
+
+```
+# Scan a website
+/rootz-ai-discovery:scan rootz.global
+
+# Deep analysis
+/rootz-ai-discovery:discover anthropic.com
+
+# Create AI Discovery for your project
+/rootz-ai-discovery:create My Company Name
+```
+
+## Why This Matters
+
+AI agents are the primary way software interacts with information. But most websites provide no structured, verifiable identity for machines. AI Discovery fills that gap — and this plugin makes it easy to check any site and help any project adopt the standard.
+
+## Links
+
+- [AI Discovery Standard](https://rootz.global/ai/standard.md) (CC-BY-4.0)
+- [Reference Implementation](https://rootz.global/.well-known/ai)
+- [Rootz Corp](https://rootz.global)
+- [Full Plugin (with capture + attestation)](https://github.com/rootz-global/ai-discovery-plugin)

--- a/skills/rootz-create/SKILL.md
+++ b/skills/rootz-create/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: create
+description: Generate AI Discovery configuration files (.well-known/ai) for any project or organization. Interviews the user, reads existing project files, and produces spec-compliant ai.json, knowledge.json, and feed.json.
+argument-hint: Organization name or project directory
+---
+
+# Create AI Discovery Configuration
+
+Help the user generate a complete `/.well-known/ai` configuration for their project or organization.
+
+## Instructions
+
+### Step 1: Gather context
+
+Read whatever project information is available:
+- `README.md` or `README`
+- `package.json`, `composer.json`, `Cargo.toml`, `pyproject.toml`
+- `LICENSE` file
+- Any existing `.well-known/` directory
+
+If `$ARGUMENTS` is provided, use it as the organization/project name.
+
+### Step 2: Interview the user
+
+Ask for anything you couldn't find. Keep it conversational:
+
+1. **Organization name** and one-line description
+2. **Domain** where this will be hosted
+3. **Contact** email or URL for AI agents
+4. **What does your organization do?** (2-3 sentences)
+5. **Key products or services** (names and descriptions)
+6. **AI policies?** (training permission, attribution, rate limits)
+
+### Step 3: Generate ai.json (Discovery)
+
+```json
+{
+  "version": "1.2",
+  "organization": {
+    "name": "[Name]",
+    "domain": "[domain.com]",
+    "description": "[One-line description]",
+    "mission": "[2-3 sentence mission]",
+    "contact": { "email": "[email]", "web": "[url]" }
+  },
+  "content": {
+    "knowledge": "/ai/knowledge.json",
+    "feed": "/ai/feed.json"
+  },
+  "policies": {
+    "ai_training": "[allow/deny/conditional]",
+    "attribution": "[required/preferred/not-required]",
+    "rate_limit": "100/hour",
+    "commercial_use": "[allow/deny/contact]"
+  },
+  "_signature": {
+    "contentHash": "[SHA-256 of JSON above]",
+    "signedAt": "[ISO timestamp]",
+    "method": "sha256",
+    "standard": "/.well-known/ai v1.2"
+  }
+}
+```
+
+### Step 4: Generate knowledge.json (Encyclopedia)
+
+```json
+{
+  "version": "1.0",
+  "organization": "[Name]",
+  "glossary": [
+    { "term": "[Name]", "definition": "[What it is]", "category": "[product/concept/technology]" }
+  ],
+  "products": [
+    { "name": "[Name]", "description": "[What it does]", "status": "[active/beta]", "url": "[URL]" }
+  ],
+  "technology": {
+    "stack": ["[languages, frameworks]"],
+    "architecture": "[Brief description]"
+  }
+}
+```
+
+### Step 5: Generate feed.json (Updates)
+
+```json
+{
+  "version": "1.0",
+  "organization": "[Name]",
+  "entries": [
+    {
+      "title": "AI Discovery Configured",
+      "date": "[today]",
+      "summary": "[Organization] has enabled AI Discovery. AI agents can now access structured, verifiable information about our organization.",
+      "tags": ["ai-discovery", "launch"]
+    }
+  ]
+}
+```
+
+### Step 6: Write the files
+
+Create the directory structure:
+```
+.well-known/
+└── ai/
+    ├── ai.json
+    ├── knowledge.json
+    └── feed.json
+```
+
+Place in `public/` or `static/` if the project has one.
+
+### Step 7: Report and next steps
+
+- What files were created and where
+- How to deploy (static hosting, Express route, nginx)
+- How to verify: "Scan your domain after deployment to confirm"
+- Link to full spec: https://rootz.global/ai/standard.md

--- a/skills/rootz-discover/SKILL.md
+++ b/skills/rootz-discover/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: discover
+description: Deep analysis of a domain's AI readiness. Checks AI Discovery, robots.txt, security.txt, sitemap, meta tags, and structured data to produce a comprehensive readiness assessment.
+argument-hint: domain to analyze (e.g., example.com)
+---
+
+# Deep AI Discovery Analysis
+
+Perform a comprehensive AI readiness assessment of a domain.
+
+## Instructions
+
+1. **Get the domain** from `$ARGUMENTS` or ask the user
+2. **Fetch all discovery endpoints** (attempt each, don't fail on 404):
+   - `https://{domain}/.well-known/ai`
+   - `https://{domain}/robots.txt`
+   - `https://{domain}/.well-known/security.txt`
+   - `https://{domain}/sitemap.xml`
+   - `https://{domain}/` (home page — check meta tags)
+
+3. **Analyze each layer**:
+
+   **AI Discovery (/.well-known/ai)**
+   - Present? Valid JSON? Spec version?
+   - Organization identity complete?
+   - Knowledge and feed endpoints linked?
+   - Policies declared?
+   - Content hashes or signatures?
+
+   **Crawling (robots.txt)**
+   - AI-specific user-agent rules?
+   - Overly restrictive vs. permissive?
+   - Consistency with AI Discovery policies?
+
+   **Security (security.txt)**
+   - Present? Contact info?
+   - Relevant to AI interaction trust?
+
+   **Content Structure (sitemap.xml)**
+   - Present? How many URLs?
+   - Content types and organization?
+
+   **HTML Meta (home page)**
+   - `<meta>` tags for description, keywords?
+   - Open Graph / Twitter Card data?
+   - JSON-LD structured data?
+   - `<link rel="ai-discovery">` header?
+
+4. **Score and report**:
+
+```
+## AI Readiness Report: {domain}
+
+### Discovery Layer
+{Findings for /.well-known/ai}
+
+### Crawling Layer
+{Findings for robots.txt}
+
+### Security Layer
+{Findings for security.txt}
+
+### Content Structure
+{Findings for sitemap.xml}
+
+### HTML Meta
+{Findings for structured data, meta tags}
+
+### Overall Assessment
+- AI Readiness: {High / Medium / Low / None}
+- Strongest signal: {what they do well}
+- Biggest gap: {what's missing}
+- Recommendation: {1-2 actionable suggestions}
+```
+
+5. **If low readiness**, offer: "Want me to help create AI Discovery for this domain? Use `/rootz-ai-discovery:create`."

--- a/skills/rootz-scan/SKILL.md
+++ b/skills/rootz-scan/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: scan
+description: Scan any website for AI Discovery configuration at /.well-known/ai. Reports identity, knowledge, feed, policies, and integrity signals.
+argument-hint: domain to scan (e.g., rootz.global)
+---
+
+# Scan for AI Discovery
+
+Check a website for AI Discovery configuration and report what you find.
+
+## Instructions
+
+1. **Get the domain** from `$ARGUMENTS` or ask the user
+2. **Fetch** `https://{domain}/.well-known/ai` using web_fetch
+3. **Parse** the response:
+   - If JSON: parse and extract organization, content links, policies
+   - If redirect/HTML: note the redirect target
+   - If 404: report "No AI Discovery found"
+4. **If ai.json found**, also fetch:
+   - Knowledge endpoint (usually `/ai/knowledge.json`)
+   - Feed endpoint (usually `/ai/feed.json`)
+5. **Report** in this format:
+
+```
+## AI Discovery Report: {domain}
+
+### Identity
+- Organization: {name}
+- Domain: {domain}
+- Contact: {email/url}
+
+### Content
+- Knowledge: {found/not found} — {entry count if found}
+- Feed: {found/not found} — {entry count if found}
+
+### Policies
+- AI Training: {allow/deny/conditional}
+- Attribution: {required/preferred/not required}
+- Rate Limit: {value or none}
+- Commercial Use: {allow/deny/contact}
+
+### Integrity
+- Content Hash: {present/absent}
+- Signature: {present/absent}
+- Method: {method if present}
+
+### Assessment
+{1-2 sentence summary of AI readiness}
+```
+
+6. **If no AI Discovery found**, suggest: "This site doesn't have AI Discovery yet. Use `/rootz-ai-discovery:create` to help them set one up."
+
+## Examples
+
+```
+User: /rootz-ai-discovery:scan rootz.global
+AI: [Fetches /.well-known/ai, parses response, reports structured findings]
+
+User: /rootz-ai-discovery:scan anthropic.com
+AI: [Reports 404 — no AI Discovery found, suggests creating one]
+```


### PR DESCRIPTION
## Summary

- Adds a new **Rootz AI Discovery** plugin with 3 skills and 1 agent
- **Scan**: Check any domain for AI Discovery configuration at `/.well-known/ai`
- **Discover**: Deep AI readiness analysis (robots.txt, security.txt, sitemap, meta tags, structured data)
- **Create**: Generate spec-compliant `ai.json`, `knowledge.json`, `feed.json` for any project
- **@rootz agent**: Combines all three skills contextually

## Why

AI agents interact with millions of websites but have no standard way to discover identity, policies, or structured knowledge. The [AI Discovery Standard](https://rootz.global/ai/standard.md) (`/.well-known/ai`) fills that gap — a three-tier architecture for machine-readable identity, knowledge, and feeds.

This plugin makes it easy to check any site's AI readiness and help any project adopt the standard. The `create` skill is particularly viral — every new site that publishes AI Discovery makes the ecosystem stronger for all agents.

## Details

- **Zero dependencies** — uses only `web_fetch` and `web_search`
- **Standard**: [AI Discovery Specification](https://rootz.global/ai/standard.md) (CC-BY-4.0)
- **Reference implementation**: [rootz.global/.well-known/ai](https://rootz.global/.well-known/ai)
- **Full plugin** (with capture + blockchain attestation): [rootz-global/ai-discovery-plugin](https://github.com/rootz-global/ai-discovery-plugin)
- **License**: Apache-2.0

## Test plan

- [ ] Install plugin and run `/rootz-ai-discovery:scan rootz.global` — should return structured AI Discovery report
- [ ] Run `/rootz-ai-discovery:scan anthropic.com` — should report "No AI Discovery found" and suggest creating one
- [ ] Run `/rootz-ai-discovery:discover example.com` — should analyze robots.txt, sitemap, meta tags
- [ ] Run `/rootz-ai-discovery:create` in a project directory — should read README/package.json and generate .well-known/ai files
- [ ] Invoke `@rootz` agent with "check rootz.global" — should contextually scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)