### PR TITLE
docs: add author attribution to GTM skills

### DIFF
--- a/skills/gtm-0-to-1-launch/SKILL.md
+++ b/skills/gtm-0-to-1-launch/SKILL.md
@@ -2,6 +2,9 @@
 name: gtm-0-to-1-launch
 description: Launch new products from idea to first customers. Use when launching products, finding early adopters, building launch week playbooks, diagnosing why adoption stalls, or learning that press coverage does not equal growth. Includes the three-layer diagnosis, the 2-week experiment cycle, and the launch that got 50K impressions and 12 signups.
 license: MIT
+metadata:
+  author: Smit Patel (https://linkedin.com/in/smitkpatel)
+  source: https://github.com/beingsmit/technical-product-gtm
 ---
 
 # 0-to-1 Launch
@@ -316,7 +319,3 @@ Customer problem first → Narrow pilot → Reference customers together → Lev
 ---
 
 *Based on launching features that optimized for press and got 12 signups from 50K impressions, diagnosing launch stalls across three companies using the three-layer model, and building the 2-week experiment cycle that turned ad hoc testing into a repeatable machine. Also draws on partner-led market entry across multiple geographies and segments. Not theory — lessons from mistaking vanity metrics for growth and learning to diagnose the actual problem.*
-
----
-
-*Author: [Smit Patel](https://linkedin.com/in/smitkpatel) · Full 11-skill GTM pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)*

--- a/skills/gtm-ai-gtm/SKILL.md
+++ b/skills/gtm-ai-gtm/SKILL.md
@@ -2,6 +2,9 @@
 name: gtm-ai-gtm
 description: Go-to-market strategy for AI products. Use when positioning AI products, handling "who is responsible when it breaks" objections, pricing variable-cost AI, choosing between copilot/agent/teammate framing, or selling autonomous tools into enterprises.
 license: MIT
+metadata:
+  author: Smit Patel (https://linkedin.com/in/smitkpatel)
+  source: https://github.com/beingsmit/technical-product-gtm
 ---
 
 # AI Product GTM
@@ -564,7 +567,3 @@ Do they have incident response processes for tool failures?
 ---
 
 *Based on enterprise AI agent GTM across developer tools and infrastructure. Patterns drawn from working enterprise deal cycles selling autonomous AI products — some carried directly, others supported alongside sales leadership — including the positioning trap diagnosis that shifted from feature competition to structural differentiation, the ceiling-moment qualification that improved outbound conversion significantly, and frameworks tested across security, operations, and engineering buyer personas. Not theory — lessons from deals where "autonomous" killed conversations and "teammate" converted.*
-
----
-
-*Author: [Smit Patel](https://linkedin.com/in/smitkpatel) · Full 11-skill GTM pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)*

--- a/skills/gtm-board-and-investor-communication/SKILL.md
+++ b/skills/gtm-board-and-investor-communication/SKILL.md
@@ -2,6 +2,9 @@
 name: gtm-board-and-investor-communication
 description: Board meeting preparation, investor updates, and executive communication. Use when preparing board decks, writing investor updates, handling bad news with the board, structuring QBRs, or building board-level metric discipline. Includes the "Three Things" narrative model, the 4-tier metric hierarchy, and the pre-brief pattern that prevents board surprises.
 license: MIT
+metadata:
+  author: Smit Patel (https://linkedin.com/in/smitkpatel)
+  source: https://github.com/beingsmit/technical-product-gtm
 ---
 
 # Board and Investor Communication
@@ -451,7 +454,3 @@ Exec (weekly) → Leadership (bi-weekly) → All-hands (monthly) → Team (ongoi
 ---
 
 *Based on preparing and supporting board communications across multiple companies from Series A through post-IPO — building the deck and sitting in the room at some, reporting updates to the board at others. Includes the investor update cadence that maintained trust through missed quarters, the "Three Things" narrative model used across multiple companies, and the metric discipline framework that survived years of hypergrowth. Not theory — patterns from being close enough to the board to see what lands and what doesn't.*
-
----
-
-*Author: [Smit Patel](https://linkedin.com/in/smitkpatel) · Full 11-skill GTM pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)*

--- a/skills/gtm-developer-ecosystem/SKILL.md
+++ b/skills/gtm-developer-ecosystem/SKILL.md
@@ -2,6 +2,9 @@
 name: gtm-developer-ecosystem
 description: Build and scale developer-led adoption through ecosystem programs. Use when deciding open vs curated ecosystems, building developer programs, scaling platform adoption, or designing student program pipelines.
 license: MIT
+metadata:
+  author: Smit Patel (https://linkedin.com/in/smitkpatel)
+  source: https://github.com/beingsmit/technical-product-gtm
 ---
 
 # Developer Ecosystem
@@ -305,7 +308,3 @@ Is this a common question?
 ---
 
 *Based on building developer ecosystems at multiple platform companies, including the open vs curated marketplace decision, student program development (3-year arc building talent pipeline), and partner ecosystem growth. Not theory — patterns from building developer ecosystems that actually drove platform adoption and multi-year brand loyalty.*
-
----
-
-*Author: [Smit Patel](https://linkedin.com/in/smitkpatel) · Full 11-skill GTM pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)*

--- a/skills/gtm-enterprise-account-planning/SKILL.md
+++ b/skills/gtm-enterprise-account-planning/SKILL.md
@@ -2,6 +2,9 @@
 name: gtm-enterprise-account-planning
 description: Strategic account planning and execution for enterprise deals. Use when planning complex sales cycles, managing multiple stakeholders, applying MEDDICC qualification, tracking deal health, or building mutual action plans. Includes the "stale MAP equals dead deal" pattern.
 license: MIT
+metadata:
+  author: Smit Patel (https://linkedin.com/in/smitkpatel)
+  source: https://github.com/beingsmit/technical-product-gtm
 ---
 
 # Enterprise Account Planning
@@ -424,7 +427,3 @@ Have you met the Economic Buyer?
 ---
 
 *Based on enterprise sales at a platform company during hypergrowth, with patterns from closing strategic accounts, navigating complex procurement processes, and learning the hard way that stale MAPs = dead deals. Not theory — lessons from watching deals die because we didn't track health metrics and closing deals because we validated EB alignment early.*
-
----
-
-*Author: [Smit Patel](https://linkedin.com/in/smitkpatel) · Full 11-skill GTM pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)*

--- a/skills/gtm-enterprise-onboarding/SKILL.md
+++ b/skills/gtm-enterprise-onboarding/SKILL.md
@@ -2,6 +2,9 @@
 name: gtm-enterprise-onboarding
 description: Four-phase framework for onboarding enterprise customers from contract to value realization. Use when implementing new enterprise customers, preventing churn during onboarding, or solving the adoption cliff that kills deals post-go-live. Includes the Week 4 ghosting pattern.
 license: MIT
+metadata:
+  author: Smit Patel (https://linkedin.com/in/smitkpatel)
+  source: https://github.com/beingsmit/technical-product-gtm
 ---
 
 # Enterprise Onboarding
@@ -452,7 +455,3 @@ Are active users growing Week 6 → Week 12?
 ---
 
 *Based on enterprise onboarding across multiple platform companies — designing partner onboarding directly and collaborating closely with CS on customer onboarding. Not theory — lessons from seeing Week 4 ghosting happen repeatedly and learning that go-live ≠ success, and understanding the adoption cliff that kills 30% of deals in first year.*
-
----
-
-*Author: [Smit Patel](https://linkedin.com/in/smitkpatel) · Full 11-skill GTM pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)*

--- a/skills/gtm-operating-cadence/SKILL.md
+++ b/skills/gtm-operating-cadence/SKILL.md
@@ -2,6 +2,9 @@
 name: gtm-operating-cadence
 description: Design meeting rhythms, metric reporting, quarterly planning, and decision-making velocity for scaling companies. Use when decisions are slow, planning is broken, the company is growing but alignment is worse, or leadership meetings consume all time without producing decisions.
 license: MIT
+metadata:
+  author: Smit Patel (https://linkedin.com/in/smitkpatel)
+  source: https://github.com/beingsmit/technical-product-gtm
 ---
 
 # Operating Cadence
@@ -415,7 +418,3 @@ Daily: Slack wins/customer-voice → Weekly: CEO email + function updates → Mo
 ---
 
 *Based on operating cadence design across companies scaling from 20 to 1,000+ employees, including the five-level meeting architecture that survived 3x headcount growth, the weekly reporting format that caught pipeline problems 3 weeks earlier than monthly reviews, and the CEO weekly update format refined across multiple companies. Not theory — patterns from building operating systems through hypergrowth and teaching them to the next team.*
-
----
-
-*Author: [Smit Patel](https://linkedin.com/in/smitkpatel) · Full 11-skill GTM pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)*

--- a/skills/gtm-partnership-architecture/SKILL.md
+++ b/skills/gtm-partnership-architecture/SKILL.md
@@ -2,6 +2,9 @@
 name: gtm-partnership-architecture
 description: Build and scale partner ecosystems that drive revenue and platform adoption. Use when building partner programs from scratch, tiering partnerships, managing co-marketing, making build-vs-partner decisions, or structuring crawl-walk-run partner deployment.
 license: MIT
+metadata:
+  author: Smit Patel (https://linkedin.com/in/smitkpatel)
+  source: https://github.com/beingsmit/technical-product-gtm
 ---
 
 # Partnership Architecture
@@ -465,7 +468,3 @@ Did Crawl phase meet success criteria?
 ---
 
 *Based on partnerships work across multiple platform companies during hypergrowth, including running a developer marketplace ecosystem (open vs curated decision) and leveraging cloud provider certification requirements for channel growth. Not theory — patterns from partnerships that actually drove revenue and platform adoption.*
-
----
-
-*Author: [Smit Patel](https://linkedin.com/in/smitkpatel) · Full 11-skill GTM pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)*

--- a/skills/gtm-positioning-strategy/SKILL.md
+++ b/skills/gtm-positioning-strategy/SKILL.md
@@ -2,6 +2,9 @@
 name: gtm-positioning-strategy
 description: Find and own a defensible market position. Use when messaging sounds like competitors, conversion is weak despite awareness, repositioning a product, or testing positioning claims. Includes Crawl-Walk-Run rollout methodology and the word change that improved enterprise deal progression.
 license: MIT
+metadata:
+  author: Smit Patel (https://linkedin.com/in/smitkpatel)
+  source: https://github.com/beingsmit/technical-product-gtm
 ---
 
 # Positioning Strategy
@@ -433,7 +436,3 @@ Did new positioning outperform incumbent by 20%+?
 ---
 
 *Based on positioning work at AI agent and developer platforms, including navigating the framing spectrum from "autonomous" to "AI companion" and how category framing changes enterprise buyer perception. Also includes Crawl-Walk-Run rollout methodology from repositioning products without breaking existing customer recognition. Not theory — patterns from testing positioning before committing to rebrands.*
-
----
-
-*Author: [Smit Patel](https://linkedin.com/in/smitkpatel) · Full 11-skill GTM pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)*

--- a/skills/gtm-product-led-growth/SKILL.md
+++ b/skills/gtm-product-led-growth/SKILL.md
@@ -2,6 +2,9 @@
 name: gtm-product-led-growth
 description: Build self-serve acquisition and expansion motions. Use when deciding PLG vs sales-led, optimizing activation, driving freemium conversion, building growth equations, or recognizing when product complexity demands human touch. Includes the parallel test where sales-led won 10x on revenue.
 license: MIT
+metadata:
+  author: Smit Patel (https://linkedin.com/in/smitkpatel)
+  source: https://github.com/beingsmit/technical-product-gtm
 ---
 
 # Product-Led Growth
@@ -334,7 +337,3 @@ Document every successful experiment as a playbook.
 ---
 
 *Based on experience across multiple platform companies — leading a growth team building PLG and sales-led motions from scratch, and operating inside successful PLG + sales-led machines at hypergrowth companies. The combination taught both sides: what it takes to establish these motions early (when resources are thin and every bet matters) and what the mature version looks like at scale (growth equations, channel economics systems, freemium pricing gates, and systematic A/B testing that documents every win and loss into executable playbooks). Not theory — lessons from building the machine and operating inside ones that worked.*
-
----
-
-*Author: [Smit Patel](https://linkedin.com/in/smitkpatel) · Full 11-skill GTM pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)*

--- a/skills/gtm-technical-product-pricing/SKILL.md
+++ b/skills/gtm-technical-product-pricing/SKILL.md
@@ -2,6 +2,9 @@
 name: gtm-technical-product-pricing
 description: Pricing strategy for technical products. Use when choosing usage-based vs seat-based, designing freemium thresholds, structuring enterprise pricing conversations, deciding when to raise prices, or using price as a positioning signal.
 license: MIT
+metadata:
+  author: Smit Patel (https://linkedin.com/in/smitkpatel)
+  source: https://github.com/beingsmit/technical-product-gtm
 ---
 
 # Technical Product Pricing
@@ -348,7 +351,3 @@ Is value ratio > 5x for most customers?
 ---
 
 *Based on pricing work at developer platforms and enterprise software companies, including enterprise price increases with zero customer loss, freemium threshold design that separated hobbyists from production users, partner pricing models, and pricing conversations across hundreds of enterprise deal cycles. Not theory — patterns from pricing decisions that directly impacted revenue.*
-
----
-
-*Author: [Smit Patel](https://linkedin.com/in/smitkpatel) · Full 11-skill GTM pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)*


### PR DESCRIPTION
Adds author credit and source repo link to the bottom of all 11 GTM skills merged in #1066. Each skill now ends with:

> *Author: [Smit Patel](https://linkedin.com/in/smitkpatel) · Full 11-skill GTM pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)*

No content changes — just attribution.