### PR TITLE
fix: skill-validator invocation for .github/plugin/plugin.json convention

### DIFF
--- a/eng/external-plugin-quality-gates.mjs
+++ b/eng/external-plugin-quality-gates.mjs
@@ -156,13 +156,32 @@ function downloadSkillValidator(workDir) {
   return binaryPath;
 }
 
+// Ordered list of candidate locations for plugin.json, from most to least specific.
+// The skill-validator --plugin mode expects plugin.json at the plugin root, but
+// both the Copilot CLI and many external repos use nested conventions. We read the
+// manifest ourselves so skill/agent paths can be resolved from the plugin root
+// consistently, regardless of where the manifest lives.
+const PLUGIN_JSON_CANDIDATES = [
+  [".github", "plugin", "plugin.json"],
+  [".plugins", "plugin.json"],
+  ["plugin.json"],
+];
+
+function findPluginJson(pluginRoot) {
+  for (const segments of PLUGIN_JSON_CANDIDATES) {
+    const candidate = path.join(pluginRoot, ...segments);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 function buildSkillValidatorArgs(pluginRoot) {
-  // External plugins (and the Copilot CLI) use the .github/plugin/plugin.json convention,
-  // but skill-validator --plugin expects plugin.json at the plugin root. Read the manifest
-  // ourselves and pass --skills / --agents so the validator sees the right paths.
-  const pluginJsonPath = path.join(pluginRoot, ".github", "plugin", "plugin.json");
-  if (!fs.existsSync(pluginJsonPath)) {
-    // Fallback: let the validator try --plugin directly (handles non-standard layouts).
+  const pluginJsonPath = findPluginJson(pluginRoot);
+  if (!pluginJsonPath) {
+    // No recognised plugin.json location found — let the validator fail with its
+    // own diagnostic (covers exotic layouts and surfaces the real error to submitters).
     return ["check", "--verbose", "--plugin", pluginRoot];
   }
 
@@ -170,13 +189,14 @@ function buildSkillValidatorArgs(pluginRoot) {
   try {
     pluginJson = JSON.parse(fs.readFileSync(pluginJsonPath, "utf8"));
   } catch {
-    // Malformed plugin.json — let the validator surface the error via --plugin.
+    // Malformed plugin.json — let the validator surface the parse error.
     return ["check", "--verbose", "--plugin", pluginRoot];
   }
 
   const args = ["check", "--verbose"];
 
-  // Use [].concat() to handle both array and scalar string values in plugin.json.
+  // Paths in plugin.json are relative to the plugin root regardless of where
+  // plugin.json itself lives. Use [].concat() to accept both string and array values.
   const skillPaths = [].concat(pluginJson.skills ?? [])
     .map((s) => path.resolve(pluginRoot, s))
     .filter((p) => fs.existsSync(p));
@@ -204,7 +224,8 @@ function buildSkillValidatorArgs(pluginRoot) {
   }
 
   if (skillPaths.length === 0 && agentPaths.length === 0) {
-    // Nothing to validate via --skills/--agents; fall back to --plugin.
+    // plugin.json found but no resolvable skills/agents — fall back to --plugin so the
+    // validator can surface the specific validation error to the submitter.
     return ["check", "--verbose", "--plugin", pluginRoot];
   }
 

--- a/eng/external-plugin-quality-gates.mjs
+++ b/eng/external-plugin-quality-gates.mjs
@@ -156,10 +156,66 @@ function downloadSkillValidator(workDir) {
   return binaryPath;
 }
 
+function buildSkillValidatorArgs(pluginRoot) {
+  // External plugins (and the Copilot CLI) use the .github/plugin/plugin.json convention,
+  // but skill-validator --plugin expects plugin.json at the plugin root. Read the manifest
+  // ourselves and pass --skills / --agents so the validator sees the right paths.
+  const pluginJsonPath = path.join(pluginRoot, ".github", "plugin", "plugin.json");
+  if (!fs.existsSync(pluginJsonPath)) {
+    // Fallback: let the validator try --plugin directly (handles non-standard layouts).
+    return ["check", "--verbose", "--plugin", pluginRoot];
+  }
+
+  let pluginJson;
+  try {
+    pluginJson = JSON.parse(fs.readFileSync(pluginJsonPath, "utf8"));
+  } catch {
+    // Malformed plugin.json — let the validator surface the error via --plugin.
+    return ["check", "--verbose", "--plugin", pluginRoot];
+  }
+
+  const args = ["check", "--verbose"];
+
+  // Use [].concat() to handle both array and scalar string values in plugin.json.
+  const skillPaths = [].concat(pluginJson.skills ?? [])
+    .map((s) => path.resolve(pluginRoot, s))
+    .filter((p) => fs.existsSync(p));
+
+  // Agent entries may be directory paths or explicit file paths; normalise to directories
+  // so AgentDiscovery.DiscoverAgentsInDirectory can discover agents within them.
+  // Deduplicate in case multiple file entries share the same parent directory.
+  const agentPaths = [...new Set(
+    [].concat(pluginJson.agents ?? [])
+      .map((a) => {
+        const resolved = path.resolve(pluginRoot, a);
+        if (fs.existsSync(resolved) && fs.statSync(resolved).isFile()) {
+          return path.dirname(resolved);
+        }
+        return resolved;
+      })
+      .filter((p) => fs.existsSync(p))
+  )];
+
+  if (skillPaths.length > 0) {
+    args.push("--skills", ...skillPaths);
+  }
+  if (agentPaths.length > 0) {
+    args.push("--agents", ...agentPaths);
+  }
+
+  if (skillPaths.length === 0 && agentPaths.length === 0) {
+    // Nothing to validate via --skills/--agents; fall back to --plugin.
+    return ["check", "--verbose", "--plugin", pluginRoot];
+  }
+
+  return args;
+}
+
 function runSkillValidatorGate(workDir, pluginRoot) {
   try {
     const validatorBinary = downloadSkillValidator(workDir);
-    const check = runCommand(validatorBinary, ["check", "--verbose", "--plugin", pluginRoot]);
+    const args = buildSkillValidatorArgs(pluginRoot);
+    const check = runCommand(validatorBinary, args);
 
     if (check.exitCode === 0) {
       return { status: "pass", output: check.output };


### PR DESCRIPTION
## Problem

The `skill-validator --plugin <dir>` mode expects `plugin.json` at `<dir>/plugin.json`. But external plugins use a variety of locations for their manifest:

- `.github/plugin/plugin.json` — Copilot CLI convention, used by most external plugins  
- `.plugins/plugin.json` — alternate convention used by some repos
- `plugin.json` at root — what the validator natively handles

This caused every external plugin using nested conventions to fail the `skill-validator` quality gate with a misleading `❌ No plugin.json found` error — even when the install smoke test passed correctly. The `copilot-goal-skill` submission (issue #1806) is a concrete example.

## Root cause

From [dotnet/skills `CheckCommand.cs`](https://github.com/dotnet/skills/blob/main/eng/skill-validator/src/Check/CheckCommand.cs):

```csharp
var pluginJsonPath = Path.Combine(fullPath, "plugin.json");
if (!File.Exists(pluginJsonPath))
{
    Console.Error.WriteLine($"❌ No plugin.json found in '{pluginDir}'");
    return 1;
}
```

The validator expects `plugin.json` at the plugin root only. Additionally, `PluginDiscovery.ParsePluginJson` resolves `skills`/`agents` paths relative to the `plugin.json` directory — so passing `.github/plugin` as the plugin dir would look for skills at `.github/plugin/skills/…` instead of the plugin root.

## Fix

Extract `findPluginJson()` + `buildSkillValidatorArgs()` in `eng/external-plugin-quality-gates.mjs`:

1. Probe three candidate locations in priority order: `.github/plugin/plugin.json`, `.plugins/plugin.json`, `plugin.json`
2. When found, read `skills`/`agents` paths — always resolved relative to the **plugin root** (not wherever `plugin.json` lives)
3. Invoke the validator with `--skills`/`--agents` flags instead of `--plugin`
4. Fall back to `--plugin pluginRoot` only when no recognised location exists or when skills/agents can't be resolved (surfaces the real error to submitters)

Additional robustness: `[].concat()` handles both string and array `skills`/`agents` values; agent directory deduplication prevents passing the same dir twice.

**Why this is safe**: The `--skills`/`--agents` mode still validates all SKILL.md frontmatter, description length limits, and agent files. The install smoke test already covers `plugin.json` structural validity.

Closes #1806 (unblocks re-running quality gates once this lands)