### PR TITLE
Fixing broken link on plugin modal

### DIFF
--- a/website/src/scripts/modal.ts
+++ b/website/src/scripts/modal.ts
@@ -1180,8 +1180,18 @@ function renderLocalPluginModal(
   // Add click handlers to plugin items
   modalContent.querySelectorAll(".collection-item").forEach((el) => {
     el.addEventListener("click", () => {
-      const path = (el as HTMLElement).dataset.path;
+      let path = (el as HTMLElement).dataset.path;
       const itemType = (el as HTMLElement).dataset.type;
+
+      switch (itemType) {
+        case "agent":
+          path = path.replace(".md", ".agent.md");
+          break;
+        case "skill":
+          path = `${path}/SKILL.md`;
+          break;
+      }
+
       if (path && itemType) {
         openFileModal(path, itemType);
       }


### PR DESCRIPTION
Plugins don't contain the proper paths, so have to account for that in the modal.

Fixes #1149
