### PR TITLE
Update fastah-ip-geo-tools plugin

### DIFF
--- a/plugins/fastah-ip-geo-tools/.mcp.json
+++ b/plugins/fastah-ip-geo-tools/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "fastahIpGeofeed": {
+      "type": "http",
+      "url": "https://mcp.fastah.ai/mcp"
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new configuration file for the `fastah-ip-geo-tools` plugin, defining an MCP server connection. The configuration specifies the server type and URL for `fastahIpGeofeed`.

Configuration addition:

* Added `.mcp.json` to define the `fastahIpGeofeed` MCP server with HTTP type and its endpoint URL.