### PR TITLE
Add ai-ready external plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -11,6 +11,34 @@
   },
   "plugins": [
     {
+      "name": "ai-ready",
+      "description": "Analyze any repository and generate AI-ready configuration — AGENTS.md, copilot-instructions.md, skills, CI workflows, issue templates, and more. GitHub-native: auto-discovers repo context, community health, and PR review patterns to generate customized assets that teach AI agents and human contributors how to work in the repo correctly.",
+      "version": "0.3.0-alpha",
+      "author": {
+        "name": "John Papa",
+        "url": "https://github.com/johnpapa"
+      },
+      "homepage": "https://github.com/johnpapa/ai-ready",
+      "keywords": [
+        "ai-ready",
+        "repo-setup",
+        "agents",
+        "copilot-instructions",
+        "skills",
+        "ci",
+        "templates",
+        "contributions",
+        "maintainer",
+        "github-native"
+      ],
+      "license": "MIT",
+      "repository": "https://github.com/johnpapa/ai-ready",
+      "source": {
+        "source": "github",
+        "repo": "johnpapa/ai-ready"
+      }
+    },
+    {
       "name": "ai-team-orchestration",
       "source": "ai-team-orchestration",
       "description": "Bootstrap and run a multi-agent AI development team with named roles (Producer, Dev Team, QA). Sprint planning, brainstorm prompts with distinct agent voices, cross-chat context survival, and parallel team workflows. Based on a proven template that shipped a 30-game app in 5 days with zero human-written code.",

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -155,5 +155,22 @@
       "source": "github",
       "repo": "microsoft/What-I-Did-Copilot"
     }
+  },
+  {
+    "name": "ai-ready",
+    "description": "Analyze any repository and generate AI-ready configuration — AGENTS.md, copilot-instructions.md, skills, CI workflows, issue templates, and more. GitHub-native: auto-discovers repo context, community health, and PR review patterns to generate customized assets that teach AI agents and human contributors how to work in the repo correctly.",
+    "version": "0.3.0-alpha",
+    "author": {
+      "name": "John Papa",
+      "url": "https://github.com/johnpapa"
+    },
+    "homepage": "https://github.com/johnpapa/ai-ready",
+    "keywords": ["ai-ready", "repo-setup", "agents", "copilot-instructions", "skills", "ci", "templates", "contributions", "maintainer", "github-native"],
+    "license": "MIT",
+    "repository": "https://github.com/johnpapa/ai-ready",
+    "source": {
+      "source": "github",
+      "repo": "johnpapa/ai-ready"
+    }
   }
 ]


### PR DESCRIPTION
## What

Adds the `ai-ready` external plugin to the awesome-copilot marketplace — a Copilot CLI skill that analyzes any repository and generates AI-ready configuration assets.

## What it does

When a user says "make this repo ai-ready", the skill:

1. **Auto-discovers GitHub context** (zero user input) — repo metadata, language breakdown, community health, contributors, PR review patterns, CI workflows
2. **Mines PR review comments** for repeated feedback → turns maintainer review fatigue into automated conventions in `copilot-instructions.md`
3. **Analyzes the codebase** — manifest files, test setup, directory structure, existing AI config, changelog health, documentation setup
4. **Generates customized assets** — AGENTS.md, copilot-instructions.md, copilot-setup-steps.yml, CI workflow, issue templates, README contributing section, maintenance matrix, and more
5. **Displays an AI-Readiness Report** — score with progress bar, what was created/skipped/suggested
6. **Offers an opt-in AI-Ready badge** — Shields.io badge for the README + `ai-ready` GitHub topic

## Why

Contributors (human and AI) don't know a repo's conventions. Maintainers waste time re-teaching them in every PR review. AI agents compound this — more PRs, same quality gap. This plugin closes the gap by teaching AI how to work in the repo correctly.

## Technical details

- **Skill-only** — no extensions, no MCP servers, no arbitrary code execution
- **GitHub-native** — uses GitHub MCP tools and `gh` CLI to auto-discover context
- Uses only Copilot CLI's built-in tools (glob, grep, view, create, edit, bash)
- Never overwrites existing files — only fills gaps
- Self-consistency rule: generated files follow the conventions they establish

## Tested on

| Repo | Type | Result |
|------|------|--------|
| [DanWahlin/agent-arcade](https://github.com/DanWahlin/agent-arcade) | Tauri + Phaser game | Generated 9 assets |
| [johnpapa/vscode-peacock](https://github.com/johnpapa/vscode-peacock) | VS Code extension | Generated 4 assets |
| [johnpapa/shopathome](https://github.com/johnpapa/shopathome) | Full-stack monorepo | Generated 2 assets |

## Changes in this PR

| File | Change |
|------|--------|
| `.github/plugin/marketplace.json` | Added `ai-ready` entry (external, `source.repo: johnpapa/ai-ready`) |
| `plugins/external.json` | Added `ai-ready` entry (matches existing external plugin format) |

## Plugin repo

https://github.com/johnpapa/ai-ready

## Install (once merged)

```bash
copilot plugin install ai-ready@awesome-copilot
```