### PR TITLE
docs(readme): add Helium MCP for additional MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ New to GitHub Copilot customization? The **[Learning Hub](https://awesome-copilo
 
 Looking at how to use Awesome Copilot? Check out the **[Tools section](https://awesome-copilot.github.com/tools)** of the website for MCP servers, editor integrations, and other developer tooling to get the most out of this collection.
 
+### Additional MCP Servers
+
+- **[Helium MCP](https://github.com/connerlambden/helium-mcp)** — Real-time news intelligence with bias scoring, financial market data, and ML options pricing via MCP. [Docs](https://heliumtrades.com/mcp-page/)
+
 ## Install a Plugin
 
 For most users, the **Awesome Copilot** marketplace is already registered in the Copilot CLI/VS Code, so you can install a plugin directly:


### PR DESCRIPTION
## Summary

Adds **Helium MCP** under the **Tools** section as an additional MCP server.

Helium provides real-time news intelligence with bias scoring across 15+ dimensions, financial market data (stocks/ETFs/crypto), and ML options pricing over MCP. Works with GitHub Copilot and other MCP-compatible coding assistants.

- **GitHub**: https://github.com/connerlambden/helium-mcp
- **Docs**: https://heliumtrades.com/mcp-page/
- **Free tier**: 50 queries, no API key needed