### PR TITLE
[codeowner] Update CODEOWNERS for PR #1009

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,3 +32,6 @@
 
 # Added via #codeowner from PR #990
 /skills/issue-fields-migration/ @labudis
+
+# Added via #codeowner from PR #1009
+/skills/publish-to-pages/ @AndreaGriffiths11


### PR DESCRIPTION
This PR updates the `CODEOWNERS` file to assign ownership to the contributor who added files in PR #1009.

## Changes

| Path | Owner |
|------|-------|
| `/skills/publish-to-pages/` | @AndreaGriffiths11 |

@AndreaGriffiths11 was assigned as the owner of the `publish-to-pages` skill directory they contributed in PR #1009.




> Generated by [Codeowner Update Agent](https://github.com/github/awesome-copilot/actions/runs/23123446456) · [◷](https://github.com/search?q=repo%3Agithub%2Fawesome-copilot+%22gh-aw-workflow-id%3A+codeowner-update%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Codeowner Update Agent, engine: copilot, id: 23123446456, workflow_id: codeowner-update, run: https://github.com/github/awesome-copilot/actions/runs/23123446456 -->

<!-- gh-aw-workflow-id: codeowner-update -->