### PR TITLE
Add copilot-brag-sheet plugin — continuous work tracking for Copilot CLI sessions

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -84,6 +84,30 @@
       "version": "0.1.0"
     },
     {
+      "name": "copilot-brag-sheet",
+      "description": "Auto-track every Copilot CLI session into a structured work impact log — files edited, PRs created, git actions — with on-demand markdown reports for performance reviews.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Microsoft",
+        "url": "https://www.microsoft.com"
+      },
+      "homepage": "https://github.com/microsoft/copilot-brag-sheet",
+      "keywords": [
+        "copilot",
+        "work-tracking",
+        "productivity",
+        "brag-sheet",
+        "session-logging",
+        "impact"
+      ],
+      "license": "MIT",
+      "repository": "https://github.com/microsoft/copilot-brag-sheet",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/copilot-brag-sheet"
+      }
+    },
+    {
       "name": "copilot-sdk",
       "source": "copilot-sdk",
       "description": "Build applications with the GitHub Copilot SDK across multiple programming languages. Includes comprehensive instructions for C#, Go, Node.js/TypeScript, and Python to help you create AI-powered applications.",

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -155,5 +155,22 @@
       "source": "github",
       "repo": "microsoft/What-I-Did-Copilot"
     }
+  },
+  {
+    "name": "copilot-brag-sheet",
+    "description": "Auto-track every Copilot CLI session into a structured work impact log — files edited, PRs created, git actions — with on-demand markdown reports for performance reviews.",
+    "version": "1.0.0",
+    "author": {
+      "name": "Microsoft",
+      "url": "https://www.microsoft.com"
+    },
+    "homepage": "https://github.com/microsoft/copilot-brag-sheet",
+    "keywords": ["copilot", "work-tracking", "productivity", "brag-sheet", "session-logging", "impact"],
+    "license": "MIT",
+    "repository": "https://github.com/microsoft/copilot-brag-sheet",
+    "source": {
+      "source": "github",
+      "repo": "microsoft/copilot-brag-sheet"
+    }
   }
 ]


### PR DESCRIPTION
## ⚠️ On hold — reassessing contribution format

We're evaluating whether to submit this as:
1. **External plugin** (`plugins/external.json`) — current approach, but `copilot plugin install` won't load our `joinSession()` extension, which could confuse users
2. **Hook contribution** (`hooks/work-log-tracker/`) — lightweight session logger that's natively installable, with a link to the full extension for richer functionality

The repo has moved to the Microsoft org: **https://github.com/microsoft/copilot-brag-sheet** (MIT, public, OSMP compliant).

Will update this PR once we've decided the right path. Feedback from maintainers on the preferred approach is very welcome!

---

### What copilot-brag-sheet does

A Copilot CLI extension that continuously tracks every AI coding session into a structured work impact log — capturing files edited, PRs created, and git actions. Say "brag" to save an accomplishment, "review my work" to see your log.

- **Repository**: [microsoft/copilot-brag-sheet](https://github.com/microsoft/copilot-brag-sheet)
- **107 tests**, CI on 3 OSes × 3 Node versions
- **Zero dependencies**, MIT licensed

### Install (extension-based, not plugin-based)

```bash
curl -sL https://raw.githubusercontent.com/microsoft/copilot-brag-sheet/main/install.sh | bash
```