### PR TITLE
docs: clarify .NET Framework project formats

### DIFF
--- a/instructions/dotnet-framework.instructions.md
+++ b/instructions/dotnet-framework.instructions.md
@@ -10,20 +10,25 @@ applyTo: '**/*.csproj, **/*.cs'
 
 ## Project File Management
 
-### Non-SDK Style Project Structure
-.NET Framework projects use the legacy project format, which differs significantly from modern SDK-style projects:
+### Legacy and SDK-Style Project Structure
+Many .NET Framework projects use the legacy non-SDK project format, which differs significantly from modern SDK-style projects. However, SDK-style project files can also target .NET Framework, such as `net48` or `net472`. Check the `.csproj` format before applying project-file guidance:
 
-- **Explicit File Inclusion**: All new source files **MUST** be explicitly added to the project file (`.csproj`) using a `<Compile>` element
-  - .NET Framework projects do not automatically include files in the directory like SDK-style projects
+- **Legacy non-SDK projects**: All new source files **MUST** be explicitly added to the project file (`.csproj`) using a `<Compile>` element
+  - Legacy non-SDK projects do not automatically include files in the directory like SDK-style projects
   - Example: `<Compile Include="Path\To\NewFile.cs" />`
 
-- **No Implicit Imports**: Unlike SDK-style projects, .NET Framework projects do not automatically import common namespaces or assemblies
+- **SDK-style projects**: If the project file has an `Sdk` attribute, use SDK-style conventions even when it targets .NET Framework
+  - Example: `<Project Sdk="Microsoft.NET.Sdk">`
+  - Uses `<TargetFramework>` instead of `<TargetFrameworkVersion>`
+  - Example: `<TargetFramework>net48</TargetFramework>`
+
+- **No Implicit Imports in legacy projects**: Unlike SDK-style projects, legacy non-SDK projects do not automatically import common namespaces or assemblies
  
-- **Build Configuration**: Contains explicit `<PropertyGroup>` sections for Debug/Release configurations
+- **Build Configuration in legacy projects**: Contains explicit `<PropertyGroup>` sections for Debug/Release configurations
 
-- **Output Paths**: Explicit `<OutputPath>` and `<IntermediateOutputPath>` definitions
+- **Output Paths in legacy projects**: Explicit `<OutputPath>` and `<IntermediateOutputPath>` definitions
 
-- **Target Framework**: Uses `<TargetFrameworkVersion>` instead of `<TargetFramework>`
+- **Target Framework in legacy projects**: Uses `<TargetFrameworkVersion>` instead of `<TargetFramework>`
   - Example: `<TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>`
 
 ## NuGet Package Management


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [x] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

Clarifies the .NET Framework instruction file so it no longer treats all .NET Framework projects as legacy non-SDK-style projects.

Many older .NET Framework projects do use legacy project files, but SDK-style projects can also target .NET Framework, for example `net48` or `net472`. This update scopes the explicit file inclusion and `<TargetFrameworkVersion>` guidance to legacy non-SDK projects, while noting that SDK-style projects should use SDK-style conventions such as `<TargetFramework>net48</TargetFramework>`.

Fixes #1693.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [x] Update to existing instruction, prompt, agent, plugin, skill, or workflow.
- [ ] Other (please specify):

---

## Additional Notes

Validation run locally:

- `git diff --check`
- `npm run build`
- `npm run plugin:validate`
- `npm run skill:validate`

`npm run build` reported README and generated marketplace output were already up to date after this docs-only change.

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
