### PR TITLE
Add microsoft-events plugin (Microsoft Build & Ignite sessions)

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -369,6 +369,30 @@
       }
     },
     {
+      "name": "microsoft-events",
+      "description": "Connect your project to Microsoft Build and Ignite sessions — discover relevant talks, explore what's new for your stack, and plan next steps from your development environment.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Microsoft",
+        "url": "https://www.microsoft.com"
+      },
+      "homepage": "https://github.com/microsoft/Build-CLI",
+      "keywords": [
+        "microsoft",
+        "build",
+        "ignite",
+        "events",
+        "sessions",
+        "learn"
+      ],
+      "license": "Apache-2.0",
+      "repository": "https://github.com/microsoft/Build-CLI",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/Build-CLI"
+      }
+    },
+    {
       "name": "modernize-dotnet",
       "description": "AI-powered .NET modernization and upgrade assistant. Helps upgrade .NET Framework and .NET applications to the latest versions of .NET.",
       "version": "1.0.1102-preview1",

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -8,7 +8,14 @@
       "url": "https://www.microsoft.com"
     },
     "homepage": "https://github.com/microsoft/Dataverse-skills",
-    "keywords": ["dataverse", "power-platform", "microsoft", "mcp", "python", "sdk"],
+    "keywords": [
+      "dataverse",
+      "power-platform",
+      "microsoft",
+      "mcp",
+      "python",
+      "sdk"
+    ],
     "license": "MIT",
     "repository": "https://github.com/microsoft/Dataverse-skills",
     "source": {
@@ -26,7 +33,14 @@
       "url": "https://www.microsoft.com"
     },
     "homepage": "https://github.com/microsoft/azure-skills",
-    "keywords": ["azure", "cloud", "infrastructure", "deployment", "microsoft", "devops"],
+    "keywords": [
+      "azure",
+      "cloud",
+      "infrastructure",
+      "deployment",
+      "microsoft",
+      "devops"
+    ],
     "license": "MIT",
     "repository": "https://github.com/microsoft/github-copilot-for-azure",
     "source": {
@@ -44,7 +58,16 @@
       "url": "https://www.microsoft.com"
     },
     "homepage": "https://github.com/dotnet/skills",
-    "keywords": ["dotnet", "csharp", "coding", "skills", "csharp-script", "single-file", "nuget-publishing", "pinvoke"],
+    "keywords": [
+      "dotnet",
+      "csharp",
+      "coding",
+      "skills",
+      "csharp-script",
+      "single-file",
+      "nuget-publishing",
+      "pinvoke"
+    ],
     "license": "MIT",
     "repository": "https://github.com/dotnet/skills",
     "source": {
@@ -62,7 +85,18 @@
       "url": "https://www.microsoft.com"
     },
     "homepage": "https://github.com/dotnet/skills",
-    "keywords": ["dotnet", "diagnostics", "performance", "debugging", "tracing", "symbolicate", "android-tombstone", "dump-collection", "microbenchmarking", "clr-activation"],
+    "keywords": [
+      "dotnet",
+      "diagnostics",
+      "performance",
+      "debugging",
+      "tracing",
+      "symbolicate",
+      "android-tombstone",
+      "dump-collection",
+      "microbenchmarking",
+      "clr-activation"
+    ],
     "license": "MIT",
     "repository": "https://github.com/dotnet/skills",
     "source": {
@@ -72,20 +106,27 @@
     }
   },
   {
-  "name": "skills-for-copilot-studio",
-  "description": "Microsoft Copilot Studio plugins for AI coding agents",
-  "version": "1.0.3",
-  "author": {
-    "name": "Microsoft Copilot Studio CAT Team",
-    "url": "https://www.microsoft.com"
+    "name": "skills-for-copilot-studio",
+    "description": "Microsoft Copilot Studio plugins for AI coding agents",
+    "version": "1.0.3",
+    "author": {
+      "name": "Microsoft Copilot Studio CAT Team",
+      "url": "https://www.microsoft.com"
     },
-  "homepage": "https://github.com/microsoft/skills-for-copilot-studio",
-  "keywords": ["copilot", "copilot-studio", "studio", "agent", "microsoft", "coding"],
-  "license": "MIT",
-  "repository": "https://github.com/microsoft/skills-for-copilot-studio",
-  "source": {
-    "source": "github",
-    "repo": "microsoft/skills-for-copilot-studio"
+    "homepage": "https://github.com/microsoft/skills-for-copilot-studio",
+    "keywords": [
+      "copilot",
+      "copilot-studio",
+      "studio",
+      "agent",
+      "microsoft",
+      "coding"
+    ],
+    "license": "MIT",
+    "repository": "https://github.com/microsoft/skills-for-copilot-studio",
+    "source": {
+      "source": "github",
+      "repo": "microsoft/skills-for-copilot-studio"
     }
   },
   {
@@ -97,7 +138,12 @@
       "url": "https://www.microsoft.com"
     },
     "homepage": "https://github.com/dotnet/modernize-dotnet",
-    "keywords": ["modernization", "upgrade", "migration", "dotnet"],
+    "keywords": [
+      "modernization",
+      "upgrade",
+      "migration",
+      "dotnet"
+    ],
     "license": "MIT",
     "repository": "https://github.com/dotnet/modernize-dotnet",
     "source": {
@@ -115,7 +161,18 @@
       "url": "https://www.microsoft.com"
     },
     "homepage": "https://learn.microsoft.com",
-    "keywords": ["microsoft", "azure", "dotnet", "windows", "api", "documentation", "rag", "dynamics", "powerbi", "code-samples"],
+    "keywords": [
+      "microsoft",
+      "azure",
+      "dotnet",
+      "windows",
+      "api",
+      "documentation",
+      "rag",
+      "dynamics",
+      "powerbi",
+      "code-samples"
+    ],
     "license": "MIT",
     "repository": "https://github.com/MicrosoftDocs/mcp",
     "source": {
@@ -132,7 +189,13 @@
       "url": "https://www.figma.com"
     },
     "homepage": "https://github.com/figma/mcp-server-guide",
-    "keywords": ["figma", "design", "mcp", "ui", "code-connect"],
+    "keywords": [
+      "figma",
+      "design",
+      "mcp",
+      "ui",
+      "code-connect"
+    ],
     "repository": "https://github.com/figma/mcp-server-guide",
     "source": {
       "source": "github",
@@ -141,14 +204,22 @@
   },
   {
     "name": "whatidid",
-    "description": "Turn your Copilot sessions into proof of impact — research-grounded HTML reports with effort estimation, skills analysis, and ROI metrics from local session logs.",
+    "description": "Turn your Copilot sessions into proof of impact \u2014 research-grounded HTML reports with effort estimation, skills analysis, and ROI metrics from local session logs.",
     "version": "1.0.0",
     "author": {
       "name": "Microsoft",
       "url": "https://www.microsoft.com"
     },
     "homepage": "https://github.com/microsoft/What-I-Did-Copilot",
-    "keywords": ["copilot", "productivity", "impact", "report", "estimation", "roi", "session-logs"],
+    "keywords": [
+      "copilot",
+      "productivity",
+      "impact",
+      "report",
+      "estimation",
+      "roi",
+      "session-logs"
+    ],
     "license": "MIT",
     "repository": "https://github.com/microsoft/What-I-Did-Copilot",
     "source": {
@@ -165,12 +236,47 @@
       "url": "https://github.com/Azure/git-ape"
     },
     "homepage": "https://github.com/Azure/git-ape",
-    "keywords": ["azure", "cloud", "infrastructure", "arm-templates", "deployment", "devops", "iac", "security", "cost-estimation", "github-actions"],
+    "keywords": [
+      "azure",
+      "cloud",
+      "infrastructure",
+      "arm-templates",
+      "deployment",
+      "devops",
+      "iac",
+      "security",
+      "cost-estimation",
+      "github-actions"
+    ],
     "license": "MIT",
     "repository": "https://github.com/Azure/git-ape",
     "source": {
       "source": "github",
       "repo": "Azure/git-ape"
+    }
+  },
+  {
+    "name": "microsoft-events",
+    "description": "Connect your project to Microsoft Build and Ignite sessions \u2014 discover relevant talks, explore what's new for your stack, and plan next steps from your development environment.",
+    "version": "1.0.0",
+    "author": {
+      "name": "Microsoft",
+      "url": "https://www.microsoft.com"
+    },
+    "homepage": "https://github.com/microsoft/Build-CLI",
+    "keywords": [
+      "microsoft",
+      "build",
+      "ignite",
+      "events",
+      "sessions",
+      "learn"
+    ],
+    "license": "Apache-2.0",
+    "repository": "https://github.com/microsoft/Build-CLI",
+    "source": {
+      "source": "github",
+      "repo": "microsoft/Build-CLI"
     }
   }
 ]


### PR DESCRIPTION
Adds the **microsoft-events** plugin to the external plugins registry. Rebased from #1680 onto `staged` as requested.

This skill connects developer projects to Microsoft Build and Ignite session catalogs. It reads project dependencies, maps them to Microsoft products, and searches the live session catalog for relevant talks.

**Capabilities:**
- Discover sessions relevant to your project's tech stack
- Explore what's new for specific Microsoft technologies
- Look up sessions by code
- Plan next steps after attending sessions

**Repository:** https://github.com/microsoft/Build-CLI
**npm package:** [@microsoft/events-cli](https://www.npmjs.com/package/@microsoft/events-cli)
**License:** Apache-2.0