### PR TITLE
Add Shopify external plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -466,6 +466,31 @@
       "version": "1.0.0"
     },
     {
+      "name": "shopify-plugin",
+      "description": "Shopify developer tools for building on the Shopify platform. Search Shopify docs, generate and validate GraphQL, Liquid, and UI extension code.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Shopify",
+        "url": "https://www.shopify.com"
+      },
+      "homepage": "https://github.com/Shopify/shopify-plugins",
+      "keywords": [
+        "shopify",
+        "mcp",
+        "graphql",
+        "liquid",
+        "storefront",
+        "admin-api",
+        "ecommerce"
+      ],
+      "license": "MIT",
+      "repository": "https://github.com/Shopify/shopify-plugins",
+      "source": {
+        "source": "github",
+        "repo": "Shopify/shopify-plugins"
+      }
+    },
+    {
       "name": "skills-for-copilot-studio",
       "description": "Microsoft Copilot Studio plugins for AI coding agents",
       "version": "1.0.3",

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -138,5 +138,22 @@
       "source": "github",
       "repo": "figma/mcp-server-guide"
     }
+  },
+  {
+    "name": "shopify-plugin",
+    "description": "Shopify developer tools for building on the Shopify platform. Search Shopify docs, generate and validate GraphQL, Liquid, and UI extension code.",
+    "version": "1.0.0",
+    "author": {
+      "name": "Shopify",
+      "url": "https://www.shopify.com"
+    },
+    "homepage": "https://github.com/Shopify/shopify-plugins",
+    "keywords": ["shopify", "mcp", "graphql", "liquid", "storefront", "admin-api", "ecommerce"],
+    "license": "MIT",
+    "repository": "https://github.com/Shopify/shopify-plugins",
+    "source": {
+      "source": "github",
+      "repo": "Shopify/shopify-plugins"
+    }
   }
 ]


### PR DESCRIPTION
## Summary

- Adds `shopify-plugins` as an external plugin sourced from `Shopify/shopify-plugins`
- Provides Shopify developer tools: doc search, GraphQL/Liquid/UI extension code generation and validation via MCP

## Checklist

- [x] Entry added to `plugins/external.json`
- [x] Uses `github` source type pointing to `Shopify/shopify-plugins` (plugin.json at repo root)