### PR TITLE
feat: add AGT governance artifacts (policy, allowlist, CI workflow)

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -1,0 +1,93 @@
+name: Governance Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  governance:
+    name: Governance validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check required governance files
+        run: |
+          STATUS="pass"
+          for file in AGENTS.md SECURITY.md mcp-allowlist.yaml governance/policy.yaml; do
+            if [ -f "$file" ]; then
+              echo "✅ $file"
+            else
+              echo "❌ $file missing"
+              STATUS="fail"
+            fi
+          done
+          for file in .github/copilot-instructions.md; do
+            if [ -f "$file" ]; then
+              echo "✅ $file"
+            else
+              echo "⚠️ $file missing (recommended)"
+            fi
+          done
+          if [ "$STATUS" = "fail" ]; then
+            echo "::warning::Required governance files are missing"
+          fi
+
+      - name: Validate MCP allowlist
+        run: |
+          python3 -c "
+          import yaml, sys
+          with open('mcp-allowlist.yaml') as f:
+              data = yaml.safe_load(f)
+          known = data.get('known', [])
+          blocked = data.get('blocked', [])
+          mode = data.get('enforcement', 'warn')
+          print(f'Enforcement: {mode}')
+          print(f'Known servers: {len(known)}')
+          print(f'Blocked servers: {len(blocked)}')
+          overlap = set(known) & set(blocked)
+          if overlap:
+              print(f'::error::Servers in both known and blocked: {overlap}')
+              sys.exit(1)
+          print('✅ MCP allowlist is valid')
+          "
+
+      - name: Validate governance policy
+        run: |
+          python3 -c "
+          import yaml
+          with open('governance/policy.yaml') as f:
+              data = yaml.safe_load(f)
+          mode = data.get('kernel', {}).get('mode', 'unset')
+          rings = data.get('rings', {})
+          blocked = data.get('blocked_patterns', [])
+          print(f'Policy mode: {mode}')
+          print(f'Rings defined: {len(rings)}')
+          print(f'Blocked patterns: {len(blocked)}')
+          print('✅ Governance policy is valid')
+          "
+
+      - name: Check for hardcoded secrets
+        run: |
+          PATTERNS='(AKIA[0-9A-Z]{16}|sk-[a-zA-Z0-9]{48}|ghp_[a-zA-Z0-9]{36}|-----BEGIN (RSA |EC )?PRIVATE KEY-----)'
+          if grep -rPn "$PATTERNS" --include="*.py" --include="*.yaml" --include="*.yml" --include="*.json" --exclude-dir=.git --exclude-dir=__pycache__ --exclude-dir=.pytest_cache . 2>/dev/null; then
+            echo "::error::Potential hardcoded secrets detected"
+            exit 1
+          else
+            echo "✅ No hardcoded secrets detected"
+          fi
+
+      - name: AGT toolkit verify (optional)
+        continue-on-error: true
+        run: |
+          pip install "agent-governance-toolkit[full]>=3.0.0" --quiet 2>/dev/null || { echo "AGT not installable — skipping"; exit 0; }
+          agent-governance verify --json || echo "::warning::AGT governance verify reported issues"
+
+      - name: AGT integrity check (optional)
+        continue-on-error: true
+        run: |
+          which agent-governance >/dev/null 2>&1 || exit 0
+          agent-governance integrity --verify . || echo "::warning::Integrity check reported changes"

--- a/governance/policy.yaml
+++ b/governance/policy.yaml
@@ -1,0 +1,70 @@
+# Awesome Copilot Governance Policy (YAML)
+# =========================================
+# Loaded by the PolicyEngine at startup. Defines rules that apply
+# to all agents operating in the awesome-copilot context.
+#
+# This file is enforceable via AGT's PolicyEvaluator when
+# agent-governance-toolkit is installed.
+
+kernel:
+  mode: strict           # strict | permissive | audit
+
+# Default limits for any agent session
+limits:
+  max_tokens_per_task: 8000
+  max_tool_calls_per_task: 25
+  max_session_duration_minutes: 60
+
+# Blocked patterns — actions matching these are denied
+blocked_patterns:
+  - "rm -rf /"
+  - "DROP TABLE"
+  - "DELETE FROM"
+  - "os.system("
+  - "eval("
+  - "exec("
+  - "pickle.load"
+  - "subprocess.run.*shell=True"
+
+# Ring-based permissions
+rings:
+  0:  # Kernel — requires attestation
+    requires_attestation: true
+    capabilities:
+      - infra_create
+      - infra_delete
+      - iam_modify
+      - secret_read
+  1:  # Trusted
+    capabilities:
+      - file_write_user
+      - tool_call
+      - code_execute
+      - network_egress_restricted
+  2:  # Standard
+    capabilities:
+      - file_read
+      - tool_call
+      - code_execute
+      - repo_read
+  3:  # Sandbox — read only
+    capabilities:
+      - file_read
+      - repo_read
+    rate_limit: 10/min
+    timeout_seconds: 5
+
+# Approval workflows
+approval:
+  destructive_actions:
+    - "delete_*"
+    - "write_production_*"
+    - "infra_*"
+  min_approvals: 1
+  timeout_minutes: 30
+
+# Observability requirements
+audit:
+  log_all_decisions: true
+  log_format: jsonl
+  retention_days: 90

--- a/mcp-allowlist.yaml
+++ b/mcp-allowlist.yaml
@@ -1,0 +1,16 @@
+# MCP Server Allowlist for Awesome Copilot
+# ========================================
+#
+# Enforcement mode:
+#   warn  — unknown servers produce a warning (non-blocking)
+#   block — unknown servers produce a violation (blocks execution)
+enforcement: warn
+
+# Known MCP servers used by awesome-copilot agents and skills.
+known:
+  - github                # GitHub API access for PR/commit/issue data
+  - fetch                 # Web fetch for documentation references
+
+# Servers that are explicitly blocked.
+blocked:
+  - evil-server


### PR DESCRIPTION
Adds Agent Governance Toolkit (AGT) governance artifacts to enable automated governance validation on PRs.

## Changes
- **governance/policy.yaml** - Strict-mode policy with ring-based permissions, blocked patterns, approval workflows, and audit config
- **mcp-allowlist.yaml** - MCP server allowlist with warn enforcement mode
- **.github/workflows/governance-check.yml** - CI workflow that validates governance files, MCP allowlist, policy config, scans for hardcoded secrets, and optionally runs AGT verify

## Why
Standardizing governance across all repos using the AGT pattern established in agent-sre, ai-native-team, and sdlc-toolkit.