### PR TITLE
Normalize merged external-plugin PR labels

### DIFF
--- a/.github/workflows/external-plugin-approval-command.yml
+++ b/.github/workflows/external-plugin-approval-command.yml
@@ -3,6 +3,8 @@ name: External Plugin Approval Commands
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [closed]
 
 permissions:
   contents: write
@@ -13,6 +15,7 @@ jobs:
   handle-command:
     runs-on: ubuntu-latest
     if: >-
+      github.event_name == 'issue_comment' &&
       !github.event.issue.pull_request &&
       (contains(github.event.comment.body, '/approve') || contains(github.event.comment.body, '/reject'))
     steps:
@@ -404,6 +407,65 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: issueNumber,
                 state: 'closed'
+              });
+            }
+
+  sync-merged-pr-labels:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'external-plugin')
+    steps:
+      - name: Normalize merged external plugin PR labels
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const staleLabels = ['awaiting-review', 'awaiting-approval', 'ready-for-review', 'rejected'];
+
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'approved',
+                color: '1D76DB',
+                description: 'Submission was approved by a maintainer'
+              });
+            } catch (error) {
+              if (error.status !== 422) {
+                throw error;
+              }
+            }
+
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100
+            });
+            const labelNames = new Set(currentLabels.map((label) => label.name));
+
+            if (!labelNames.has('approved')) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: ['approved']
+              });
+            }
+
+            for (const labelName of staleLabels) {
+              if (!labelNames.has(labelName)) {
+                continue;
+              }
+
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                name: labelName
               });
             }
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

When external plugin catalog PRs are merged, they can keep stale state labels like `awaiting-review` or `rejected`. This change ensures merged PRs labeled `external-plugin` are normalized to the approved end state.

It updates the external plugin approval workflow to also run on merged pull requests, adds `approved` if needed, and removes stale state labels (`awaiting-review`, `awaiting-approval`, `ready-for-review`, `rejected`). It also gates the existing issue-comment command job to issue_comment events so both triggers can share the workflow safely.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [x] Update to existing instruction, prompt, agent, plugin, skill, or workflow.
- [ ] Other (please specify):

---

## Additional Notes

N/A

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.