### PR TITLE
Fix/remove homepage padding

### DIFF
--- a/website/src/styles/starlight-overrides.css
+++ b/website/src/styles/starlight-overrides.css
@@ -108,6 +108,18 @@ body:has(#main-content) {
   --sl-color-bg-nav: transparent;
 }
 
+/* Remove header border and Starlight padding/borders above the custom content.
+   Hero section (and its background grid) touches the header seamlessly,
+   completely eliminating any 'bar' or gap between them. */
+body:has(#main-content) header.header {
+  border-bottom: none !important;
+}
+
+body:has(#main-content) .content-panel {
+  padding-top: 0 !important;
+  border-top: none !important;
+}
+
 /* ── Hide Starlight's built-in theme selector (dropdown) ─── */
 /* We use our own custom ThemeToggle component instead */
 starlight-theme-select {


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [ ] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

This PR fixes a UI issue on the project's homepage where a dark gap or "annoying bar" appeared between the main header and the hero section grid background. 

The issue was caused by Starlight's default wrapper containers (`.content-panel`) injecting a `1.5rem` top padding and a `1px` hairline top border on the custom splash page template. By specifically targeting the `body:has(#main-content)` custom page structure and overriding these Starlight padding and border rules in `starlight-overrides.css`, the hero section's grid background now extends seamlessly to the bottom of the header.

**Visual Changes:**

### Before
<img width="1463" height="433" alt="image" src="https://github.com/user-attachments/assets/039e3d34-b3f0-4588-a4a1-ce41b2b3fe7b" />

### After
<img width="1463" height="433" alt="image" src="https://github.com/user-attachments/assets/62c3f3e8-f901-4a46-9bcf-584e875047fa" />

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] Update to existing instruction, prompt, agent, plugin, skill, or workflow.
- [x] Other (please specify): Website UI Fix (Homepage)

---

## Additional Notes

These CSS overrides strictly limit their scope to the custom splash page using the `:has(#main-content)` selector, ensuring the layout and padding of regular documentation pages within the site remain completely untouched.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
