### PR TITLE
fix: correct workflow paths and directory references

### DIFF
--- a/.github/workflows/duplicate-resource-detector.md
+++ b/.github/workflows/duplicate-resource-detector.md
@@ -1,5 +1,5 @@
 ---
-description: Weekly scan of agents, instructions, and skills to identify potential duplicate resources and report them for review
+description: Weekly scan of agents, instructions, skills, hooks, and workflows to identify potential duplicate resources and report them for review
 on:
   schedule: weekly
 permissions:
@@ -28,6 +28,9 @@ Scan all resources in the following directories and identify groups of resources
 - `agents/` (`.agent.md` files)
 - `instructions/` (`.instructions.md` files)
 - `skills/` (folders — check `SKILL.md` inside each)
+- `hooks/` (folders — check `README.md` inside each)
+- `workflows/` (`.md` files)
+- `plugins/` (folders — check `.github/plugin/plugin.json` inside each)
 
 ### Step 1: Gather Resource Metadata
 
@@ -38,7 +41,7 @@ For each resource, extract:
 3. **Front matter `name`** field (if present)
 4. **First ~20 lines of body content** (the markdown after the front matter)
 
-Use bash to read files efficiently. For skills, read `skills/<name>/SKILL.md`.
+Use bash to read files efficiently. For skills, read `skills/<name>/SKILL.md`. For hooks, read `hooks/<name>/README.md`. For workflows, read the `.md` files directly in the `workflows/` directory. For plugins, read `.github/plugin/plugin.json` inside each plugin folder.
 
 ### Step 2: Identify Potential Duplicates
 
@@ -50,6 +53,7 @@ Compare resources and flag groups that look like potential duplicates. Consider 
 - **Cross-type overlap** — an agent and an instruction (or instruction and skill) that cover the same topic so thoroughly that one may make the other redundant
 
 Be pragmatic. Resources that cover related but distinct topics are NOT duplicates. For example:
+
 - `react.instructions.md` (general React coding standards) and `react-testing.agent.md` (React testing agent) are **not** duplicates — they serve different purposes.
 - `python-fastapi.instructions.md` and `python-flask.instructions.md` are **not** duplicates — they target different frameworks.
 - `code-review.agent.md` and `code-review.instructions.md` that both do the same style of code review **are** potential duplicates worth flagging.
@@ -63,6 +67,7 @@ Search for issues with label "duplicate-review" that are closed
 ```
 
 Read the comments and body of those past issues to find any pairs or groups that reviewers have explicitly marked as **"accepted"** or **"not duplicates"**. Look for phrases like:
+
 - "accepted as-is"
 - "not duplicates"
 - "intentionally separate"
@@ -123,4 +128,6 @@ Use `<details>` blocks to collapse groups if there are more than 10.
 - Include cross-type duplicates (e.g., an agent and an instruction doing the same thing).
 - Limit the report to the top 20 most likely duplicate groups to keep it actionable.
 - For skills, use the folder name and description from `SKILL.md`.
+- For hooks, use the folder name and description from `README.md`.
+- For plugins, use the folder name and description from `.github/plugin/plugin.json`.
 - Process resources in batches to stay within time limits — prioritize name and description comparison, then spot-check content for top candidates.

--- a/.github/workflows/learning-hub-updater.md
+++ b/.github/workflows/learning-hub-updater.md
@@ -23,17 +23,17 @@ safe-outputs:
 
 # Check for Awesome GitHub Copilot Updates
 
-You are a documentation maintainer for the Awesome GitHub Copilot Learning Hub. Your job is to check for recent updates to GitHub Copilot and determine if the Learning Hub pages in `website/learning-hub` need updating.
+You are a documentation maintainer for the Awesome GitHub Copilot Learning Hub. Your job is to check for recent updates to GitHub Copilot and determine if the Learning Hub pages in `website/src/content/docs/learning-hub` need updating.
 
 ## Step 1 — Gather recent Copilot updates
 
 Use `web-fetch` to read the following pages and extract the latest entries from the past 7 days:
 
-- https://github.blog/changelog/label/copilot/ — official changelog
-- https://github.com/github/copilot-cli/blob/main/changelog.md — CLI changelog
-- https://github.blog/ai-and-ml/github-copilot/ — blog posts
-- https://code.visualstudio.com/updates - VS Code release notes (filter for Copilot-related updates)
-- https://nishanil.github.io/copilot-guide/ - community-maintained guide (check for recent commits or updates)
+- <https://github.blog/changelog/label/copilot/> — official changelog
+- <https://github.com/github/copilot-cli/blob/main/changelog.md> — CLI changelog
+- <https://github.blog/ai-and-ml/github-copilot/> — blog posts
+- <https://code.visualstudio.com/updates> - VS Code release notes (filter for Copilot-related updates)
+- <https://nishanil.github.io/copilot-guide/> - community-maintained guide (check for recent commits or updates)
 
 Also use `gh` CLI to check the latest releases and commits in the `github/copilot-cli` repo.
 
@@ -61,17 +61,17 @@ If there is nothing new or everything is already up to date, stop here and repor
 
 If updates are needed, make a decision on whether a new page needs to be added (e.g., for a major new feature) or if existing pages can be updated with new sections.
 
-### For new pages:
+### For new pages
 
 A new page should be created for major features or capabilities that warrant their own documentation (e.g., a new feature of Copilot, a new pattern for working with Copilot, etc.).
 
 To create a new page:
 
-1. Create a new markdown file in the appropriate section of `website/learning-hub` (e.g., `website/learning-hub/agents/new-agent.md`).
+1. Create a new markdown file in the appropriate section of `website/src/content/docs/learning-hub` (e.g., `website/src/content/docs/learning-hub/new-topic.md`).
 2. Write a summary of the new feature, how it works, and its use cases.
 3. Add a "Further Reading" section with links to official documentation, blog posts, and relevant community resources.
 
-### For updates to existing pages:
+### For updates to existing pages
 
 If the new information can be added to existing pages, edit those pages to include refinements, new sections, or updated information as needed. Make sure to update any relevant links in the "Further Reading" sections.
 

--- a/.github/workflows/pr-duplicate-check.md
+++ b/.github/workflows/pr-duplicate-check.md
@@ -1,5 +1,5 @@
 ---
-description: 'Checks PRs for potential duplicate agents, instructions, skills, and workflows already in the repository'
+description: 'Checks PRs for potential duplicate agents, instructions, skills, hooks, workflows, and plugins already in the repository'
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -34,10 +34,12 @@ Filter for files in these resource directories:
 - `agents/` (`.agent.md` files)
 - `instructions/` (`.instructions.md` files)
 - `skills/` (folders — the SKILL.md inside each folder is the resource)
+- `hooks/` (folders — the README.md inside each folder is the resource)
 - `workflows/` (`.md` files)
+- `plugins/` (folders — the `.github/plugin/plugin.json` inside each folder is the resource)
 
 If **no files** from these directories were modified, call `noop` with the message:
-"No agent, instruction, skill, or workflow files were changed in this PR — no duplicate check needed."
+"No agent, instruction, skill, hook, workflow, or plugin files were changed in this PR — no duplicate check needed."
 
 ## Step 2: Read Metadata for the PR's New Resources
 
@@ -57,7 +59,9 @@ Read all existing resources in the repository (excluding files that are part of 
 - `agents/` (`.agent.md` files)
 - `instructions/` (`.instructions.md` files)
 - `skills/` (folders — read `SKILL.md` inside each)
+- `hooks/` (folders — read `README.md` inside each)
 - `workflows/` (`.md` files)
+- `plugins/` (folders — read `.github/plugin/plugin.json` inside each)
 
 For each, extract the same metadata: file path, description, name field, and first ~20 lines.
 
@@ -71,6 +75,7 @@ Compare the PR's new resources against the existing repository resources. Flag p
 - **Cross-type overlap** — an agent and an instruction (or skill) that cover the same topic so thoroughly that one may make the other redundant
 
 Be pragmatic. Resources that cover related but distinct topics are **not** duplicates:
+
 - `react.instructions.md` (general React coding standards) and `react-testing.agent.md` (React testing agent) → **not** duplicates
 - `python-fastapi.instructions.md` and `python-flask.instructions.md` → **not** duplicates (different frameworks)
 - `code-review.agent.md` and `code-review.instructions.md` that both enforce the same style rules → **potential** duplicate
@@ -92,8 +97,8 @@ This PR adds resources that may be similar to existing ones in the repository. P
 
 | Resource | Type | Description |
 |----------|------|-------------|
-| `<new file from this PR>` | <Agent/Instruction/Skill/Workflow> | <description> |
-| `<existing file in repo>` | <Agent/Instruction/Skill/Workflow> | <description> |
+| `<new file from this PR>` | <Agent/Instruction/Skill/Hook/Workflow/Plugin> | <description> |
+| `<existing file in repo>` | <Agent/Instruction/Skill/Hook/Workflow/Plugin> | <description> |
 
 **Why flagged:** <Brief explanation of the similarity>
 
@@ -117,4 +122,6 @@ Call `noop` with the message: "No potential duplicate resources detected in this
 - Sort groups by confidence: strongest duplicate signal first.
 - Limit the report to the top **5** most likely duplicate groups to keep feedback actionable.
 - For skills, report by folder name (e.g., `skills/my-skill/`) using the description from `SKILL.md`.
+- For hooks, report by folder name (e.g., `hooks/my-hook/`) using the description from `README.md`.
+- For plugins, report by folder name (e.g., `plugins/my-plugin/`) using the description from `.github/plugin/plugin.json`.
 - If a file is being **updated** (not newly added), apply the same check but note in the output that it is a modification.

--- a/.github/workflows/resource-staleness-report.md
+++ b/.github/workflows/resource-staleness-report.md
@@ -1,5 +1,5 @@
 ---
-description: Weekly report identifying stale and aging resources across agents, prompts, instructions, hooks, and skills folders
+description: Weekly report identifying stale and aging resources across agents, instructions, hooks, skills, workflows, and plugins folders
 on:
   schedule: weekly
 permissions:
@@ -23,10 +23,11 @@ You are an AI agent that audits the resources in this repository to identify one
 Analyze all files in the following directories to determine when each file last had a **major** (substantive) change committed:
 
 - `agents/` (`.agent.md` files)
-- `prompts/` (`.prompt.md` files)
 - `instructions/` (`.instructions.md` files)
-- `hooks/` (folders — check the folder's files)
 - `skills/` (folders — check the folder's files)
+- `hooks/` (folders — check the folder's files)
+- `workflows/` (`.md` files)
+- `plugins/` (folders — check `.github/plugin/plugin.json` inside each)
 
 ### What Counts as a Major Change
 
@@ -53,7 +54,7 @@ This gives the most recent commit that **modified** (not just renamed) the file.
 git log -1 --format="%H %ai" --diff-filter=A -- <filepath>
 ```
 
-For hook and skill folders, check all files within the folder and use the **most recent** major change date across any file in that folder.
+For hook, skill, and plugin folders, check all files within the folder and use the **most recent** major change date across any file in that folder.
 
 ### Classification
 
@@ -106,7 +107,7 @@ Organize the issue body as follows:
 
 | Resource | Type | Last Major Change | Days Ago |
 |----------|------|-------------------|----------|
-| `prompts/example.prompt.md` | Prompt | 2025-02-01 | 20 |
+| `workflows/example.md` | Workflow | 2025-02-01 | 20 |
 
 ### Deep Review: 10 Oldest Stale Resources
 
@@ -128,8 +129,8 @@ Use `<details>` blocks to collapse sections with more than 15 entries.
 
 ## Guidelines
 
-- Process all resource types: agents, prompts, instructions, hooks, and skills.
-- For **hooks** and **skills**, treat the entire folder as one resource. Report it by folder name and use the most recent change date of any file within.
+- Process all resource types: agents, instructions, skills, hooks, workflows, and plugins.
+- For **hooks**, **skills**, and **plugins**, treat the entire folder as one resource. Report it by folder name and use the most recent change date of any file within.
 - Sort tables by "Days Ago" descending (oldest first).
 - After building the stale table, inspect the **10 oldest stale resources** in more depth and include the deeper review section.
 - In the deeper review, prefer **high-signal issues**: outdated version assumptions, deprecated APIs, misleading instructions, harmful heuristics, unsafe defaults, or instructions that are scoped too broadly.


### PR DESCRIPTION
## Changes
- Fix learning-hub-updater path to website/src/content/docs/learning-hub
- Remove prompts references and align resource scans to existing directories
- Add missing plugins coverage in duplicate detection workflow guidance
- Align duplicate-check workflow metadata, templates, and noop messaging

## Scope
- 4 workflow markdown files only

## Notes
- Target branch is staged, per repository contribution guidelines