### PR TITLE
Clarify that Set-ItResult ends the It block (Pester v5 Skip section)

### DIFF
--- a/instructions/powershell-pester-5.instructions.md
+++ b/instructions/powershell-pester-5.instructions.md
@@ -121,6 +121,7 @@ Invoke-Pester -TagFilter 'Unit' -ExcludeTagFilter 'Slow'
 - **`-Skip`**: Available on `Describe`, `Context`, and `It` to skip tests
 - **Conditional**: Use `-Skip:$condition` for dynamic skipping
 - **Runtime Skip**: Use `Set-ItResult -Skipped` during test execution (setup/teardown still run)
+- **Ends the test body**: `Set-ItResult -Skipped`/`-Inconclusive` throws internally to end the `It` block, so code after it does not run; a trailing `return` is unreachable and should not be added
 
 ```powershell
 It 'Should work on Windows' -Skip:(-not $IsWindows) { }


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

Adds one bullet to the **Skip** section of `instructions/powershell-pester-5.instructions.md`
clarifying that `Set-ItResult -Skipped`/`-Inconclusive` *ends* the current `It` block:

> - **Ends the test body**: `Set-ItResult -Skipped`/`-Inconclusive` throws internally to end the
>   `It` block, so code after it does not run; a trailing `return` is unreachable and should not be
>   added

The existing "Runtime Skip" bullet notes that setup/teardown still run, but doesn't say the call
ends the current test body. Without that, it's a common mistake to add a `return` after
`Set-ItResult` — automated reviewers (including Copilot's PR reviewer) recurrently suggest it —
which is unreachable dead code.

This is verified by Pester's implementation: `Set-ItResult` ends in
`throw [Pester.Factory]::CreateErrorRecord(...)`, which unwinds the `It` block for Pester to catch
and record as the result. Confirmed empirically on Pester 5.7.1: an `It` that calls
`Set-ItResult -Skipped` followed by `throw` reports **Skipped**, not Failed — the statement after
the skip never executes.

---

## Type of Contribution

- [x] Update to existing instruction, prompt, agent, plugin, skill, or workflow.

---

## Additional Notes

- Docs-only, single-line addition; no frontmatter change.
- `npm start` (`update-readme` + `generate-marketplace`) produces no diff to `README.md` or
  `marketplace.json`, since the change is in the file body rather than its title/description.
- "Tested with GitHub Copilot" is left unchecked because this is a factual clarification of Pester's
  runtime behavior rather than a new Copilot-facing instruction; the claim is verified against
  Pester's source and runtime as described above.

By submitting this pull request, I confirm that my contribution abides by the Code of Conduct and
will be licensed under the MIT License.
