### PR TITLE
Update modernize-dotnet plugin to 1.0.1152-preview1

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -474,7 +474,7 @@
     {
       "name": "modernize-dotnet",
       "description": "AI-powered .NET modernization and upgrade assistant. Helps upgrade .NET Framework and .NET applications to the latest versions of .NET.",
-      "version": "1.0.1146-preview1",
+      "version": "1.0.1152-preview1",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -276,7 +276,7 @@
   {
     "name": "modernize-dotnet",
     "description": "AI-powered .NET modernization and upgrade assistant. Helps upgrade .NET Framework and .NET applications to the latest versions of .NET.",
-    "version": "1.0.1146-preview1",
+    "version": "1.0.1152-preview1",
     "author": {
       "name": "Microsoft",
       "url": "https://www.microsoft.com"


### PR DESCRIPTION
Automated update of modernize-dotnet plugin registry entry from UpgradeAssistant build main-20260602.2 (version 1.0.1152-preview1).