### PR TITLE
Fix contributor check risk parsing

### DIFF
--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -46,7 +46,6 @@ jobs:
           fi
 
       - name: Run profile check
-        id: profile
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -55,11 +54,8 @@ jobs:
             --username "${{ steps.author.outputs.username }}" \
             --json > /tmp/profile.json 2>/tmp/profile.log
           set -e
-          risk=$(jq -r '.risk // "UNKNOWN"' /tmp/profile.json 2>/dev/null || echo "UNKNOWN")
-          echo "risk=$risk" >> "$GITHUB_OUTPUT"
 
       - name: Run credential audit
-        id: credential
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -69,8 +65,48 @@ jobs:
             --repo "${{ github.repository }}" \
             --json > /tmp/cred.json 2>/tmp/cred.log
           set -e
-          risk=$(jq -r '.risk // "UNKNOWN"' /tmp/cred.json 2>/dev/null || echo "UNKNOWN")
-          echo "risk=$risk" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve check risks
+        id: results
+        run: |
+          extract_risk() {
+            file="$1"
+            fallback="$2"
+
+            if [ ! -s "$file" ]; then
+              echo "$fallback"
+              return
+            fi
+
+            risk=$(
+              jq -r '
+                [
+                  .risk,
+                  .overall_risk,
+                  .overallRisk,
+                  .result.risk,
+                  .result.overall_risk,
+                  .result.overallRisk
+                ]
+                | map(select(. != null and . != ""))
+                | .[0] // empty
+              ' "$file" 2>/dev/null \
+                | tr "[:lower:]" "[:upper:]" \
+                | tr -d "\r"
+            )
+
+            case "$risk" in
+              HIGH|MEDIUM|LOW|NONE|UNKNOWN) echo "$risk" ;;
+              "") echo "$fallback" ;;
+              *) echo "$fallback" ;;
+            esac
+          }
+
+          profile_risk=$(extract_risk /tmp/profile.json UNKNOWN)
+          credential_risk=$(extract_risk /tmp/cred.json UNKNOWN)
+
+          echo "profile=$profile_risk" >> "$GITHUB_OUTPUT"
+          echo "credential=$credential_risk" >> "$GITHUB_OUTPUT"
 
       - name: Compute overall risk
         id: overall
@@ -78,15 +114,21 @@ jobs:
           risk_to_num() {
             case "$1" in
               HIGH) echo 3 ;;
-              MEDIUM|UNKNOWN) echo 2 ;;
-              LOW) echo 1 ;;
-              *) echo 2 ;;
+              MEDIUM) echo 2 ;;
+              LOW|NONE) echo 1 ;;
+              UNKNOWN|"") echo 0 ;;
+              *) echo 0 ;;
             esac
           }
-          p=$(risk_to_num "${{ steps.profile.outputs.risk }}")
-          c=$(risk_to_num "${{ steps.credential.outputs.risk }}")
+          p=$(risk_to_num "${{ steps.results.outputs.profile }}")
+          c=$(risk_to_num "${{ steps.results.outputs.credential }}")
           max=$p; [ "$c" -gt "$max" ] && max=$c
-          case "$max" in 3) r="HIGH" ;; 2) r="MEDIUM" ;; 1) r="LOW" ;; *) r="MEDIUM" ;; esac
+          case "$max" in
+            3) r="HIGH" ;;
+            2) r="MEDIUM" ;;
+            1) r="LOW" ;;
+            *) r="UNKNOWN" ;;
+          esac
           echo "risk=$r" >> "$GITHUB_OUTPUT"
 
       - name: Comment on MEDIUM or HIGH risk
@@ -97,8 +139,8 @@ jobs:
           number="${{ steps.author.outputs.number }}"
           type="${{ steps.author.outputs.type }}"
           risk="${{ steps.overall.outputs.risk }}"
-          profile="${{ steps.profile.outputs.risk }}"
-          cred="${{ steps.credential.outputs.risk }}"
+          profile="${{ steps.results.outputs.profile }}"
+          cred="${{ steps.results.outputs.credential }}"
 
           if [ "$risk" = "HIGH" ]; then icon="🔴"; else icon="🟡"; fi
 
@@ -151,7 +193,7 @@ jobs:
             echo "## $icon Contributor Check: \`${{ steps.author.outputs.username }}\`"
             echo "| Check | Risk |"
             echo "|-------|------|"
-            echo "| Profile | ${{ steps.profile.outputs.risk }} |"
-            echo "| Credential | ${{ steps.credential.outputs.risk }} |"
+            echo "| Profile | ${{ steps.results.outputs.profile }} |"
+            echo "| Credential | ${{ steps.results.outputs.credential }} |"
             echo "| **Overall** | **$risk** |"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- normalize AGT risk extraction from the profile and credential JSON outputs
- stop treating empty or unknown per-check values as MEDIUM risk
- keep the comment and job summary aligned with the resolved risk values