### PR TITLE
Add Ivy Tendril to CLI Tools

### DIFF
--- a/website/data/tools.yml
+++ b/website/data/tools.yml
@@ -434,3 +434,32 @@ tools:
       - planning
       - scheduling
       - mcp
+
+  - id: ivy-tendril
+    name: Ivy Tendril
+    description: >-
+      Open-source AI coding orchestrator that manages GitHub Copilot, Claude Code,
+      Codex, Antigravity, and OpenCode through a plan-based lifecycle. Decomposes tasks
+      into structured plans, dispatches agents in isolated git worktrees, runs automated
+      verification gates (build, test, lint, format, AI review), and accumulates
+      self-improving memory across sessions. Local-first desktop app.
+    category: CLI Tools
+    featured: false
+    requirements:
+      - Windows, macOS, or Linux
+      - At least one supported coding agent installed (GitHub Copilot CLI, Claude Code, Codex, etc.)
+    links:
+      github: https://github.com/Ivy-Interactive/Ivy-Tendril
+      documentation: https://tendril.ivy.app/getting-started/installation
+    features:
+      - "🔄 Plan lifecycle: Idea → plan → execute → verify → PR in a structured pipeline"
+      - "🤖 Agent-agnostic: Orchestrates Copilot, Claude Code, Codex, Antigravity, OpenCode"
+      - "✅ Verification gates: Build, test, lint, format, and AI review before human sees the diff"
+      - "🧠 Self-improving: Agents learn your codebase conventions through persistent memory"
+      - "🌳 Git worktree isolation: Each task runs in its own worktree"
+    tags:
+      - orchestration
+      - multi-agent
+      - verification
+      - worktree
+      - local-first


### PR DESCRIPTION
## Summary

Adds **Ivy Tendril** to the Tools catalog under **CLI Tools**.

Ivy Tendril is an open-source AI coding orchestrator that manages GitHub Copilot (alongside Claude Code, Codex, Antigravity, and OpenCode) through a plan-based lifecycle with verification gates, self-improving memory, and git worktree isolation.

## Why CLI Tools?

Tendril is a desktop app that orchestrates coding agents — including Copilot CLI — through structured pipelines. It sits alongside other CLI Tools like "Swarm Orchestrator" (which also coordinates multiple agents in worktrees) and "APM" (which manages agent packages across Copilot and others).

## Links

- GitHub: https://github.com/Ivy-Interactive/Ivy-Tendril
- Website: https://tendril.ivy.app
- License: FSL (converts to Apache 2.0 after 2 years)

## Checklist

- [x] Targets `staged` branch
- [x] Only modifies `website/data/tools.yml`
- [x] Follows the tools schema (id, name, description, category, links, features, tags)
- [x] Tool is actively maintained