### PR TITLE
fix(excalidraw-diagram-generator): force UTF-8 stdout so add-arrow/add-icon don't crash on Windows

### DIFF
--- a/skills/excalidraw-diagram-generator/scripts/add-arrow.py
+++ b/skills/excalidraw-diagram-generator/scripts/add-arrow.py
@@ -233,6 +233,9 @@ def add_arrow_to_diagram(
 
 def main():
     """Main entry point."""
+    if hasattr(sys.stdout, "reconfigure"):
+        # Ensure consistent UTF-8 output on Windows consoles.
+        sys.stdout.reconfigure(encoding="utf-8")
     if len(sys.argv) < 6:
         print("Usage: python add-arrow.py <diagram_path> <from_x> <from_y> <to_x> <to_y> [OPTIONS]")
         print("\nOptions:")

--- a/skills/excalidraw-diagram-generator/scripts/add-icon-to-diagram.py
+++ b/skills/excalidraw-diagram-generator/scripts/add-icon-to-diagram.py
@@ -329,6 +329,9 @@ def add_icon_to_diagram(
 
 def main():
     """Main entry point."""
+    if hasattr(sys.stdout, "reconfigure"):
+        # Ensure consistent UTF-8 output on Windows consoles.
+        sys.stdout.reconfigure(encoding="utf-8")
     if len(sys.argv) < 5:
         print("Usage: python add-icon-to-diagram.py <diagram_path> <icon_name> <x> <y> [OPTIONS]")
         print("\nOptions:")


### PR DESCRIPTION
## Problem

On Windows, `add-arrow.py` and `add-icon-to-diagram.py` crash at the very end of an otherwise
successful run. Both finish by printing a check mark, e.g.:

```python
print(f"✓ Successfully added arrow to diagram")
```

On a standard Windows console Python's stdout uses the `cp1252` code page, which cannot encode
`U+2713` (✓). That print raises `UnicodeEncodeError`, so the script exits with code **1 even though it
has already saved the file**. The edit lands, but any caller that checks the exit code sees a failure.
It is also easy to misdiagnose, because the traceback goes to stdout while stderr stays empty.

Repro (Windows, default code page):

```
python add-arrow.py diagram.excalidraw 0 0 100 100 --label "x"
...
Saving diagram
Error: 'charmap' codec can't encode character '✓' in position 0: character maps to <undefined>
# exit code 1, but diagram.excalidraw WAS modified
```

This makes the two scripts unreliable when driven from automation (or any tool that checks exit codes)
on Windows.

## Fix

Reconfigure stdout to UTF-8 at the start of `main()` in both scripts. This is the **same guard already
used by `split-excalidraw-library.py`** in the same `scripts/` directory, so this just brings the other
two scripts in line:

```python
if hasattr(sys.stdout, "reconfigure"):
    # Ensure consistent UTF-8 output on Windows consoles.
    sys.stdout.reconfigure(encoding="utf-8")
```

No behavior change on macOS/Linux; on Windows the success message now prints and the script exits 0.

## Verification

On Windows with the default cp1252 console:

- before: `add-arrow.py ...` -> exit 1, `charmap` error raised after the file was already saved
- after: `add-arrow.py ...` -> prints `✓ Successfully added arrow to diagram`, exit 0

Two files, +3/-0 each, no functional change beyond the encoding fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
