### PR TITLE
docs: add SignalSpore MCP tool listing

### DIFF
--- a/website/data/tools.yml
+++ b/website/data/tools.yml
@@ -41,6 +41,51 @@ tools:
       - search
       - install
 
+  - id: signalspore-mcp
+    name: SignalSpore MCP
+    description: >-
+      Model-aware preflight MCP server for coding agents. SignalSpore gates risky tasks
+      before shell commands, migrations, deploys, database resets, and brittle integrations;
+      returns trap-aware execution briefs; and records safe post-task deltas with live receipts.
+    category: MCP Servers
+    featured: false
+    requirements:
+      - Node.js 18 or higher
+      - npm
+      - A SignalSpore policy ID and write token from https://www.signalspore.com/setup
+    links:
+      github: https://github.com/yeahdog/signalspore-mcp
+      documentation: https://www.signalspore.com/mcp
+    features:
+      - "Local gate: skip, quick_check, or full_preflight before risky agent work"
+      - "Protected preflight: trap-aware briefs with stop conditions and expected checks"
+      - "Safe delta loop: submit sanitized post-task outcomes tied to the original session/card"
+      - "Live receipts: operators can verify first-run activity at signalspore.com/live"
+    configuration:
+      type: json
+      content: |
+        {
+          "servers": {
+            "signalspore": {
+              "type": "stdio",
+              "command": "npx",
+              "args": ["-y", "github:yeahdog/signalspore-mcp"],
+              "env": {
+                "SIGNALSPORE_BASE_URL": "https://www.signalspore.com",
+                "SIGNALSPORE_AGENT_POLICY_ID": "policy_your_agent_here",
+                "SIGNALSPORE_WRITE_TOKEN": "sspwt_your_write_token_here"
+              }
+            }
+          }
+        }
+    tags:
+      - mcp
+      - coding-agents
+      - preflight
+      - safety
+      - guardrails
+      - risk-management
+
   - id: chatcrystal
     name: ChatCrystal
     description: >-

--- a/website/data/tools.yml
+++ b/website/data/tools.yml
@@ -69,7 +69,7 @@ tools:
             "signalspore": {
               "type": "stdio",
               "command": "npx",
-              "args": ["-y", "github:yeahdog/signalspore-mcp"],
+              "args": ["-y", "@yeahdog/signalspore-mcp"],
               "env": {
                 "SIGNALSPORE_BASE_URL": "https://www.signalspore.com",
                 "SIGNALSPORE_AGENT_POLICY_ID": "policy_your_agent_here",


### PR DESCRIPTION
## Summary
- add SignalSpore MCP to the Awesome Copilot Tools catalog under MCP Servers
- include the public GitHub npx install path and Copilot-compatible MCP config snippet
- describe the risky-task preflight loop for shell, migration, deploy, database reset, and brittle integration work

## Why
SignalSpore needs real external agent activity, not just internal/non-Hermes candidate events. Listing the MCP server where GitHub Copilot operators browse MCP-compatible tools gives outside users a direct copy-paste path to create live receipts on https://www.signalspore.com/live.

## Validation
- Confirmed `website/data/tools.yml` contains the new `signalspore-mcp` entry
- Confirmed the config uses `npx -y github:yeahdog/signalspore-mcp`
- SignalSpore MCP repo has a public smoke-test issue for independent operator provenance: https://github.com/yeahdog/signalspore-mcp/issues/1

## Maintainer trust note

I withdrew duplicate early directory submissions and kept only the accepted TensorBlock listing plus this focused PR, so this submission is not part of an ongoing broad self-promotion sweep. The MCP package and docs remain public at https://github.com/yeahdog/signalspore-mcp.