### PR TITLE
Add dotnet-test external plugin from dotnet/skills

### DIFF
--- a/plugins/external.json
+++ b/plugins/external.json
@@ -72,6 +72,24 @@
     }
   },
   {
+    "name": "dotnet-test",
+    "description": "Skills for running, diagnosing, and migrating .NET tests: test execution, filtering, platform detection, and MSTest workflows.",
+    "version": "0.1.0",
+    "author": {
+      "name": "Microsoft",
+      "url": "https://www.microsoft.com"
+    },
+    "homepage": "https://github.com/dotnet/skills",
+    "keywords": ["dotnet", "testing", "mstest", "unit-testing", "test-migration", "test-generation", "coverage", "testability"],
+    "license": "MIT",
+    "repository": "https://github.com/dotnet/skills",
+    "source": {
+      "source": "github",
+      "repo": "dotnet/skills",
+      "path": "plugins/dotnet-test"
+    }
+  },
+  {
   "name": "skills-for-copilot-studio",
   "description": "Microsoft Copilot Studio plugins for AI coding agents",
   "version": "1.0.3",


### PR DESCRIPTION
Adds the `dotnet-test` plugin as an external plugin reference pointing to [dotnet/skills](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test).

This plugin provides skills and agents for running, diagnosing, and migrating .NET tests — including test execution, filtering, platform detection, MSTest workflows, test generation, and testability migration.

Follows the same pattern as the existing `dotnet` and `dotnet-diag` entries.