### PR TITLE
Enforce canonical plugin manifest ordering

### DIFF
--- a/eng/clean-materialized-plugins.mjs
+++ b/eng/clean-materialized-plugins.mjs
@@ -177,7 +177,7 @@ function main() {
   } else {
     console.log(`✅ Removed ${total} materialized file(s) from plugins.`);
     if (manifestsUpdated > 0) {
-      console.log(`✅ Updated ${manifestsUpdated} plugin manifest(s) with canonical spec ordering.`);
+      console.log(`✅ Updated ${manifestsUpdated} plugin manifest(s) to restore and normalize spec entries.`);
     }
   }
 }

--- a/eng/clean-materialized-plugins.mjs
+++ b/eng/clean-materialized-plugins.mjs
@@ -42,6 +42,14 @@ export function restoreManifestFromMaterializedFiles(pluginPath) {
 
   let changed = false;
   for (const [field, spec] of Object.entries(MATERIALIZED_SPECS)) {
+    if (Array.isArray(plugin[field])) {
+      const sortedEntries = sortPluginEntries(plugin[field]);
+      if (!arraysEqual(plugin[field], sortedEntries)) {
+        plugin[field] = sortedEntries;
+        changed = true;
+      }
+    }
+
     const materializedPath = path.join(pluginPath, spec.path);
     if (!fs.existsSync(materializedPath) || !fs.statSync(materializedPath).isDirectory()) {
       continue;
@@ -132,6 +140,10 @@ function arraysEqual(left, right) {
   return left.every((value, index) => value === right[index]);
 }
 
+function sortPluginEntries(entries) {
+  return [...entries].sort((left, right) => left.localeCompare(right));
+}
+
 function toPosixPath(filePath) {
   return filePath.split(path.sep).join("/");
 }
@@ -165,7 +177,7 @@ function main() {
   } else {
     console.log(`✅ Removed ${total} materialized file(s) from plugins.`);
     if (manifestsUpdated > 0) {
-      console.log(`✅ Updated ${manifestsUpdated} plugin manifest(s) with folder trailing slashes.`);
+      console.log(`✅ Updated ${manifestsUpdated} plugin manifest(s) with canonical spec ordering.`);
     }
   }
 }

--- a/eng/validate-plugins.mjs
+++ b/eng/validate-plugins.mjs
@@ -64,6 +64,18 @@ function validateKeywords(keywords) {
   return null;
 }
 
+function arraysEqual(left, right) {
+  if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
+}
+
+function sortPluginEntries(entries) {
+  return [...entries].sort((left, right) => left.localeCompare(right));
+}
+
 function validateSpecPaths(plugin) {
   const errors = [];
   const specs = {
@@ -77,6 +89,9 @@ function validateSpecPaths(plugin) {
     if (!Array.isArray(arr)) {
       errors.push(`${field} must be an array`);
       continue;
+    }
+    if (!arraysEqual(arr, sortPluginEntries(arr))) {
+      errors.push(`${field} must be sorted alphabetically`);
     }
     for (let i = 0; i < arr.length; i++) {
       const p = arr[i];

--- a/plugins/ai-team-orchestration/.github/plugin/plugin.json
+++ b/plugins/ai-team-orchestration/.github/plugin/plugin.json
@@ -17,8 +17,8 @@
   "repository": "https://github.com/github/awesome-copilot",
   "license": "MIT",
   "agents": [
-    "./agents/ai-team-producer.md",
     "./agents/ai-team-dev.md",
+    "./agents/ai-team-producer.md",
     "./agents/ai-team-qa.md"
   ],
   "skills": [

--- a/plugins/awesome-copilot/.github/plugin/plugin.json
+++ b/plugins/awesome-copilot/.github/plugin/plugin.json
@@ -18,8 +18,8 @@
     "./agents/meta-agentic-project-scaffold.md"
   ],
   "skills": [
-    "./skills/suggest-awesome-github-copilot-skills/",
+    "./skills/suggest-awesome-github-copilot-agents/",
     "./skills/suggest-awesome-github-copilot-instructions/",
-    "./skills/suggest-awesome-github-copilot-agents/"
+    "./skills/suggest-awesome-github-copilot-skills/"
   ]
 }

--- a/plugins/azure-cloud-development/.github/plugin/plugin.json
+++ b/plugins/azure-cloud-development/.github/plugin/plugin.json
@@ -18,18 +18,18 @@
     "devops"
   ],
   "agents": [
+    "./agents/azure-logic-apps-expert.md",
     "./agents/azure-principal-architect.md",
     "./agents/azure-saas-architect.md",
-    "./agents/azure-logic-apps-expert.md",
     "./agents/azure-verified-modules-bicep.md",
     "./agents/azure-verified-modules-terraform.md",
-    "./agents/terraform-azure-planning.md",
-    "./agents/terraform-azure-implement.md"
+    "./agents/terraform-azure-implement.md",
+    "./agents/terraform-azure-planning.md"
   ],
   "skills": [
-    "./skills/azure-resource-health-diagnose/",
     "./skills/az-cost-optimize/",
-    "./skills/import-infrastructure-as-code/",
-    "./skills/azure-pricing/"
+    "./skills/azure-pricing/",
+    "./skills/azure-resource-health-diagnose/",
+    "./skills/import-infrastructure-as-code/"
   ]
 }

--- a/plugins/cast-imaging/.github/plugin/plugin.json
+++ b/plugins/cast-imaging/.github/plugin/plugin.json
@@ -16,8 +16,8 @@
     "devops"
   ],
   "agents": [
-    "./agents/cast-imaging-software-discovery.md",
     "./agents/cast-imaging-impact-analysis.md",
+    "./agents/cast-imaging-software-discovery.md",
     "./agents/cast-imaging-structural-quality-advisor.md"
   ]
 }

--- a/plugins/context-engineering/.github/plugin/plugin.json
+++ b/plugins/context-engineering/.github/plugin/plugin.json
@@ -19,7 +19,7 @@
   ],
   "skills": [
     "./skills/context-map/",
-    "./skills/what-context-needed/",
-    "./skills/refactor-plan/"
+    "./skills/refactor-plan/",
+    "./skills/what-context-needed/"
   ]
 }

--- a/plugins/csharp-dotnet-development/.github/plugin/plugin.json
+++ b/plugins/csharp-dotnet-development/.github/plugin/plugin.json
@@ -17,12 +17,12 @@
     "./agents/expert-dotnet-software-engineer.md"
   ],
   "skills": [
-    "./skills/csharp-async/",
     "./skills/aspnet-minimal-api-openapi/",
-    "./skills/csharp-xunit/",
-    "./skills/csharp-nunit/",
+    "./skills/csharp-async/",
     "./skills/csharp-mstest/",
+    "./skills/csharp-nunit/",
     "./skills/csharp-tunit/",
+    "./skills/csharp-xunit/",
     "./skills/dotnet-best-practices/",
     "./skills/dotnet-upgrade/"
   ]

--- a/plugins/database-data-management/.github/plugin/plugin.json
+++ b/plugins/database-data-management/.github/plugin/plugin.json
@@ -18,13 +18,13 @@
     "data-management"
   ],
   "agents": [
-    "./agents/postgresql-dba.md",
-    "./agents/ms-sql-dba.md"
+    "./agents/ms-sql-dba.md",
+    "./agents/postgresql-dba.md"
   ],
   "skills": [
-    "./skills/sql-optimization/",
-    "./skills/sql-code-review/",
+    "./skills/postgresql-code-review/",
     "./skills/postgresql-optimization/",
-    "./skills/postgresql-code-review/"
+    "./skills/sql-code-review/",
+    "./skills/sql-optimization/"
   ]
 }

--- a/plugins/dataverse-sdk-for-python/.github/plugin/plugin.json
+++ b/plugins/dataverse-sdk-for-python/.github/plugin/plugin.json
@@ -14,9 +14,9 @@
     "sdk"
   ],
   "skills": [
-    "./skills/dataverse-python-quickstart/",
     "./skills/dataverse-python-advanced-patterns/",
     "./skills/dataverse-python-production-code/",
+    "./skills/dataverse-python-quickstart/",
     "./skills/dataverse-python-usecase-builder/"
   ]
 }

--- a/plugins/edge-ai-tasks/.github/plugin/plugin.json
+++ b/plugins/edge-ai-tasks/.github/plugin/plugin.json
@@ -15,7 +15,7 @@
     "implementation"
   ],
   "agents": [
-    "./agents/task-researcher.md",
-    "./agents/task-planner.md"
+    "./agents/task-planner.md",
+    "./agents/task-researcher.md"
   ]
 }

--- a/plugins/flowstudio-power-automate/.github/plugin/plugin.json
+++ b/plugins/flowstudio-power-automate/.github/plugin/plugin.json
@@ -19,10 +19,10 @@
     "governance"
   ],
   "skills": [
-    "./skills/flowstudio-power-automate-mcp/",
-    "./skills/flowstudio-power-automate-debug/",
     "./skills/flowstudio-power-automate-build/",
-    "./skills/flowstudio-power-automate-monitoring/",
-    "./skills/flowstudio-power-automate-governance/"
+    "./skills/flowstudio-power-automate-debug/",
+    "./skills/flowstudio-power-automate-governance/",
+    "./skills/flowstudio-power-automate-mcp/",
+    "./skills/flowstudio-power-automate-monitoring/"
   ]
 }

--- a/plugins/frontend-web-dev/.github/plugin/plugin.json
+++ b/plugins/frontend-web-dev/.github/plugin/plugin.json
@@ -19,8 +19,8 @@
     "vue"
   ],
   "agents": [
-    "./agents/expert-react-frontend-engineer.md",
-    "./agents/electron-angular-native.md"
+    "./agents/electron-angular-native.md",
+    "./agents/expert-react-frontend-engineer.md"
   ],
   "skills": [
     "./skills/playwright-explore-website/",

--- a/plugins/gem-team/.github/plugin/plugin.json
+++ b/plugins/gem-team/.github/plugin/plugin.json
@@ -1,20 +1,20 @@
 {
   "agents": [
-    "./agents/gem-orchestrator.md",
-    "./agents/gem-researcher.md",
-    "./agents/gem-planner.md",
-    "./agents/gem-implementer.md",
     "./agents/gem-browser-tester.md",
-    "./agents/gem-devops.md",
-    "./agents/gem-reviewer.md",
-    "./agents/gem-documentation-writer.md",
-    "./agents/gem-debugger.md",
-    "./agents/gem-critic.md",
     "./agents/gem-code-simplifier.md",
-    "./agents/gem-designer.md",
-    "./agents/gem-implementer-mobile.md",
+    "./agents/gem-critic.md",
+    "./agents/gem-debugger.md",
     "./agents/gem-designer-mobile.md",
-    "./agents/gem-mobile-tester.md"
+    "./agents/gem-designer.md",
+    "./agents/gem-devops.md",
+    "./agents/gem-documentation-writer.md",
+    "./agents/gem-implementer-mobile.md",
+    "./agents/gem-implementer.md",
+    "./agents/gem-mobile-tester.md",
+    "./agents/gem-orchestrator.md",
+    "./agents/gem-planner.md",
+    "./agents/gem-researcher.md",
+    "./agents/gem-reviewer.md"
   ],
   "author": {
     "email": "mubaidr@gmail.com",

--- a/plugins/java-development/.github/plugin/plugin.json
+++ b/plugins/java-development/.github/plugin/plugin.json
@@ -16,9 +16,9 @@
     "javadoc"
   ],
   "skills": [
+    "./skills/create-spring-boot-java-project/",
     "./skills/java-docs/",
     "./skills/java-junit/",
-    "./skills/java-springboot/",
-    "./skills/create-spring-boot-java-project/"
+    "./skills/java-springboot/"
   ]
 }

--- a/plugins/mcp-m365-copilot/.github/plugin/plugin.json
+++ b/plugins/mcp-m365-copilot/.github/plugin/plugin.json
@@ -19,8 +19,8 @@
     "./agents/mcp-m365-agent-expert.md"
   ],
   "skills": [
-    "./skills/mcp-create-declarative-agent/",
     "./skills/mcp-create-adaptive-cards/",
+    "./skills/mcp-create-declarative-agent/",
     "./skills/mcp-deploy-manage-agents/"
   ]
 }

--- a/plugins/partners/.github/plugin/plugin.json
+++ b/plugins/partners/.github/plugin/plugin.json
@@ -23,6 +23,7 @@
     "./agents/amplitude-experiment-implementation.md",
     "./agents/apify-integration-expert.md",
     "./agents/arm-migration.md",
+    "./agents/comet-opik.md",
     "./agents/diffblue-cover.md",
     "./agents/droid.md",
     "./agents/dynatrace-expert.md",
@@ -36,9 +37,8 @@
     "./agents/neon-migration-specialist.md",
     "./agents/neon-optimization-analyzer.md",
     "./agents/octopus-deploy-release-notes-mcp.md",
-    "./agents/stackhawk-security-onboarding.md",
-    "./agents/terraform.md",
     "./agents/pagerduty-incident-responder.md",
-    "./agents/comet-opik.md"
+    "./agents/stackhawk-security-onboarding.md",
+    "./agents/terraform.md"
   ]
 }

--- a/plugins/polyglot-test-agent/.github/plugin/plugin.json
+++ b/plugins/polyglot-test-agent/.github/plugin/plugin.json
@@ -20,14 +20,14 @@
     "go"
   ],
   "agents": [
-    "./agents/polyglot-test-generator.md",
-    "./agents/polyglot-test-researcher.md",
-    "./agents/polyglot-test-planner.md",
-    "./agents/polyglot-test-implementer.md",
     "./agents/polyglot-test-builder.md",
-    "./agents/polyglot-test-tester.md",
     "./agents/polyglot-test-fixer.md",
-    "./agents/polyglot-test-linter.md"
+    "./agents/polyglot-test-generator.md",
+    "./agents/polyglot-test-implementer.md",
+    "./agents/polyglot-test-linter.md",
+    "./agents/polyglot-test-planner.md",
+    "./agents/polyglot-test-researcher.md",
+    "./agents/polyglot-test-tester.md"
   ],
   "skills": [
     "./skills/polyglot-test-agent/"

--- a/plugins/power-platform-mcp-connector-development/.github/plugin/plugin.json
+++ b/plugins/power-platform-mcp-connector-development/.github/plugin/plugin.json
@@ -18,7 +18,7 @@
     "./agents/power-platform-mcp-integration-expert.md"
   ],
   "skills": [
-    "./skills/power-platform-mcp-connector-suite/",
-    "./skills/mcp-copilot-studio-server-generator/"
+    "./skills/mcp-copilot-studio-server-generator/",
+    "./skills/power-platform-mcp-connector-suite/"
   ]
 }

--- a/plugins/project-planning/.github/plugin/plugin.json
+++ b/plugins/project-planning/.github/plugin/plugin.json
@@ -18,22 +18,22 @@
     "technical-spike"
   ],
   "agents": [
-    "./agents/task-planner.md",
-    "./agents/task-researcher.md",
-    "./agents/planner.md",
-    "./agents/plan.md",
-    "./agents/prd.md",
     "./agents/implementation-plan.md",
-    "./agents/research-technical-spike.md"
+    "./agents/plan.md",
+    "./agents/planner.md",
+    "./agents/prd.md",
+    "./agents/research-technical-spike.md",
+    "./agents/task-planner.md",
+    "./agents/task-researcher.md"
   ],
   "skills": [
-    "./skills/breakdown-feature-implementation/",
-    "./skills/breakdown-feature-prd/",
     "./skills/breakdown-epic-arch/",
     "./skills/breakdown-epic-pm/",
-    "./skills/create-implementation-plan/",
-    "./skills/update-implementation-plan/",
+    "./skills/breakdown-feature-implementation/",
+    "./skills/breakdown-feature-prd/",
     "./skills/create-github-issues-feature-from-implementation-plan/",
-    "./skills/create-technical-spike/"
+    "./skills/create-implementation-plan/",
+    "./skills/create-technical-spike/",
+    "./skills/update-implementation-plan/"
   ]
 }

--- a/plugins/react18-upgrade/.github/plugin/plugin.json
+++ b/plugins/react18-upgrade/.github/plugin/plugin.json
@@ -16,12 +16,12 @@
   },
   "repository": "https://github.com/github/awesome-copilot",
   "license": "MIT",
-   "agents": [
+  "agents": [
     "./agents/react18-auditor.md",
+    "./agents/react18-batching-fixer.md",
+    "./agents/react18-class-surgeon.md",
     "./agents/react18-commander.md",
     "./agents/react18-dep-surgeon.md",
-    "./agents/react18-class-surgeon.md",
-    "./agents/react18-batching-fixer.md",
     "./agents/react18-test-guardian.md"
   ],
   "skills": [

--- a/plugins/rug-agentic-workflow/.github/plugin/plugin.json
+++ b/plugins/rug-agentic-workflow/.github/plugin/plugin.json
@@ -15,8 +15,8 @@
     "qa"
   ],
   "agents": [
+    "./agents/qa-subagent.md",
     "./agents/rug-orchestrator.md",
-    "./agents/swe-subagent.md",
-    "./agents/qa-subagent.md"
+    "./agents/swe-subagent.md"
   ]
 }

--- a/plugins/salesforce-development/.github/plugin/plugin.json
+++ b/plugins/salesforce-development/.github/plugin/plugin.json
@@ -26,7 +26,7 @@
   ],
   "skills": [
     "./skills/salesforce-apex-quality/",
-    "./skills/salesforce-flow-design/",
-    "./skills/salesforce-component-standards/"
+    "./skills/salesforce-component-standards/",
+    "./skills/salesforce-flow-design/"
   ]
 }

--- a/plugins/software-engineering-team/.github/plugin/plugin.json
+++ b/plugins/software-engineering-team/.github/plugin/plugin.json
@@ -18,12 +18,12 @@
     "ai-ethics"
   ],
   "agents": [
-    "./agents/se-ux-ui-designer.md",
-    "./agents/se-technical-writer.md",
     "./agents/se-gitops-ci-specialist.md",
     "./agents/se-product-manager-advisor.md",
     "./agents/se-responsible-ai-code.md",
+    "./agents/se-security-reviewer.md",
     "./agents/se-system-architecture-reviewer.md",
-    "./agents/se-security-reviewer.md"
+    "./agents/se-technical-writer.md",
+    "./agents/se-ux-ui-designer.md"
   ]
 }

--- a/plugins/testing-automation/.github/plugin/plugin.json
+++ b/plugins/testing-automation/.github/plugin/plugin.json
@@ -18,16 +18,16 @@
     "nunit"
   ],
   "agents": [
-    "./agents/tdd-red.md",
+    "./agents/playwright-tester.md",
     "./agents/tdd-green.md",
-    "./agents/tdd-refactor.md",
-    "./agents/playwright-tester.md"
+    "./agents/tdd-red.md",
+    "./agents/tdd-refactor.md"
   ],
   "skills": [
-    "./skills/playwright-explore-website/",
-    "./skills/playwright-generate-test/",
+    "./skills/ai-prompt-engineering-safety-review/",
     "./skills/csharp-nunit/",
     "./skills/java-junit/",
-    "./skills/ai-prompt-engineering-safety-review/"
+    "./skills/playwright-explore-website/",
+    "./skills/playwright-generate-test/"
   ]
 }

--- a/plugins/typespec-m365-copilot/.github/plugin/plugin.json
+++ b/plugins/typespec-m365-copilot/.github/plugin/plugin.json
@@ -16,8 +16,8 @@
     "microsoft-365"
   ],
   "skills": [
+    "./skills/typespec-api-operations/",
     "./skills/typespec-create-agent/",
-    "./skills/typespec-create-api-plugin/",
-    "./skills/typespec-api-operations/"
+    "./skills/typespec-create-api-plugin/"
   ]
 }


### PR DESCRIPTION
## Summary
- sort existing plugin manifest `agents` and `skills` entries alphabetically
- make `plugin:clean` normalize manifest spec arrays to canonical order
- fail plugin validation when plugin spec arrays are not alphabetically sorted

## Validation
- npm run plugin:clean
- npm run build
- npm run plugin:validate
- npm run skill:validate
- bash eng/fix-line-endings.sh