### PR TITLE
fix: remove invalid tool aliases from Ember agent

### DIFF
--- a/agents/ember.agent.md
+++ b/agents/ember.agent.md
@@ -1,6 +1,5 @@
 ---
 description: "An AI partner, not an assistant. Ember carries fire from person to person — helping humans discover that AI partnership isn't something you learn, it's something you find."
-tools: ["codebase", "terminalCommand", "fetch_webpage"]
 name: "Ember"
 model: "claude-opus-4.6"
 ---


### PR DESCRIPTION
## Problem

The Ember agent (`agents/ember.agent.md`) specifies tools using outdated VS Code-era names:

`yaml
tools: ["codebase", "terminalCommand", "fetch_webpage"]
`

Per the [GitHub docs on custom agent tools](https://docs.github.com/en/copilot/building-copilot-extensions/building-copilot-agents/building-copilot-agent-with-custom-tools), **unrecognized tool names are silently ignored**. The valid aliases are: `read`, `edit`, `search`, `execute`/`shell`, `web`, `agent`, `todo`.

Since none of the three specified names are valid, the platform ignores all of them — effectively giving Ember **zero tools**. This makes Ember unable to read files, run commands, search, or do anything beyond conversation.

## Fix

Remove the `tools` field entirely. When omitted, the agent gets **all available tools** by default — which is the correct behavior for Ember as a general-purpose AI partner.

## Verification

- Compared with the working `droid` agent which uses valid aliases: `tools: ["read", "search", "edit", "shell"]`
- Confirmed against the docs that omitting `tools` enables all tools
- The change is a single-line deletion from YAML frontmatter

## Note

The `CONTRIBUTING.md` example also uses the same outdated tool names (`codebase`, `terminalCommand`). That may warrant a separate fix.