### PR TITLE
fix(copilot-sdk-nodejs): correct assistant message delta event name

### DIFF
--- a/cookbook/copilot-sdk/nodejs/accessibility-report.md
+++ b/cookbook/copilot-sdk/nodejs/accessibility-report.md
@@ -90,7 +90,7 @@ async function main() {
     let idleResolve: (() => void) | null = null;
 
     session.on((event) => {
-        if (event.type === "assistant.message.delta") {
+        if (event.type === "assistant.message_delta") {
             process.stdout.write(event.data.deltaContent ?? "");
         } else if (event.type === "session.idle") {
             idleResolve?.();
@@ -179,7 +179,7 @@ main().catch(console.error);
 ## How it works
 
 1. **Playwright MCP server**: Configures a local MCP server running `@playwright/mcp` to provide browser automation tools
-2. **Streaming output**: Uses `streaming: true` and `assistant.message.delta` events for real-time token-by-token output
+2. **Streaming output**: Uses `streaming: true` and `assistant.message_delta` events for real-time token-by-token output
 3. **Accessibility snapshot**: Playwright's `browser_snapshot` tool captures the full accessibility tree of the page
 4. **Structured report**: The prompt engineers a consistent WCAG-aligned report format with emoji severity indicators
 5. **Test generation**: Optionally detects the project language and generates Playwright accessibility tests
@@ -212,7 +212,7 @@ Unlike `sendAndWait`, this recipe uses streaming for real-time output:
 
 ```typescript
 session.on((event) => {
-    if (event.type === "assistant.message.delta") {
+    if (event.type === "assistant.message_delta") {
         process.stdout.write(event.data.deltaContent ?? "");
     } else if (event.type === "session.idle") {
         idleResolve?.();

--- a/cookbook/copilot-sdk/nodejs/recipe/accessibility-report.ts
+++ b/cookbook/copilot-sdk/nodejs/recipe/accessibility-report.ts
@@ -55,7 +55,7 @@ async function main() {
     let idleResolve: (() => void) | null = null;
 
     session.on((event) => {
-        if (event.type === "assistant.message.delta") {
+        if (event.type === "assistant.message_delta") {
             process.stdout.write(event.data.deltaContent ?? "");
         } else if (event.type === "session.idle") {
             idleResolve?.();
@@ -72,12 +72,12 @@ async function main() {
 
     const prompt = `
     Use the Playwright MCP server to analyze the accessibility of this webpage: ${url}
-    
+
     Please:
     1. Navigate to the URL using playwright-browser_navigate
     2. Take an accessibility snapshot using playwright-browser_snapshot
     3. Analyze the snapshot and provide a detailed accessibility report
-    
+
     Format the report EXACTLY like this structure with emoji indicators:
 
     📊 Accessibility Report: [Page Title] (domain.com)
@@ -133,8 +133,8 @@ async function main() {
         const detectLanguagePrompt = `
         Analyze the current working directory to detect the primary programming language used in this project.
         Look for project files like package.json, *.csproj, pom.xml, requirements.txt, go.mod, etc.
-        
-        Respond with ONLY the detected language name (e.g., "TypeScript", "JavaScript", "C#", "Python", "Java") 
+
+        Respond with ONLY the detected language name (e.g., "TypeScript", "JavaScript", "C#", "Python", "Java")
         and a brief explanation of why you detected it.
         If no project is detected, suggest "TypeScript" as the default for Playwright tests.
         `;
@@ -151,7 +151,7 @@ async function main() {
 
         const testGenerationPrompt = `
         Based on the accessibility report you just generated for ${url}, create Playwright accessibility tests in ${language}.
-        
+
         The tests should:
         1. Verify all the accessibility checks from the report
         2. Test for the issues that were found (to ensure they get fixed)
@@ -167,7 +167,7 @@ async function main() {
            - Touch targets meet minimum size requirements
         4. Use Playwright's accessibility testing features
         5. Include helpful comments explaining each test
-        
+
         Output the complete test file that can be saved and run.
         Use the Playwright MCP server tools if you need to verify any page details.
         `;


### PR DESCRIPTION
The accessibility-report recipe and its companion doc used `"assistant.message.delta"` (dotted), which never matches the SDK event. The canonical name is `"assistant.message_delta"` (underscore), as documented in [`instructions/copilot-sdk-nodejs.instructions.md`](https://github.com/github/awesome-copilot/blob/main/instructions/copilot-sdk-nodejs.instructions.md) and used by the Python cookbook. Without this fix the streaming branch was dead and no incremental output was printed.


## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

> Note: this PR updates an existing copilot-sdk recipe rather than adding a new file, so the "new file" checkbox above is intentionally unchecked.

---

## Description

Fix an incorrect event-type literal in the Node.js Copilot SDK `accessibility-report` cookbook recipe and its companion documentation.

- **What was wrong:** Both [`cookbook/copilot-sdk/nodejs/recipe/accessibility-report.ts`](https://github.com/github/awesome-copilot/blob/97cc3f24602b6431b82dbce2afec7a1f3611664f/cookbook/copilot-sdk/nodejs/recipe/accessibility-report.ts) and [`cookbook/copilot-sdk/nodejs/accessibility-report.md`](https://github.com/github/awesome-copilot/blob/97cc3f24602b6431b82dbce2afec7a1f3611664f/cookbook/copilot-sdk/nodejs/accessibility-report.md) compared `event.type` against `"assistant.message.delta"` (dotted). The SDK never emits that string, so the streaming `if` branch was dead code — no incremental tokens were ever printed when running the recipe.
- **What's correct:** The canonical event name is `"assistant.message_delta"` (underscore). This is consistent with:
  - [`instructions/copilot-sdk-nodejs.instructions.md`](https://github.com/github/awesome-copilot/blob/main/instructions/copilot-sdk-nodejs.instructions.md) 
- **Effect of the fix:** The streaming output path in the Node.js recipe now actually fires, matching the behavior demonstrated in the other language cookbooks and described in the recipe's narrative.

Also cleans up trailing whitespace inside a few prompt template literals (no behavioral impact).

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [x] Update to existing instruction, prompt, agent, plugin, skill, or workflow.
- [ ] Other (please specify):

---

## Additional Notes

- Files changed: 2 (`cookbook/copilot-sdk/nodejs/recipe/accessibility-report.ts`, `cookbook/copilot-sdk/nodejs/accessibility-report.md`).
- No README change is expected from `npm start` because this PR does not add or rename any indexable file — please confirm before merging.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
