### PR TITLE
Add og:image dimensions for better social cards

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,45 @@
+# Awesome GitHub Copilot website
+
+Astro + Starlight site published to <https://awesome-copilot.github.com/>.
+
+## Local development
+
+Run these from the **repository root** (they generate the data the site needs first):
+
+```bash
+npm run website:data    # generate public/data/*.json from repo content
+npm run website:dev     # generate data + start the dev server
+npm run website:build   # full production build
+```
+
+## Social preview cards (LinkedIn, etc.)
+
+Shared links render as large preview cards driven by Open Graph / Twitter meta tags.
+LinkedIn (and most platforms) read **Open Graph** — primarily `og:image` — while Twitter/X
+also uses `twitter:card=summary_large_image`. Most tags are produced automatically:
+
+- **Starlight defaults** emit `og:title`, `og:description`, `og:url`, `og:type`,
+  `og:site_name`, and `twitter:card=summary_large_image`.
+- **`astro.config.mjs`** (global `head`) emits the shared image tags: `og:image`,
+  `og:image:width`, `og:image:height`, `og:image:alt`, and `twitter:image`.
+- **`src/components/Head.astro`** adds `twitter:title`/`description`, `og:image:secure_url`,
+  `og:image:type`, and `twitter:image:alt`.
+
+Each page's `title` and `description` (StarlightPage frontmatter) flow into the card text,
+so keep them clear and benefit-focused.
+
+### The image-dimension invariant
+
+`og:image:width` / `og:image:height` in `astro.config.mjs` describe `public/images/social-image.png`
+(currently **2400×1260**, ~1.91:1). Crawlers use these dimensions to understand the image and
+may use them when selecting/rendering the preview. If you swap the image or add a per-page image
+override, update the **full** image set so every tag stays consistent: `og:image`,
+`og:image:width`, `og:image:height`, `og:image:alt`, and `twitter:image` (the last one matters
+because `Head.astro` derives `og:image:secure_url` from `twitter:image` first).
+
+### After deploying
+
+LinkedIn caches scrapes aggressively. To force a refresh and confirm the card renders, run the
+changed URL through the [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/).
+HTML output alone doesn't prove the live card — verify the deployed image returns HTTP 200 over
+HTTPS with `Content-Type: image/png` and no auth.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -6,7 +6,13 @@ import pagefindResources from "./src/integrations/pagefind-resources";
 const site = "https://awesome-copilot.github.com/";
 const siteDescription =
   "Community-contributed agents, instructions, and skills to enhance your GitHub Copilot experience";
+// Social preview image used for all Open Graph / Twitter cards (e.g. LinkedIn, which is
+// Open Graph-driven). socialImageWidth/Height MUST match the actual pixels of social-image.png.
+// If a page ever overrides og:image, also override og:image:width/height and twitter:image
+// (Head.astro derives og:image:secure_url from twitter:image first).
 const socialImageUrl = new URL("/images/social-image.png", site).toString();
+const socialImageWidth = "2400";
+const socialImageHeight = "1260";
 
 // https://astro.build/config
 export default defineConfig({
@@ -25,6 +31,20 @@ export default defineConfig({
           attrs: {
             property: "og:image",
             content: socialImageUrl,
+          },
+        },
+        {
+          tag: "meta",
+          attrs: {
+            property: "og:image:width",
+            content: socialImageWidth,
+          },
+        },
+        {
+          tag: "meta",
+          attrs: {
+            property: "og:image:height",
+            content: socialImageHeight,
           },
         },
         {


### PR DESCRIPTION
## What this does

If you've ever dropped an `awesome-copilot.github.com` link into LinkedIn and gotten a sad little thumbnail instead of a proper card, this is for you.

The good news: most of the Open Graph plumbing was already here. Starlight emits the title, description, URL, and `twitter:card`. Our `astro.config.mjs` wires up an absolute `og:image`, and `Head.astro` fills in the secure URL, type, and the Twitter tags. The image itself (`social-image.png`) is already the right shape — 2400×1260, roughly the 1.91:1 ratio the platforms want, and well under the size limit.

The one thing missing was telling crawlers how big that image is. So this adds `og:image:width` and `og:image:height` to the global head. LinkedIn leans on Open Graph, and giving it the dimensions up front makes it far more likely to render the big card on the first scrape instead of guessing.

No image generation, no new dependencies, no per-page share pages. Just the missing two tags.

## What's in here

- **`website/astro.config.mjs`** — adds `og:image:width` (2400) and `og:image:height` (1260) to the global head, right next to the existing `og:image`. I pulled the values into named constants and left a comment so the next person knows they have to stay in sync with the actual PNG.
- **`website/README.md`** — there wasn't one, so I added it. It explains which layer emits which tags, the dimension invariant, and the bit everyone forgets: LinkedIn caches aggressively, so run changed URLs through the [Post Inspector](https://www.linkedin.com/post-inspector/) after deploy to force a refresh.

## How I checked it

Ran `npm run website:build` and grepped `dist/**/*.html`. The home page plus the agents and skills pages all come out with exactly one of each tag — absolute `og:image`, the new width/height, `twitter:card=summary_large_image` — and each page keeps its own title and description.

One caveat worth saying out loud: the build only catches hard breakage, not someone quietly removing a tag down the road. We don't have any social-meta validation in CI today. Happy to add a small check for that in a follow-up if we want the guardrail.