### PR TITLE
Fix security-review skill discovery

### DIFF
--- a/eng/generate-website-data.mjs
+++ b/eng/generate-website-data.mjs
@@ -430,14 +430,25 @@ function generateSkillsData(gitDates) {
 
       // Get last updated from SKILL.md file
       const skillFilePath = `${relativePath}/SKILL.md`;
+      const title = metadata.name
+        .split("-")
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(" ");
+      const searchText = [
+        title,
+        metadata.description,
+        folder,
+        metadata.name,
+        relativePath,
+        category,
+      ]
+        .join(" ")
+        .toLowerCase();
 
       skills.push({
         id: folder,
         name: metadata.name,
-        title: metadata.name
-          .split("-")
-          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-          .join(" "),
+        title,
         description: metadata.description,
         assets: metadata.assets,
         hasAssets: metadata.assets.length > 0,
@@ -447,6 +458,7 @@ function generateSkillsData(gitDates) {
         skillFile: skillFilePath,
         files: files,
         lastUpdated: gitDates.get(skillFilePath) || null,
+        searchText,
       });
     }
   }
@@ -774,7 +786,7 @@ function generateSearchIndex(
       description: skill.description,
       path: skill.skillFile,
       lastUpdated: skill.lastUpdated,
-      searchText: `${skill.title} ${skill.description}`.toLowerCase(),
+      searchText: skill.searchText,
     });
   }
 


### PR DESCRIPTION
## Problem

`security-review` is published, but exact slug searches like `security-review` were unreliable because generated skill search metadata only guaranteed the display title and description.

## What changed

This keeps the old search inputs and adds the missing ones in generated website data.

| Search input | Before | After |
| --- | --- | --- |
| Display title, e.g. `Security Review` | Searched | Still searched |
| Description | Searched | Still searched |
| Skill id/folder, e.g. `security-review` | Not guaranteed | Added |
| Frontmatter `name`, e.g. `security-review` | Not guaranteed | Added |
| Path, e.g. `skills/security-review` | Not searched | Added |
| Category | Not searched | Added |

`metadata.name` is the raw skill name from `SKILL.md` (`security-review`). `skill.title` is the generated display title (`Security Review`). The generated `searchText` now includes both, so existing queries like `Security`, `Review`, and `Security Review` do not regress, while exact slug/path queries now work too.

No `skills/security-review/SKILL.md` description change is needed anymore; the generator now indexes the skill name/path directly. Without this generator change, a skill could work around the issue by repeating its slug in the description, but that should not be required.

## Validation

- `npm run website:data`
- `npm run skill:validate`
- `npm run website:build`
- `git diff --check`
- Confirmed generated `skills.json` includes `Security Review`, `security-review`, and `skills/security-review` in searchable metadata

Fixes #1513