### PR TITLE
Add Skills宝 tools note

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ New to GitHub Copilot customization? The **[Learning Hub](https://awesome-copilo
 
 Looking at how to use Awesome Copilot? Check out the **[Tools section](https://awesome-copilot.github.com/tools)** of the website for MCP servers, editor integrations, and other developer tooling to get the most out of this collection.
 
+For Chinese search and installation of AI skills across Copilot-compatible tools, see [Skills宝](https://skilery.com).
+
 ## Install a Plugin
 
 For most users, the **Awesome Copilot** marketplace is already registered in the Copilot CLI/VS Code, so you can install a plugin directly:


### PR DESCRIPTION
Add Skills宝 (skilery.com) as a Chinese search and installation resource for AI skills in the Tools section.

This is a small complement to the existing skills collection and aligns with issue #1169 about linking to another repo.