### PR TITLE
Update agent frontmatter options to remove deprecated "infer"

### DIFF
--- a/instructions/agents.instructions.md
+++ b/instructions/agents.instructions.md
@@ -27,7 +27,6 @@ name: 'Agent Display Name'
 tools: ['read', 'edit', 'search']
 model: 'Claude Sonnet 4.5'
 target: 'vscode'
-infer: true
 ---
 ```
 
@@ -61,10 +60,15 @@ infer: true
 - If omitted, agent is available in both environments
 - Use when agent has environment-specific features
 
-#### **infer** (OPTIONAL)
-- Boolean controlling whether Copilot can automatically use this agent based on context
+#### **user-invocable** (OPTIONAL)
+- Boolean controlling whether the agent appears in the agents dropdown in chat
 - Default: `true` if omitted
-- Set to `false` to require manual agent selection
+- Set to `false` to create agents that are only accessible as subagents or programmatically
+
+#### **disable-model-invocation** (OPTIONAL)
+- Boolean controlling whether the agent can be invoked as a subagent by other agents
+- Default: `false` if omitted
+- Set to `true` to prevent subagent invocation while keeping it available in the picker
 
 #### **metadata** (OPTIONAL, GitHub.com only)
 - Object with name-value pairs for agent annotation
@@ -850,7 +854,9 @@ Each level can override settings from previous levels.
 - [ ] `tools` configured appropriately (or intentionally omitted)
 - [ ] `model` specified for optimal performance
 - [ ] `target` set if environment-specific
-- [ ] `infer` set to `false` if manual selection required
+- [ ] Use `user-invocable: false` to hide from picker while allowing subagent invocation
+- [ ] Use `disable-model-invocation: true` to prevent subagent invocation while keeping picker visibility
+
 
 ### Prompt Content
 - [ ] Clear agent identity and role defined


### PR DESCRIPTION
* Removed 'infer' option and replaced it with 'user-invocable' and 'disable-model-invocation'.
* Clarified the purpose of new options for better usability.
* Updated guidelines to reflect changes in agent invocation behavior.

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [x] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.

---

## Description

<!-- Briefly describe your contribution and its purpose. Include any relevant context or usage notes. -->

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [x] Update to existing instruction, prompt, agent, plugin, skill, or workflow.
- [ ] Other (please specify):

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
