### PR TITLE
Fix: jackson3 migration guide link

### DIFF
--- a/instructions/springboot-4-migration.instructions.md
+++ b/instructions/springboot-4-migration.instructions.md
@@ -1495,7 +1495,7 @@ tasks.withType<JavaExec> {
 - [Spring Boot 4.0 Migration Guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide)
 - [Spring Boot 4.0 Release Notes](https://github.com/spring-projects/spring-boot/releases)
 - [Spring Framework 7.0 Documentation](https://docs.spring.io/spring-framework/reference/)
-- [Jackson 3 Migration Guide](https://github.com/FasterXML/jackson/wiki/Jackson-3.0-Migration-Guide)
+- [Jackson 3 Migration Guide](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md)
 - [Kotlin 2.2 Release Notes](https://kotlinlang.org/docs/whatsnew22.html)
 
 ---


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [x] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

Navigating to `Jackson 3 Migration Guide` link resulted in a redirect to `https://github.com/FasterXML/jackson/wiki` with message "You do not have permission to update this wiki". This change introduces a working link to the guide.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [x] Update to existing instruction, prompt, agent, plugin, skill, or workflow.
- [ ] Other (please specify):

---

## Additional Notes

With this change, Copilot CLI was able to directly access the `Jackson 3 Migration Guide` without having to search for it itself during a Spring Boot 4 migration.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
