### PR TITLE
Fix ghs_ token detection regex to support new token format

### DIFF
--- a/hooks/secrets-scanner/scan-secrets.sh
+++ b/hooks/secrets-scanner/scan-secrets.sh
@@ -30,7 +30,7 @@ PATTERNS=(
   # GitHub tokens
   "GITHUB_PAT|critical|ghp_[0-9A-Za-z]{36}"
   "GITHUB_OAUTH|critical|gho_[0-9A-Za-z]{36}"
-  "GITHUB_APP_TOKEN|critical|ghs_[0-9A-Za-z]{36}"
+  "GITHUB_APP_TOKEN|critical|ghs_[0-9A-Za-z._-]{36,}"
   "GITHUB_REFRESH_TOKEN|critical|ghr_[0-9A-Za-z]{36}"
   "GITHUB_FINE_GRAINED_PAT|critical|github_pat_[0-9A-Za-z_]{82}"
 


### PR DESCRIPTION
Updates the `ghs_` token regex to support the new token format which allows dots, underscores, and dashes (`[A-Za-z0-9._-]`) and variable length (no longer fixed at 36 chars).

See the changelog: https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/
Tracking in Slack: [#tmp-stateless-app-tokens](https://github-grid.enterprise.slack.com/archives/C0AH8M0MVUK)
Part of: github/authentication#6826

---

Replaces #1827 (was broken by target branch change).