### PR TITLE
docs: add source link to GTM skills for directory visibility

### DIFF
--- a/skills/gtm-0-to-1-launch/SKILL.md
+++ b/skills/gtm-0-to-1-launch/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 # 0-to-1 Launch
 
+> By [Smit Patel](https://linkedin.com/in/smitkpatel) · Full pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)
+
 Launch new products from idea to first customers. The goal isn't headlines — it's finding 10 customers who can't live without you.
 
 ## When to Use

--- a/skills/gtm-ai-gtm/SKILL.md
+++ b/skills/gtm-ai-gtm/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 # AI Product GTM
 
+> By [Smit Patel](https://linkedin.com/in/smitkpatel) · Full pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)
+
 Go-to-market strategy for AI products. These aren't generic AI principles — they're patterns from selling autonomous AI agents into enterprises where "autonomous" scared buyers and "teammate" converted them.
 
 ## When to Use

--- a/skills/gtm-board-and-investor-communication/SKILL.md
+++ b/skills/gtm-board-and-investor-communication/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 # Board and Investor Communication
 
+> By [Smit Patel](https://linkedin.com/in/smitkpatel) · Full pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)
+
 Structure board meetings, investor updates, and executive communication that builds trust and drives decisions — not slide decks that nobody reads.
 
 ## When to Use

--- a/skills/gtm-developer-ecosystem/SKILL.md
+++ b/skills/gtm-developer-ecosystem/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 # Developer Ecosystem
 
+> By [Smit Patel](https://linkedin.com/in/smitkpatel) · Full pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)
+
 Build and scale developer-led adoption through ecosystem programs, community, and partnerships. Focus on what actually drives adoption, not vanity metrics.
 
 ## When to Use

--- a/skills/gtm-enterprise-account-planning/SKILL.md
+++ b/skills/gtm-enterprise-account-planning/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 # Enterprise Account Planning
 
+> By [Smit Patel](https://linkedin.com/in/smitkpatel) · Full pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)
+
 Strategic account planning and execution for enterprise deals. Turn complex sales cycles into systematic wins — or at least know when they're dying before you waste months.
 
 ## When to Use

--- a/skills/gtm-enterprise-onboarding/SKILL.md
+++ b/skills/gtm-enterprise-onboarding/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 # Enterprise Onboarding
 
+> By [Smit Patel](https://linkedin.com/in/smitkpatel) · Full pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)
+
 Four-phase framework for onboarding enterprise customers from contract to value realization. The goal isn't just go-live — it's sustained adoption that doesn't cliff at Week 12.
 
 ## When to Use

--- a/skills/gtm-operating-cadence/SKILL.md
+++ b/skills/gtm-operating-cadence/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 # Operating Cadence
 
+> By [Smit Patel](https://linkedin.com/in/smitkpatel) · Full pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)
+
 The meeting structure that worked at 30 people collapses at 100. What worked at 100 collapses at 300. The failure mode is always the same: too many people in too many meetings making too few decisions.
 
 ## When to Use

--- a/skills/gtm-partnership-architecture/SKILL.md
+++ b/skills/gtm-partnership-architecture/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 # Partnership Architecture
 
+> By [Smit Patel](https://linkedin.com/in/smitkpatel) · Full pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)
+
 Build and scale partner ecosystems that drive revenue and platform adoption. These aren't theory — they're patterns from building partner programs that drove 8-figure ARR and observing partnerships with real economic commitment.
 
 ## When to Use

--- a/skills/gtm-positioning-strategy/SKILL.md
+++ b/skills/gtm-positioning-strategy/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 # Positioning Strategy
 
+> By [Smit Patel](https://linkedin.com/in/smitkpatel) · Full pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)
+
 Find and own a defensible market position. Turn generic messaging into clear differentiation — or at least test whether your differentiation actually resonates before committing to it.
 
 ## When to Use

--- a/skills/gtm-product-led-growth/SKILL.md
+++ b/skills/gtm-product-led-growth/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 # Product-Led Growth
 
+> By [Smit Patel](https://linkedin.com/in/smitkpatel) · Full pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)
+
 Build self-serve acquisition and expansion motions. But first, figure out if PLG is even the right motion for your product.
 
 ## When to Use

--- a/skills/gtm-technical-product-pricing/SKILL.md
+++ b/skills/gtm-technical-product-pricing/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 # Technical Product Pricing
 
+> By [Smit Patel](https://linkedin.com/in/smitkpatel) · Full pack: [beingsmit/technical-product-gtm](https://github.com/beingsmit/technical-product-gtm)
+
 
 ## Initial Assessment
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

Adds a one-line source link under each GTM skill title. The skills.sh directory doesn't render frontmatter metadata, so the author/source info merged in #1100 isn't visible there. This adds it as body content so it shows up across all skill directories.

No content changes — just one blockquote line per skill.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [x] Update to existing instruction, prompt, agent, plugin, skill, or workflow.
- [ ] Other (please specify):

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
