### PR TITLE
fix: respect all manifest locations in smoke-test post-install verification

### DIFF
--- a/eng/external-plugin-quality-gates.mjs
+++ b/eng/external-plugin-quality-gates.mjs
@@ -161,6 +161,7 @@ function downloadSkillValidator(workDir) {
 // both the Copilot CLI and many external repos use nested conventions. We read the
 // manifest ourselves so skill/agent paths can be resolved from the plugin root
 // consistently, regardless of where the manifest lives.
+// NOTE: Keep in sync with EXTERNAL_PLUGIN_ROOT_MANIFEST_PATHS in external-plugin-validation.mjs
 const PLUGIN_JSON_CANDIDATES = [
   [".github", "plugin", "plugin.json"],
   [".plugins", "plugin.json"],
@@ -307,11 +308,17 @@ function runInstallSmokeGate(workDir, plugin) {
     }
 
     const installedPluginPath = path.join(homeDir, ".copilot", "installed-plugins", "external-plugin-intake", plugin.name);
-    const pluginManifestPath = path.join(installedPluginPath, ".github", "plugin", "plugin.json");
-    if (!fs.existsSync(installedPluginPath) || !fs.existsSync(pluginManifestPath)) {
+    if (!fs.existsSync(installedPluginPath)) {
       return {
         status: "fail",
-        output: `Plugin installed but expected files were missing at ${installedPluginPath}`,
+        output: `Plugin installed but install directory was not found at ${installedPluginPath}`,
+      };
+    }
+    const pluginManifestPath = findPluginJson(installedPluginPath);
+    if (!pluginManifestPath) {
+      return {
+        status: "fail",
+        output: `Plugin installed but no plugin.json was found in any recognized location under ${installedPluginPath}`,
       };
     }
 

--- a/eng/external-plugin-validation.mjs
+++ b/eng/external-plugin-validation.mjs
@@ -23,10 +23,11 @@ export const EXTERNAL_PLUGIN_POLICIES = Object.freeze({
   }),
 });
 
+// NOTE: Keep in sync with PLUGIN_JSON_CANDIDATES in external-plugin-quality-gates.mjs
 const EXTERNAL_PLUGIN_ROOT_MANIFEST_PATHS = Object.freeze([
   "plugin.json",
   ".github/plugin/plugin.json",
-  ".plugin/plugin.json",
+  ".plugins/plugin.json",
 ]);
 
 function resolvePolicy(policy) {


### PR DESCRIPTION
## Problem

Two related location-handling bugs in the external plugin validation pipeline, surfaced while investigating issue #1837:

### 1. Hardcoded manifest path in install smoke-test verification

`runInstallSmokeGate` was hardcoding `.github/plugin/plugin.json` as the expected post-install manifest location:

```js
const pluginManifestPath = path.join(installedPluginPath, ".github", "plugin", "plugin.json");
if (!fs.existsSync(installedPluginPath) || !fs.existsSync(pluginManifestPath)) {
  return { status: "fail", ... };
}
```

This caused a false `fail` for plugins whose manifest lives at `plugin.json` (root) or `.plugins/plugin.json` — even when `copilot plugin install` succeeded. The `findPluginJson()` helper already exists in the same file to probe all three candidate locations; it just wasn't being used here.

### 2. `.plugin/` vs `.plugins/` inconsistency

`EXTERNAL_PLUGIN_ROOT_MANIFEST_PATHS` in `external-plugin-validation.mjs` listed `.plugin/plugin.json` (singular), but `PLUGIN_JSON_CANDIDATES` in `external-plugin-quality-gates.mjs` (the actual lookup logic) uses `.plugins/plugin.json` (plural). A submitter seeing the error message referencing `.plugin/plugin.json` would try a path that `findPluginJson` never actually checks.

## Fix

- Replace the hardcoded manifest path with `findPluginJson(installedPluginPath)`, matching the approach used in `buildSkillValidatorArgs`
- Split the single existence check into two with distinct error messages ("install directory not found" vs "no plugin.json found in recognized location") for clearer diagnosis
- Fix `.plugin/plugin.json` → `.plugins/plugin.json` in `EXTERNAL_PLUGIN_ROOT_MANIFEST_PATHS`
- Add cross-reference comments on both constants so they stay in sync when new manifest conventions are added

> **Note:** Issue #1837 also raises a concern about API rate-limit responses being misclassified as "tag not found". That is a separate issue and not addressed in this PR.