### PR TITLE
Add work-log-tracker hook — lightweight session logging 🤖🤖🤖

### DIFF
--- a/hooks/work-log-tracker/README.md
+++ b/hooks/work-log-tracker/README.md
@@ -1,0 +1,69 @@
+---
+name: 'Work Log Tracker'
+description: 'Lightweight session logging — tracks what you worked on across repos'
+tags: ['logging', 'productivity', 'work-tracking']
+---
+
+# Work Log Tracker Hook
+
+Lightweight session logging for GitHub Copilot coding agent. Automatically records when sessions start and end, along with git repo context, so you always know what you worked on.
+
+## Overview
+
+This hook appends a JSON Lines record to `~/.copilot-work-log/sessions.jsonl` for every coding agent session:
+
+- **Session start**: timestamp, working directory, git repo name, branch
+- **Session end**: timestamp
+
+No prompts or code are logged — only metadata.
+
+## Installation
+
+1. Copy this hook folder to your repository's `.github/hooks/` directory:
+   ```bash
+   cp -r hooks/work-log-tracker .github/hooks/
+   ```
+
+2. Ensure scripts are executable:
+   ```bash
+   chmod +x .github/hooks/work-log-tracker/*.sh
+   ```
+
+3. Commit the hook configuration to your repository's default branch.
+
+## Log Format
+
+Records are appended to `~/.copilot-work-log/sessions.jsonl` in JSON Lines format:
+
+```json
+{"timestamp":"2026-01-15T10:30:00Z","event":"session_start","cwd":"/home/user/project","repo":"my-app","branch":"feature/auth","pid":12345}
+{"timestamp":"2026-01-15T11:00:00Z","event":"session_end","pid":12345}
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WORK_LOG_DIR` | `~/.copilot-work-log` | Directory for log files |
+| `SKIP_WORK_LOG` | unset | Set to `true` to disable logging |
+
+## Privacy & Security
+
+- **No code or prompts are logged** — only session metadata (timestamps, repo name, branch)
+- Logs are stored locally in your home directory
+- Set `SKIP_WORK_LOG=true` to disable entirely
+- No external network calls
+
+## Want More?
+
+This hook provides basic session tracking. For full-featured work logging with:
+
+- ✍️ Manual brag-sheet entries with impact tracking
+- 📊 Categorized work logs (PR, bugfix, infrastructure, oncall, etc.)
+- 📝 Auto-generated markdown reports for performance reviews
+- 🔄 Git backup to keep your work log synced
+- 📁 File and PR tracking within sessions
+
+Check out **[copilot-brag-sheet](https://github.com/vidhartbhatia/copilot-brag-sheet)** — a zero-dependency Copilot CLI extension that builds on the same idea.
+
+Also see **[What-I-Did-Copilot](https://github.com/microsoft/What-I-Did-Copilot)** for another approach to AI-assisted work tracking.

--- a/hooks/work-log-tracker/hooks.json
+++ b/hooks/work-log-tracker/hooks.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": ".github/hooks/work-log-tracker/log-session-start.sh",
+        "cwd": ".",
+        "timeoutSec": 5
+      }
+    ],
+    "sessionEnd": [
+      {
+        "type": "command",
+        "bash": ".github/hooks/work-log-tracker/log-session-end.sh",
+        "cwd": ".",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/hooks/work-log-tracker/log-session-end.sh
+++ b/hooks/work-log-tracker/log-session-end.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Log session end to ~/.copilot-work-log/sessions.jsonl
+
+set -euo pipefail
+
+# Skip if logging disabled
+if [[ "${SKIP_WORK_LOG:-}" == "true" ]]; then
+  exit 0
+fi
+
+# Read input from Copilot (required by hook protocol)
+INPUT=$(cat)
+
+# Configurable log directory
+LOG_DIR="${WORK_LOG_DIR:-$HOME/.copilot-work-log}"
+mkdir -p "$LOG_DIR"
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Write JSON record
+printf '{"timestamp":"%s","event":"session_end","pid":%d}\n' \
+  "$TIMESTAMP" "$$" \
+  >> "$LOG_DIR/sessions.jsonl"
+
+exit 0

--- a/hooks/work-log-tracker/log-session-start.sh
+++ b/hooks/work-log-tracker/log-session-start.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Log session start with git context to ~/.copilot-work-log/sessions.jsonl
+
+set -euo pipefail
+
+# Skip if logging disabled
+if [[ "${SKIP_WORK_LOG:-}" == "true" ]]; then
+  exit 0
+fi
+
+# Read input from Copilot (required by hook protocol)
+INPUT=$(cat)
+
+# Configurable log directory
+LOG_DIR="${WORK_LOG_DIR:-$HOME/.copilot-work-log}"
+mkdir -p "$LOG_DIR"
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+CWD=$(pwd)
+
+# Detect git repo and branch (fail gracefully)
+GIT_REPO=""
+GIT_BRANCH=""
+if command -v git &>/dev/null && git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
+  GIT_REPO=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "")
+  GIT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+fi
+
+# Write JSON record (no jq dependency — pure bash)
+printf '{"timestamp":"%s","event":"session_start","cwd":"%s","repo":"%s","branch":"%s","pid":%d}\n' \
+  "$TIMESTAMP" "$CWD" "$GIT_REPO" "$GIT_BRANCH" "$$" \
+  >> "$LOG_DIR/sessions.jsonl"
+
+exit 0


### PR DESCRIPTION
## What this adds

A lightweight **work-log-tracker** hook that logs Copilot coding agent session start/end events to `~/.copilot-work-log/sessions.jsonl`.

### What it tracks

- **Session start**: timestamp, working directory, git repo name, git branch, PID
- **Session end**: timestamp, PID

No code or prompts are logged — only session metadata.

### Why it's useful

Developers often lose track of what they worked on across repos and branches. This hook provides a zero-config, append-only log of session activity that can be queried later (e.g., "what repos did I touch last week?").

### Files

| File | Purpose |
|------|---------|
| `hooks.json` | Hook event configuration (sessionStart + sessionEnd) |
| `log-session-start.sh` | Captures cwd, git repo/branch, timestamp |
| `log-session-end.sh` | Captures end timestamp |
| `README.md` | Documentation with installation, config, and privacy info |

### Relationship to existing work

- **Complementary to [What-I-Did-Copilot](https://github.com/microsoft/What-I-Did-Copilot)** — that extension focuses on summarizing what the AI did; this hook focuses on when/where you worked
- For full-featured work tracking (manual entries, categories, git backup, markdown rendering), the README links to [copilot-brag-sheet](https://github.com/vidhartbhatia/copilot-brag-sheet)

### Design choices

- **No dependencies** — pure bash, no `jq` required
- **Privacy-first** — only metadata logged, stored locally in `~/.copilot-work-log/`
- **Configurable** — `WORK_LOG_DIR` env var to redirect output, `SKIP_WORK_LOG=true` to disable
- Follows the same patterns as existing hooks (session-logger, governance-audit)

🤖🤖🤖