### PR TITLE
Fix uv ecosystem value in dependabot skill

### DIFF
--- a/skills/dependabot/SKILL.md
+++ b/skills/dependabot/SKILL.md
@@ -58,7 +58,9 @@ Scan the repository for dependency manifests. Look for:
 | Git Submodules | `gitsubmodule` | `.gitmodules` |
 | Pre-commit | `pre-commit` | `.pre-commit-config.yaml` |
 
-Note: pnpm and yarn both use the `npm` ecosystem value.
+Notes:
+- pnpm and yarn both use the `npm` ecosystem value.
+- Prefer `uv` ecosystem value when `uv.lock` is present; otherwise use `pip`.
 
 ### Step 2: Map Directory Locations
 

--- a/skills/dependabot/SKILL.md
+++ b/skills/dependabot/SKILL.md
@@ -34,7 +34,8 @@ Scan the repository for dependency manifests. Look for:
 | Ecosystem | YAML Value | Manifest Files |
 |---|---|---|
 | npm/pnpm/yarn | `npm` | `package.json`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock` |
-| pip/pipenv/poetry/uv | `pip` | `requirements.txt`, `Pipfile`, `pyproject.toml`, `setup.py` |
+| pip/pipenv/poetry | `pip` | `requirements.txt`, `Pipfile`, `pyproject.toml`, `setup.py` |
+| uv | `uv` | `pyproject.toml`, `uv.lock` |
 | Docker | `docker` | `Dockerfile` |
 | Docker Compose | `docker-compose` | `docker-compose.yml` |
 | GitHub Actions | `github-actions` | `.github/workflows/*.yml` |


### PR DESCRIPTION

## Pull Request Checklist

- [x]  I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

This fixes the wrong ecosystem value for uv in the dependabot skill.

### Problems to fix

The dependabot skill provided `pip` as the ecosystem value for uv package manager. But Dependabot officially supports `uv` as the ecosystem value. It should be used rather than `pip`. 

### References

- https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [x] Update to existing instruction, prompt, agent, plugin, skill, or workflow.
- [ ] Other (please specify):

---

## Additional Notes

Updated files:
- skills/dependabot/SKILL.md

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
