### PR TITLE
Add copilot-brag-sheet — auto-track AI coding sessions

### DIFF
--- a/plugins/external.json
+++ b/plugins/external.json
@@ -72,20 +72,20 @@
     }
   },
   {
-  "name": "skills-for-copilot-studio",
-  "description": "Microsoft Copilot Studio plugins for AI coding agents",
-  "version": "1.0.3",
-  "author": {
-    "name": "Microsoft Copilot Studio CAT Team",
-    "url": "https://www.microsoft.com"
+    "name": "skills-for-copilot-studio",
+    "description": "Microsoft Copilot Studio plugins for AI coding agents",
+    "version": "1.0.3",
+    "author": {
+      "name": "Microsoft Copilot Studio CAT Team",
+      "url": "https://www.microsoft.com"
     },
-  "homepage": "https://github.com/microsoft/skills-for-copilot-studio",
-  "keywords": ["copilot", "copilot-studio", "studio", "agent", "microsoft", "coding"],
-  "license": "MIT",
-  "repository": "https://github.com/microsoft/skills-for-copilot-studio",
-  "source": {
-    "source": "github",
-    "repo": "microsoft/skills-for-copilot-studio"
+    "homepage": "https://github.com/microsoft/skills-for-copilot-studio",
+    "keywords": ["copilot", "copilot-studio", "studio", "agent", "microsoft", "coding"],
+    "license": "MIT",
+    "repository": "https://github.com/microsoft/skills-for-copilot-studio",
+    "source": {
+      "source": "github",
+      "repo": "microsoft/skills-for-copilot-studio"
     }
   },
   {
@@ -154,6 +154,22 @@
     "source": {
       "source": "github",
       "repo": "microsoft/What-I-Did-Copilot"
+    }
+  },
+  {
+    "name": "copilot-brag-sheet",
+    "description": "Auto-track AI coding sessions into a work impact log (brag sheet). Say 'brag' to save accomplishments, 'review my work' to see your log. Zero dependencies, local-first.",
+    "version": "1.0.0",
+    "author": {
+      "name": "Vidhart Bhatia"
+    },
+    "homepage": "https://github.com/vidhartbhatia/copilot-brag-sheet",
+    "keywords": ["brag-sheet", "work-tracker", "impact-log", "performance-review", "local-first"],
+    "license": "MIT",
+    "repository": "https://github.com/vidhartbhatia/copilot-brag-sheet",
+    "source": {
+      "source": "github",
+      "repo": "vidhartbhatia/copilot-brag-sheet"
     }
   }
 ]


### PR DESCRIPTION
## Add copilot-brag-sheet — continuous work tracking for Copilot CLI

### What is it?

**copilot-brag-sheet** is a Microsoft open-source Copilot CLI extension that **continuously tracks** your AI coding sessions into a structured work impact log. It runs in the background during every session — capturing files edited, PRs created, git actions — and lets you save notable accomplishments on the fly.

### Repository

**https://github.com/microsoft/copilot-brag-sheet** (MIT licensed, Microsoft org)

### How it differs from What-I-Did-Copilot

| | What-I-Did-Copilot | copilot-brag-sheet |
|--|---|---|
| **Approach** | Retroactive reports from session history | Continuous real-time tracking + manual entries |
| **Storage** | Generates HTML reports on demand | Persistent JSON records with markdown rendering |
| **Manual entries** | ❌ | ✅ Say "brag" to save an accomplishment anytime |
| **Ongoing tracking** | ❌ | ✅ Hooks into every session automatically |
| **Git version history** | ❌ | ✅ Local git + optional remote sync |
| **Dependencies** | Python | Zero (Node.js only) |

The two tools are **complementary** — What-I-Did generates polished impact reports, copilot-brag-sheet captures the raw work as it happens.

### Quality

- ✅ 107 tests passing
- ✅ CI on 3 OSes × 3 Node versions (Ubuntu, macOS, Windows)
- ✅ MIT licensed, Microsoft org
- ✅ Zero runtime dependencies
- ✅ OSMP compliant (CODE_OF_CONDUCT, SECURITY, SUPPORT, CLA)

### Links

- **Repository**: https://github.com/microsoft/copilot-brag-sheet
- **npm**: https://www.npmjs.com/package/copilot-brag-sheet
- **Release**: https://github.com/microsoft/copilot-brag-sheet/releases/tag/v1.0.0