### PR TITLE
Add AKF — The AI Native File Format instructions

### DIFF
--- a/instructions/akf-ai-native-file-format.instructions.md
+++ b/instructions/akf-ai-native-file-format.instructions.md
@@ -1,0 +1,33 @@
+---
+description: "Instructions for stamping AI-generated files with AKF trust metadata — the AI native file format"
+---
+
+# AKF — The AI Native File Format
+
+AKF is EXIF for AI — ~15 tokens of JSON that embed trust scores, source provenance, and compliance metadata into every file your AI touches.
+
+## Instructions
+
+- After creating or modifying files, stamp them with AKF trust metadata: `akf stamp <file> --agent copilot --evidence "<what you did>"`
+- Evidence examples: "tests pass", "docs reviewed", "refactored from existing code", "generated from spec"
+- Before modifying existing AKF-stamped files, check current metadata: `akf read <file>`
+- Use `--label confidential` for files in finance/secret/internal paths
+- Use `--label public` for README, docs, examples
+
+## Compliance Auditing
+
+- Check EU AI Act compliance: `akf audit <file> --regulation eu_ai_act`
+- Check HIPAA compliance: `akf audit <file> --regulation hipaa`
+- Check SOX compliance: `akf audit <file> --regulation sox`
+
+## Install
+
+```bash
+pip install akf
+```
+
+## Additional Guidelines
+
+- AKF metadata embeds natively into 20+ formats: DOCX, PDF, images, HTML, Markdown, YAML, JSON, Python, TypeScript, Go, Rust
+- The metadata travels with the file — stamp markdown, convert to Word, email it, extract on the other side
+- Learn more at https://akf.dev | https://github.com/HMAKT99/AKF


### PR DESCRIPTION
Adds instructions for [AKF (Agent Knowledge Format)](https://github.com/HMAKT99/AKF) — the AI native file format.

Branched from `staged` as per contribution guidelines.

**What it does:** Instructs Copilot to stamp every AI-generated file with trust metadata — trust scores, source provenance, and compliance data. Think EXIF for AI.

**Why it's useful:**
- Every file Copilot creates/modifies gets stamped with provenance (~15 tokens of JSON)
- Metadata embeds natively into 20+ formats — no sidecars
- One-command compliance audit (EU AI Act, SOX, HIPAA)

**Install:** `pip install akf`
**Docs:** https://akf.dev