### PR TITLE
docs: update proflead contributor types

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2924,7 +2924,9 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/59716480?v=4",
       "profile": "https://github.com/proflead",
       "contributions": [
-        "agents"
+        "agents",
+        "code",
+        "content"
       ]
     },
     {


### PR DESCRIPTION
Updates the existing all-contributors entry for @proflead to include code and content contributions from merged PR #1266.