### PR TITLE
Fix trailing commas in agent tools arrays causing empty tool names (400 API error)

### DIFF
--- a/agents/address-comments.agent.md
+++ b/agents/address-comments.agent.md
@@ -24,7 +24,7 @@ tools:
     "usages",
     "vscodeAPI",
     "microsoft.docs.mcp",
-    "github",
+    "github"
   ]
 ---
 

--- a/agents/kusto-assistant.agent.md
+++ b/agents/kusto-assistant.agent.md
@@ -22,7 +22,7 @@ tools:
     "terminalSelection",
     "testFailure",
     "usages",
-    "vscodeAPI",
+    "vscodeAPI"
   ]
 ---
 

--- a/agents/mentoring-juniors.agent.md
+++ b/agents/mentoring-juniors.agent.md
@@ -12,7 +12,7 @@ tools:
     "search",
     "terminalLastCommand",
     "terminalSelection",
-    "usages",
+    "usages"
   ]
 ---
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

Three agent files have a trailing comma after the last element in their `tools` YAML flow-sequence arrays. When Copilot parses these files, the trailing comma produces an empty string as an extra tool entry. The Copilot API then rejects the entire request with:

```
CAPIError: 400 Invalid 'tools[N].function.name': empty string.
Expected a string with minimum length 1, but got an empty string instead.
```

This causes **all tasks run via Copilot CLI to fail completely** whenever any of these three agents are installed — even if the user is not actively using those agents, because installed plugins contribute to the global tools array for every session.

**Affected files:**
- `agents/kusto-assistant.agent.md` — trailing comma after `vscodeAPI`
- `agents/mentoring-juniors.agent.md` — trailing comma after `usages`
- `agents/address-comments.agent.md` — trailing comma after `github`

**Fix:** Remove the trailing comma from the last element of each `tools` array.

---

## Type of Contribution

- [x] Update to existing instruction, prompt, agent, plugin, skill, or workflow.

---

## Additional Notes

The YAML flow-sequence syntax used in these files (`tools: [ "a", "b", ]`) does not permit trailing commas — unlike JSON5 or JavaScript arrays. The fix is a 1-character removal per file.

Reproducible with any Copilot CLI task when these agents are installed. Error surfaced in VS Code Copilot Chat agent mode as well.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.