### PR TITLE
chore: update Agent Governance Toolkit URLs to microsoft/ org

### DIFF
--- a/skills/agent-governance/SKILL.md
+++ b/skills/agent-governance/SKILL.md
@@ -564,6 +564,6 @@ Match governance strictness to risk level:
 
 ## Related Resources
 
-- [Agent-OS Governance Engine](https://github.com/imran-siddique/agent-os) — Full governance framework
-- [AgentMesh Integrations](https://github.com/imran-siddique/agentmesh-integrations) — Framework-specific packages
+- [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit) — Full governance framework
+- [AgentMesh Integrations](https://github.com/microsoft/agent-governance-toolkit/tree/main/packages/agentmesh-integrations) — Framework-specific packages
 - [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)


### PR DESCRIPTION
The Agent Governance Toolkit has moved from personal repos to its official home at [microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit).

This PR updates the Related Resources links in the agent-governance skill to point to the new location.

### Changes
- `imran-siddique/agent-os` → `microsoft/agent-governance-toolkit`
- `imran-siddique/agentmesh-integrations` → `microsoft/agent-governance-toolkit/tree/main/packages/agentmesh-integrations`
- "Agent-OS Governance Engine" → "Agent Governance Toolkit" (matching the official name)