### PR TITLE
fix: Changed 'bash' to 'command' in hooks.json

### DIFF
--- a/hooks/governance-audit/hooks.json
+++ b/hooks/governance-audit/hooks.json
@@ -4,7 +4,7 @@
     "sessionStart": [
       {
         "type": "command",
-        "bash": ".github/hooks/governance-audit/audit-session-start.sh",
+        "command": ".github/hooks/governance-audit/audit-session-start.sh",
         "cwd": ".",
         "timeoutSec": 5
       }
@@ -12,7 +12,7 @@
     "sessionEnd": [
       {
         "type": "command",
-        "bash": ".github/hooks/governance-audit/audit-session-end.sh",
+        "command": ".github/hooks/governance-audit/audit-session-end.sh",
         "cwd": ".",
         "timeoutSec": 5
       }
@@ -20,7 +20,7 @@
     "userPromptSubmitted": [
       {
         "type": "command",
-        "bash": ".github/hooks/governance-audit/audit-prompt.sh",
+        "command": ".github/hooks/governance-audit/audit-prompt.sh",
         "cwd": ".",
         "env": {
           "GOVERNANCE_LEVEL": "standard",

--- a/hooks/secrets-scanner/hooks.json
+++ b/hooks/secrets-scanner/hooks.json
@@ -4,7 +4,7 @@
     "sessionEnd": [
       {
         "type": "command",
-        "bash": ".github/hooks/secrets-scanner/scan-secrets.sh",
+        "command": ".github/hooks/secrets-scanner/scan-secrets.sh",
         "cwd": ".",
         "env": {
           "SCAN_MODE": "warn",

--- a/hooks/session-auto-commit/hooks.json
+++ b/hooks/session-auto-commit/hooks.json
@@ -4,7 +4,7 @@
     "sessionEnd": [
       {
         "type": "command",
-        "bash": ".github/hooks/session-auto-commit/auto-commit.sh",
+        "command": ".github/hooks/session-auto-commit/auto-commit.sh",
         "timeoutSec": 30
       }
     ]

--- a/hooks/session-logger/hooks.json
+++ b/hooks/session-logger/hooks.json
@@ -4,7 +4,7 @@
     "sessionStart": [
       {
         "type": "command",
-        "bash": ".github/hooks/session-logger/log-session-start.sh",
+        "command": ".github/hooks/session-logger/log-session-start.sh",
         "cwd": ".",
         "timeoutSec": 5
       }
@@ -12,7 +12,7 @@
     "sessionEnd": [
       {
         "type": "command",
-        "bash": ".github/hooks/session-logger/log-session-end.sh",
+        "command": ".github/hooks/session-logger/log-session-end.sh",
         "cwd": ".",
         "timeoutSec": 5
       }
@@ -20,7 +20,7 @@
     "userPromptSubmitted": [
       {
         "type": "command",
-        "bash": ".github/hooks/session-logger/log-prompt.sh",
+        "command": ".github/hooks/session-logger/log-prompt.sh",
         "cwd": ".",
         "env": {
           "LOG_LEVEL": "INFO"


### PR DESCRIPTION
As per VS code docs, I don't find "bash" as a property in hooks, the best/suitable property is "command". Reference:
https://code.visualstudio.com/docs/copilot/customization/hooks#_hook-command-properties

## Pull Request Checklist

- [X] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [X]  I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ]  My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [X] The file follows the required naming convention.
- [X] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, skill, hooks or workflow with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.

---

## Description
 Changed 'bash' to 'command' in hooks.json
As per VS code docs, I don't find "bash" as a property in hooks, the best/suitable property is "command". Reference:
https://code.visualstudio.com/docs/copilot/customization/hooks#_hook-command-properties

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [X] Update to existing instruction, prompt, agent, plugin, skill, hooks or workflow.
- [ ] Other (please specify):

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
