### PR TITLE
fix: replace bare except with except Exception in analysis.py

### DIFF
--- a/skills/datanalysis-credit-risk/references/analysis.py
+++ b/skills/datanalysis-credit-risk/references/analysis.py
@@ -483,7 +483,7 @@ def _calc_single_psi(args):
         # Bin based on non-NaN data (10 bins)
         try:
             bins = pd.qcut(train_nonan, q=10, duplicates='drop', retbins=True)[1]
-        except:
+        except Exception:
             bins = pd.cut(train_nonan, bins=10, retbins=True)[1]
         
         # Calculate proportion of each bin (including NaN bin)
@@ -996,7 +996,7 @@ def export_cleaning_report(filepath: str, steps: list,
     
     try:
         wb = load_workbook(filepath)
-    except:
+    except Exception:
         wb = Workbook()
         wb.remove(wb.active)
     


### PR DESCRIPTION
## Summary

Replaces bare \xcept:\ with \xcept Exception:\ in \skills/publish-to-pages/scripts/convert-pdf.py\ analysis function to avoid catching \SystemExit\ and \KeyboardInterrupt\.

Re-targeted to \staged\ branch as requested in #1500.

Signed-off-by: Srikanth Patchava <spatchava@meta.com>