### PR TITLE
Add soft-gate PR risk scan automation for agentic PRs

### DIFF
--- a/.github/workflows/pr-risk-scan-comment.yml
+++ b/.github/workflows/pr-risk-scan-comment.yml
@@ -16,6 +16,8 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
     steps:
       - name: Download scan artifact
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pr-risk-scan-results
@@ -32,7 +34,7 @@ jobs:
             const prNumberPath = 'pr-number.txt';
 
             if (!fs.existsSync(reportPath)) {
-              core.setFailed('Risk scan report.md artifact was not found.');
+              core.warning('Risk scan report.md artifact was not found. Skipping comment update.');
               return;
             }
 
@@ -64,7 +66,7 @@ jobs:
             }
 
             if (!prNumber) {
-              core.setFailed('Could not determine PR number for comment upsert.');
+              core.warning('Could not determine PR number for comment upsert. Skipping.');
               return;
             }
 

--- a/.github/workflows/pr-risk-scan-comment.yml
+++ b/.github/workflows/pr-risk-scan-comment.yml
@@ -1,0 +1,86 @@
+name: PR Risk Scan — Comment
+
+on:
+  workflow_run:
+    workflows: ["PR Risk Scan — Gate"]
+    types: [completed]
+
+permissions:
+  issues: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download scan artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr-risk-scan-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Upsert PR comment
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- pr-risk-scan-results -->';
+            const reportPath = 'report.md';
+            const prNumberPath = 'pr-number.txt';
+
+            if (!fs.existsSync(reportPath)) {
+              core.setFailed('Risk scan report.md artifact was not found.');
+              return;
+            }
+
+            const body = fs.readFileSync(reportPath, 'utf8');
+            let prNumber = null;
+
+            if (fs.existsSync(prNumberPath)) {
+              const parsed = parseInt(fs.readFileSync(prNumberPath, 'utf8').trim(), 10);
+              if (!Number.isNaN(parsed)) {
+                prNumber = parsed;
+              }
+            }
+
+            if (!prNumber) {
+              const fallback = context.payload.workflow_run.pull_requests?.[0]?.number;
+              if (fallback) {
+                prNumber = fallback;
+              }
+            }
+
+            if (!prNumber) {
+              core.setFailed('Could not determine PR number for comment upsert.');
+              return;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              console.log(`Updated existing risk scan comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              console.log('Created new risk scan comment');
+            }

--- a/.github/workflows/pr-risk-scan-comment.yml
+++ b/.github/workflows/pr-risk-scan-comment.yml
@@ -36,9 +36,19 @@ jobs:
               return;
             }
 
-            const body = fs.readFileSync(reportPath, 'utf8');
-            let prNumber = null;
+            let body = fs.readFileSync(reportPath, 'utf8');
 
+            // Treat artifact content as untrusted (the gate workflow runs on PR code).
+            // Prevent spam/notification abuse and avoid API failures on oversized bodies.
+            body = body.replace(/@/g, '@\u200b');
+            const maxLength = 65000;
+            if (body.length > maxLength) {
+              body = `${body.slice(0, maxLength)}\n\n_...(truncated)..._`;
+            }
+            if (!body.includes(marker)) {
+              body = `${marker}\n${body}`;
+            }
+            let prNumber = null;
             if (fs.existsSync(prNumberPath)) {
               const parsed = parseInt(fs.readFileSync(prNumberPath, 'utf8').trim(), 10);
               if (!Number.isNaN(parsed)) {

--- a/.github/workflows/pr-risk-scan.yml
+++ b/.github/workflows/pr-risk-scan.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: read
-  actions: read
 
 jobs:
   scan:
@@ -34,16 +33,42 @@ jobs:
       - name: Run PR risk scanner
         run: |
           mkdir -p pr-risk-results
+          set +e
           node ./eng/pr-risk-scan.mjs \
             --files changed-files.txt \
             --output-json pr-risk-results/results.json \
             --output-md pr-risk-results/report.md
+          scan_exit_code=$?
+          set -e
+
+          if [ $scan_exit_code -ne 0 ]; then
+            cat > pr-risk-results/results.json <<EOF
+          {
+            "generated_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+            "scanner_status": "error",
+            "finding_count": 0,
+            "severity_counts": { "high": 0, "medium": 0, "info": 0 },
+            "findings": [],
+            "error": "Scanner failed. See workflow logs."
+          }
+          EOF
+            cat > pr-risk-results/report.md <<'EOF'
+          <!-- pr-risk-scan-results -->
+          ## 🔒 PR Risk Scan Results
+          
+          Scanner execution failed for this run, so findings could not be generated.
+          
+          > This is a soft-gate report. Please inspect the workflow logs for diagnostics.
+          EOF
+          fi
+          echo "$scan_exit_code" > pr-risk-results/scan-exit-code.txt
 
       - name: Save metadata
         run: |
           echo "${{ github.event.pull_request.number }}" > pr-risk-results/pr-number.txt
 
       - name: Upload scan artifact
+        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: pr-risk-scan-results

--- a/.github/workflows/pr-risk-scan.yml
+++ b/.github/workflows/pr-risk-scan.yml
@@ -1,0 +1,51 @@
+name: PR Risk Scan — Gate
+
+on:
+  pull_request:
+    branches: [staged]
+    types: [opened, synchronize, reopened]
+    paths:
+      - "skills/**"
+      - "agents/**"
+      - "workflows/**"
+      - "plugins/**"
+      - "hooks/**"
+      - "instructions/**"
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Collect changed files
+        run: |
+          git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" > changed-files.txt
+          echo "Changed files:"
+          cat changed-files.txt || true
+
+      - name: Run PR risk scanner
+        run: |
+          mkdir -p pr-risk-results
+          node ./eng/pr-risk-scan.mjs \
+            --files changed-files.txt \
+            --output-json pr-risk-results/results.json \
+            --output-md pr-risk-results/report.md
+
+      - name: Save metadata
+        run: |
+          echo "${{ github.event.pull_request.number }}" > pr-risk-results/pr-number.txt
+
+      - name: Upload scan artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: pr-risk-scan-results
+          path: pr-risk-results/
+          retention-days: 1

--- a/eng/pr-risk-scan.mjs
+++ b/eng/pr-risk-scan.mjs
@@ -217,7 +217,7 @@ function scanSkillScriptPath(filePath, findings) {
   }
 
   addFinding(findings, {
-    rule_id: "skill-script-added",
+    rule_id: "skill-script-touched",
     severity: severityLevels.info,
     file: normalized,
     line: 1,

--- a/eng/pr-risk-scan.mjs
+++ b/eng/pr-risk-scan.mjs
@@ -340,8 +340,19 @@ function main() {
 
     scanSkillScriptPath(relativePath, findings);
 
-    if (!fs.existsSync(absolutePath) || !fs.statSync(absolutePath).isFile()) {
+    if (!fs.existsSync(absolutePath)) {
       skippedFiles.push(relativePath);
+      continue;
+    }
+
+    const stat = fs.statSync(absolutePath);
+    if (!stat.isFile()) {
+      skippedFiles.push(relativePath);
+      continue;
+    }
+
+    if (stat.size > 1024 * 1024) {
+      skippedFiles.push(`${relativePath} (skipped: file too large)`);
       continue;
     }
 

--- a/eng/pr-risk-scan.mjs
+++ b/eng/pr-risk-scan.mjs
@@ -207,7 +207,10 @@ function scanLineRules(filePath, content, findings) {
 
 function scanSkillScriptPath(filePath, findings) {
   const normalized = filePath.replace(/\\/g, "/");
-  if (!normalized.startsWith("skills/")) {
+  const isSkillScript =
+    normalized.startsWith("skills/") ||
+    /^plugins\/[^/]+\/skills\//.test(normalized);
+  if (!isSkillScript) {
     return;
   }
 

--- a/eng/pr-risk-scan.mjs
+++ b/eng/pr-risk-scan.mjs
@@ -148,7 +148,7 @@ function normalizeRelativePath(value) {
     return "";
   }
 
-  if (cleaned.includes("..")) {
+  if (/(^|\/)\.\.(\/|$)/.test(cleaned)) {
     throw new Error(`Unsafe relative path in changed files list: ${value}`);
   }
 

--- a/eng/pr-risk-scan.mjs
+++ b/eng/pr-risk-scan.mjs
@@ -270,9 +270,15 @@ function toMarkdownReport(findings, scannedFiles, skippedFiles) {
           : finding.severity === severityLevels.medium
           ? "🟠"
           : "ℹ️";
-      const match = finding.match.replace(/\|/g, "\\|");
+      const match = finding.match
+        .replace(/\\/g, "\\\\")
+        .replace(/`/g, "\\`")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/\|/g, "\\|")
+        .replace(/@/g, "@\u200b");
       summary.push(
-        `| ${severity} | \`${finding.rule_id}\` | \`${finding.file}\` | ${finding.line} | ${match} |`
+        `| ${severity} | \`${finding.rule_id}\` | \`${finding.file}\` | ${finding.line} | \`${match}\` |`
       );
     }
 

--- a/eng/pr-risk-scan.mjs
+++ b/eng/pr-risk-scan.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+import path from "path";
+
+const SCRIPT_EXTENSIONS = new Set([
+  ".sh",
+  ".bash",
+  ".ps1",
+  ".py",
+  ".js",
+  ".mjs",
+  ".ts",
+]);
+
+const severityLevels = {
+  high: "high",
+  medium: "medium",
+  info: "info",
+};
+
+const LINE_RULES = [
+  {
+    rule_id: "guardrail-bypass-language",
+    severity: severityLevels.high,
+    regex:
+      /\b(ignore (all|any|previous) (guardrails?|rules?|instructions?)|bypass (the )?(guardrails?|safety|policy)|disable (safety|guardrails?)|do not ask (for )?(confirmation|consent)|without prompting (the )?user)\b/i,
+    reason: "Language suggests bypassing policy or confirmation controls.",
+    suggested_fix:
+      "Require explicit policy adherence and user-confirmation steps for risky actions.",
+  },
+  {
+    rule_id: "remote-shell-execution",
+    severity: severityLevels.high,
+    regex: /\b(curl|wget)\b[^\n|]*\|\s*(sh|bash|zsh|pwsh|powershell)\b/i,
+    reason: "Piping remote content directly to a shell is high-risk.",
+    suggested_fix:
+      "Download, verify integrity/signature, and run from a reviewed local file.",
+  },
+  {
+    rule_id: "autoyes-package-exec",
+    severity: severityLevels.high,
+    regex:
+      /\b(npx|npm\s+exec|pnpm\s+dlx|uvx|pipx\s+run)\b[^\n]*\s(-y|--yes)\b/i,
+    reason:
+      "Auto-yes execution can bypass human review of package/runtime prompts.",
+    suggested_fix:
+      "Remove automatic consent flags and require explicit reviewer-approved invocation.",
+  },
+  {
+    rule_id: "package-exec-command",
+    severity: severityLevels.medium,
+    regex: /\b(npx|npm\s+exec|pnpm\s+dlx|uvx|pipx\s+run|uv\s+tool\s+run)\b/i,
+    reason: "Dynamic package/runtime execution introduces supply-chain risk.",
+    suggested_fix:
+      "Pin exact versions and document manual confirmation controls.",
+  },
+  {
+    rule_id: "unpinned-version-indicator",
+    severity: severityLevels.medium,
+    regex: /\B@latest\b|\blatest\b|\*|(\^|~)\d+/i,
+    reason: "Unpinned dependencies can change behavior between runs.",
+    suggested_fix: "Use exact immutable versions or commit hashes.",
+    shouldApply: (line) =>
+      /\b(npm|pnpm|yarn|npx|uvx|pip|pipx|cargo|go)\b/i.test(line),
+  },
+];
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (!key.startsWith("--")) {
+      continue;
+    }
+
+    args[key.slice(2)] = argv[i + 1];
+    i += 1;
+  }
+  return args;
+}
+
+function ensureParentDir(filePath) {
+  const directory = path.dirname(filePath);
+  fs.mkdirSync(directory, { recursive: true });
+}
+
+function normalizeRelativePath(value) {
+  const cleaned = String(value || "")
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^\.\/+/, "");
+  if (!cleaned) {
+    return "";
+  }
+
+  if (cleaned.includes("..")) {
+    throw new Error(`Unsafe relative path in changed files list: ${value}`);
+  }
+
+  return cleaned;
+}
+
+function isPotentialText(contentBuffer) {
+  const nullByte = contentBuffer.includes(0x00);
+  return !nullByte;
+}
+
+function addFinding(findings, finding) {
+  findings.push({
+    rule_id: finding.rule_id,
+    severity: finding.severity,
+    file: finding.file,
+    line: finding.line,
+    match: finding.match.slice(0, 180),
+    reason: finding.reason,
+    suggested_fix: finding.suggested_fix,
+  });
+}
+
+function scanLineRules(filePath, content, findings) {
+  const lines = content.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    for (const rule of LINE_RULES) {
+      if (typeof rule.shouldApply === "function" && !rule.shouldApply(line)) {
+        continue;
+      }
+
+      const match = line.match(rule.regex);
+      if (!match) {
+        continue;
+      }
+
+      addFinding(findings, {
+        rule_id: rule.rule_id,
+        severity: rule.severity,
+        file: filePath,
+        line: index + 1,
+        match: line.trim(),
+        reason: rule.reason,
+        suggested_fix: rule.suggested_fix,
+      });
+    }
+  }
+}
+
+function scanSkillScriptPath(filePath, findings) {
+  const normalized = filePath.replace(/\\/g, "/");
+  if (!normalized.startsWith("skills/")) {
+    return;
+  }
+
+  const extension = path.extname(normalized).toLowerCase();
+  if (!SCRIPT_EXTENSIONS.has(extension)) {
+    return;
+  }
+
+  addFinding(findings, {
+    rule_id: "skill-script-added",
+    severity: severityLevels.info,
+    file: normalized,
+    line: 1,
+    match: normalized,
+    reason:
+      "Script asset under a skill may require external runtime/dependencies.",
+    suggested_fix:
+      "Document dependencies, pin versions, and avoid implicit network installs.",
+  });
+}
+
+function severityCounts(findings) {
+  return findings.reduce(
+    (acc, finding) => {
+      acc[finding.severity] = (acc[finding.severity] || 0) + 1;
+      return acc;
+    },
+    { high: 0, medium: 0, info: 0 }
+  );
+}
+
+function toMarkdownReport(findings, scannedFiles, skippedFiles) {
+  const marker = "<!-- pr-risk-scan-results -->";
+  const counts = severityCounts(findings);
+  const summary = [
+    marker,
+    "## 🔒 PR Risk Scan Results",
+    "",
+    `Scanned **${scannedFiles.length}** changed file(s).`,
+    "",
+    "| Severity | Count |",
+    "|---|---:|",
+    `| 🔴 High | ${counts.high} |`,
+    `| 🟠 Medium | ${counts.medium} |`,
+    `| ℹ️ Info | ${counts.info} |`,
+    "",
+  ];
+
+  if (findings.length === 0) {
+    summary.push(
+      "✅ No matching risk patterns were detected in changed files."
+    );
+  } else {
+    summary.push("| Severity | Rule | File | Line | Match |");
+    summary.push("|---|---|---|---:|---|");
+    for (const finding of findings.slice(0, 100)) {
+      const severity =
+        finding.severity === severityLevels.high
+          ? "🔴"
+          : finding.severity === severityLevels.medium
+          ? "🟠"
+          : "ℹ️";
+      const match = finding.match.replace(/\|/g, "\\|");
+      summary.push(
+        `| ${severity} | \`${finding.rule_id}\` | \`${finding.file}\` | ${finding.line} | ${match} |`
+      );
+    }
+
+    if (findings.length > 100) {
+      summary.push(
+        "",
+        `_${findings.length - 100} additional finding(s) omitted from table._`
+      );
+    }
+  }
+
+  if (skippedFiles.length > 0) {
+    summary.push(
+      "",
+      "<details>",
+      "<summary>Skipped non-text or missing files</summary>",
+      ""
+    );
+    summary.push(skippedFiles.map((filePath) => `- ${filePath}`).join("\n"));
+    summary.push("", "</details>");
+  }
+
+  summary.push(
+    "",
+    "> This is an automated soft-gate report. Findings indicate review targets and do not block merge by themselves."
+  );
+
+  return `${summary.join("\n")}\n`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.files || !args["output-json"] || !args["output-md"]) {
+    throw new Error(
+      "Usage: node ./eng/pr-risk-scan.mjs --files <changed-files.txt> --output-json <results.json> --output-md <report.md>"
+    );
+  }
+
+  const changedFilesPath = path.resolve(args.files);
+  const outputJsonPath = path.resolve(args["output-json"]);
+  const outputMarkdownPath = path.resolve(args["output-md"]);
+
+  const changedFiles = fs
+    .readFileSync(changedFilesPath, "utf8")
+    .split(/\r?\n/)
+    .map(normalizeRelativePath)
+    .filter(Boolean);
+
+  const findings = [];
+  const scannedFiles = [];
+  const skippedFiles = [];
+
+  for (const relativePath of changedFiles) {
+    const absolutePath = path.resolve(relativePath);
+    scanSkillScriptPath(relativePath, findings);
+
+    if (!fs.existsSync(absolutePath) || !fs.statSync(absolutePath).isFile()) {
+      skippedFiles.push(relativePath);
+      continue;
+    }
+
+    const contentBuffer = fs.readFileSync(absolutePath);
+    if (!isPotentialText(contentBuffer)) {
+      skippedFiles.push(relativePath);
+      continue;
+    }
+
+    const content = contentBuffer.toString("utf8");
+    scanLineRules(relativePath, content, findings);
+    scannedFiles.push(relativePath);
+  }
+
+  const results = {
+    generated_at: new Date().toISOString(),
+    scanned_files: scannedFiles,
+    skipped_files: skippedFiles,
+    finding_count: findings.length,
+    severity_counts: severityCounts(findings),
+    findings,
+  };
+
+  ensureParentDir(outputJsonPath);
+  ensureParentDir(outputMarkdownPath);
+  fs.writeFileSync(outputJsonPath, `${JSON.stringify(results, null, 2)}\n`);
+  fs.writeFileSync(
+    outputMarkdownPath,
+    toMarkdownReport(findings, scannedFiles, skippedFiles)
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}

--- a/eng/pr-risk-scan.mjs
+++ b/eng/pr-risk-scan.mjs
@@ -13,6 +13,62 @@ const SCRIPT_EXTENSIONS = new Set([
   ".ts",
 ]);
 
+function isLikelyAbsolutePath(value) {
+  if (!value) {
+    return false;
+  }
+
+  // POSIX absolute (/foo), UNC (//server/share), Windows drive paths (C:/foo).
+  return (
+    value.startsWith("/") ||
+    value.startsWith("//") ||
+    /^[A-Za-z]:\//.test(value)
+  );
+}
+
+function isPathWithinRoot(rootPath, targetPath) {
+  const relative = path.relative(rootPath, targetPath);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+function hasUnpinnedVersionIndicator(line) {
+  const trimmed = line.trim();
+
+  if (!trimmed) {
+    return false;
+  }
+
+  // Command contexts where floating versions are risky.
+  if (
+    /\b(npm|pnpm|yarn|bun|npx|uvx|pip|pipx)\b[^\n]*(?:@latest\b|\blatest\b)/i.test(
+      trimmed
+    )
+  ) {
+    return true;
+  }
+
+  // package.json/yaml style dependency entries with floating ranges.
+  if (
+    /["'][^"']+["']\s*:\s*["'](\^|~|\*|latest\b)[^"']*["']/i.test(trimmed)
+  ) {
+    return true;
+  }
+
+  // pyproject/requirements style entries with broad lower-bound only specs.
+  if (
+    /\b[A-Za-z0-9_.-]+\s*(>=|>|~=)\s*\d+(?:\.\d+){0,2}\b(?!\s*,\s*<)/.test(
+      trimmed
+    )
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
 const severityLevels = {
   high: "high",
   medium: "medium",
@@ -58,11 +114,9 @@ const LINE_RULES = [
   {
     rule_id: "unpinned-version-indicator",
     severity: severityLevels.medium,
-    regex: /\B@latest\b|\blatest\b|\*|(\^|~)\d+/i,
     reason: "Unpinned dependencies can change behavior between runs.",
     suggested_fix: "Use exact immutable versions or commit hashes.",
-    shouldApply: (line) =>
-      /\b(npm|pnpm|yarn|npx|uvx|pip|pipx|cargo|go)\b/i.test(line),
+    matcher: (line) => hasUnpinnedVersionIndicator(line),
   },
 ];
 
@@ -98,6 +152,10 @@ function normalizeRelativePath(value) {
     throw new Error(`Unsafe relative path in changed files list: ${value}`);
   }
 
+  if (isLikelyAbsolutePath(cleaned)) {
+    throw new Error(`Absolute paths are not allowed in changed files list: ${value}`);
+  }
+
   return cleaned;
 }
 
@@ -127,8 +185,10 @@ function scanLineRules(filePath, content, findings) {
         continue;
       }
 
-      const match = line.match(rule.regex);
-      if (!match) {
+      const matchedByRegex = rule.regex ? rule.regex.test(line) : false;
+      const matchedByFunction =
+        typeof rule.matcher === "function" ? rule.matcher(line) : false;
+      if (!matchedByRegex && !matchedByFunction) {
         continue;
       }
 
@@ -254,6 +314,7 @@ function main() {
   const changedFilesPath = path.resolve(args.files);
   const outputJsonPath = path.resolve(args["output-json"]);
   const outputMarkdownPath = path.resolve(args["output-md"]);
+  const repoRootPath = process.cwd();
 
   const changedFiles = fs
     .readFileSync(changedFilesPath, "utf8")
@@ -266,7 +327,11 @@ function main() {
   const skippedFiles = [];
 
   for (const relativePath of changedFiles) {
-    const absolutePath = path.resolve(relativePath);
+    const absolutePath = path.resolve(repoRootPath, relativePath);
+    if (!isPathWithinRoot(repoRootPath, absolutePath)) {
+      throw new Error(`Path escapes repository root: ${relativePath}`);
+    }
+
     scanSkillScriptPath(relativePath, findings);
 
     if (!fs.existsSync(absolutePath) || !fs.statSync(absolutePath).isFile()) {

--- a/eng/pr-risk-scan.mjs
+++ b/eng/pr-risk-scan.mjs
@@ -350,7 +350,11 @@ function main() {
       continue;
     }
 
-    const stat = fs.statSync(absolutePath);
+    const stat = fs.lstatSync(absolutePath);
+    if (stat.isSymbolicLink()) {
+      skippedFiles.push(`${relativePath} (skipped: symbolic link)`);
+      continue;
+    }
     if (!stat.isFile()) {
       skippedFiles.push(relativePath);
       continue;

--- a/eng/pr-risk-scan.mjs
+++ b/eng/pr-risk-scan.mjs
@@ -270,15 +270,20 @@ function toMarkdownReport(findings, scannedFiles, skippedFiles) {
           : finding.severity === severityLevels.medium
           ? "🟠"
           : "ℹ️";
-      const match = finding.match
+      const matchText = finding.match
         .replace(/\\/g, "\\\\")
-        .replace(/`/g, "\\`")
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;")
         .replace(/\|/g, "\\|")
         .replace(/@/g, "@\u200b");
+      const backtickRuns = matchText.match(/`+/g);
+      const fenceLength = backtickRuns
+        ? Math.max(...backtickRuns.map((run) => run.length)) + 1
+        : 1;
+      const fence = "`".repeat(fenceLength);
+      const match = `${fence}${matchText}${fence}`;
       summary.push(
-        `| ${severity} | \`${finding.rule_id}\` | \`${finding.file}\` | ${finding.line} | \`${match}\` |`
+        `| ${severity} | \`${finding.rule_id}\` | \`${finding.file}\` | ${finding.line} | ${match} |`
       );
     }
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [x] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

This adds a non-blocking supply-chain risk signal for PRs that touch agentic contribution paths. The goal is to surface risky patterns early (guardrail bypass language, remote shell execution, dynamic package execution, and skill script additions) without blocking contributor flow.

The change introduces a scanner script (`eng/pr-risk-scan.mjs`) plus two GitHub workflows. The gate workflow scans changed PR files and uploads a structured artifact (`results.json` + `report.md`). A follow-on comment workflow runs with write permissions, reads only that artifact, and upserts a single marker-based PR comment containing severity counts and a findings table.

The workflows are intentionally soft-gate in v1: findings are visible and repeatable, but do not fail the PR. This keeps false-positive tuning practical before any stricter enforcement.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [x] Update to existing instruction, prompt, agent, plugin, skill, or workflow.
- [x] Other (please specify): new repository automation script in `eng/`.

---

## Additional Notes

- Added files:
  - `.github/workflows/pr-risk-scan.yml`
  - `.github/workflows/pr-risk-scan-comment.yml`
  - `eng/pr-risk-scan.mjs`
- The comment format uses marker `<!-- pr-risk-scan-results -->` to ensure idempotent updates.
- Initial preview runs show useful `skill-script-added` signal and one noisy unpinned-version match, which we can tighten in a follow-up.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.