### PR TITLE
[codeowner] Update CODEOWNERS for PR #1049

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,3 +35,8 @@
 
 # Added via #codeowner from PR #1009
 /skills/publish-to-pages/ @AndreaGriffiths11
+
+# Added via #codeowner from PR #1049
+/skills/codeql/ @VeVarunSharma
+/skills/dependabot/ @VeVarunSharma
+/skills/secret-scanning/ @VeVarunSharma


### PR DESCRIPTION
Updates the `CODEOWNERS` file to assign ownership to [@VeVarunSharma](https://github.com/VeVarunSharma) for the GHAS skills contributed in PR #1049.

## New CODEOWNERS Entries

| Path | Owner |
|------|-------|
| `/skills/codeql/` | @VeVarunSharma |
| `/skills/dependabot/` | @VeVarunSharma |
| `/skills/secret-scanning/` | @VeVarunSharma |

These entries were added as directory patterns (since skills are directory-based resources) following the existing CODEOWNERS conventions in this repository.




> Generated by [Codeowner Update Agent](https://github.com/github/awesome-copilot/actions/runs/23222671391) · [◷](https://github.com/search?q=repo%3Agithub%2Fawesome-copilot+%22gh-aw-workflow-id%3A+codeowner-update%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Codeowner Update Agent, engine: copilot, id: 23222671391, workflow_id: codeowner-update, run: https://github.com/github/awesome-copilot/actions/runs/23222671391 -->

<!-- gh-aw-workflow-id: codeowner-update -->