### PR TITLE
Automate external plugin update PR quality checks

### DIFF
--- a/.github/workflows/external-plugin-pr-quality-gates.yml
+++ b/.github/workflows/external-plugin-pr-quality-gates.yml
@@ -115,6 +115,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
+    steps:
       - name: Checkout staged branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/external-plugin-pr-quality-gates.yml
+++ b/.github/workflows/external-plugin-pr-quality-gates.yml
@@ -112,9 +112,9 @@ jobs:
     needs: [detect-changed-plugins, run-quality-gates]
     if: always()
     permissions:
+      contents: read
       issues: write
       pull-requests: write
-    steps:
       - name: Checkout staged branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/external-plugin-pr-quality-gates.yml
+++ b/.github/workflows/external-plugin-pr-quality-gates.yml
@@ -1,0 +1,224 @@
+name: External Plugin PR Quality Gates
+
+on:
+  pull_request:
+    branches: [staged]
+    paths:
+      - "plugins/external.json"
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+
+concurrency:
+  group: external-plugin-pr-quality-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  detect-changed-plugins:
+    runs-on: ubuntu-latest
+    outputs:
+      changed-plugins: ${{ steps.detect.outputs.changed-plugins }}
+      changed-count: ${{ steps.detect.outputs.changed-count }}
+      should-run: ${{ steps.detect.outputs.should-run }}
+    steps:
+      - name: Detect changed external plugins
+        id: detect
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const filePath = 'plugins/external.json';
+            const baseRef = context.payload.pull_request.base.sha;
+            const headRef = context.payload.pull_request.head.sha;
+
+            function normalizePath(value) {
+              if (!value || value === '/') {
+                return '';
+              }
+              return String(value).trim().replace(/^\/+|\/+$/g, '').toLowerCase();
+            }
+
+            function toIdentity(plugin) {
+              return [
+                String(plugin?.name ?? '').trim().toLowerCase(),
+                String(plugin?.source?.repo ?? '').trim().toLowerCase(),
+                normalizePath(plugin?.source?.path),
+              ].join('|');
+            }
+
+            async function readExternalJson(ref) {
+              const response = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: filePath,
+                ref,
+              });
+
+              const encoded = response.data?.content ?? '';
+              const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+              return JSON.parse(decoded);
+            }
+
+            const basePlugins = await readExternalJson(baseRef);
+            const headPlugins = await readExternalJson(headRef);
+            const baseByIdentity = new Map(basePlugins.map((plugin) => [toIdentity(plugin), plugin]));
+
+            const changedPlugins = headPlugins.filter((plugin) => {
+              const identity = toIdentity(plugin);
+              const basePlugin = baseByIdentity.get(identity);
+              return !basePlugin || JSON.stringify(basePlugin) !== JSON.stringify(plugin);
+            });
+
+            core.setOutput('changed-plugins', JSON.stringify(changedPlugins));
+            core.setOutput('changed-count', String(changedPlugins.length));
+            core.setOutput('should-run', changedPlugins.length > 0 ? 'true' : 'false');
+
+  run-quality-gates:
+    runs-on: ubuntu-latest
+    needs: detect-changed-plugins
+    if: needs.detect-changed-plugins.outputs.should-run == 'true'
+    outputs:
+      quality-result: ${{ steps.quality.outputs.quality-result }}
+    steps:
+      - name: Checkout staged branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: staged
+          persist-credentials: false
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - name: Install GitHub Copilot CLI
+        run: npm install -g @github/copilot
+
+      - name: Run external plugin PR quality gates
+        id: quality
+        env:
+          CHANGED_PLUGINS_JSON: ${{ needs.detect-changed-plugins.outputs.changed-plugins }}
+        run: |
+          result=$(node ./eng/external-plugin-pr-quality-gates.mjs --plugins-json "$CHANGED_PLUGINS_JSON")
+          {
+            echo 'quality-result<<EOF'
+            echo "$result"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+  sync-pr-state:
+    runs-on: ubuntu-latest
+    needs: [detect-changed-plugins, run-quality-gates]
+    if: always()
+    steps:
+      - name: Checkout staged branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: staged
+
+      - name: Sync labels and PR status comment
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          SHOULD_RUN: ${{ needs.detect-changed-plugins.outputs.should-run }}
+          CHANGED_COUNT: ${{ needs.detect-changed-plugins.outputs.changed-count }}
+          QUALITY_RESULT_JSON: ${{ needs.run-quality-gates.outputs.quality-result }}
+          QUALITY_JOB_RESULT: ${{ needs.run-quality-gates.result }}
+        with:
+          script: |
+            const path = require('path');
+            const { pathToFileURL } = require('url');
+
+            const intakeState = await import(pathToFileURL(path.join(process.env.GITHUB_WORKSPACE, 'eng', 'external-plugin-intake-state.mjs')).href);
+            const marker = '<!-- external-plugin-pr-quality -->';
+
+            const shouldRun = process.env.SHOULD_RUN === 'true';
+            const changedCount = Number.parseInt(process.env.CHANGED_COUNT || '0', 10);
+            const qualityJobResult = process.env.QUALITY_JOB_RESULT;
+
+            let qualityResult = {
+              overall_status: 'not_run',
+              failure_class: 'none',
+              checked_plugins: [],
+              summary: 'No changed external plugin entries were detected in this PR.',
+            };
+
+            if (shouldRun) {
+              if (qualityJobResult === 'failure' || qualityJobResult === 'cancelled') {
+                qualityResult = {
+                  overall_status: 'infra_error',
+                  failure_class: 'infra',
+                  checked_plugins: [],
+                  summary: 'External plugin PR quality checks failed unexpectedly. Re-run this workflow.',
+                };
+              } else if (process.env.QUALITY_RESULT_JSON) {
+                qualityResult = JSON.parse(process.env.QUALITY_RESULT_JSON);
+              } else {
+                qualityResult = {
+                  overall_status: 'infra_error',
+                  failure_class: 'infra',
+                  checked_plugins: [],
+                  summary: 'External plugin PR quality checks did not return a result payload.',
+                };
+              }
+            }
+
+            const stateLabel = qualityResult.failure_class === 'submitter_fixes'
+              ? 'requires-submitter-fixes'
+              : qualityResult.overall_status === 'pass'
+                ? 'ready-for-review'
+                : 'awaiting-review';
+
+            const desiredLabels = new Set(['external-plugin', stateLabel]);
+            await intakeState.syncExternalPluginIntakeLabels({
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issueNumber: context.issue.number,
+              desiredLabels,
+            });
+
+            const checkedPlugins = Array.isArray(qualityResult.checked_plugins) ? qualityResult.checked_plugins : [];
+            const header = qualityResult.failure_class === 'submitter_fixes'
+              ? '## ⚠️ External plugin PR checks require submitter fixes'
+              : qualityResult.overall_status === 'pass'
+                ? '## ✅ External plugin PR checks passed'
+                : '## ⚠️ External plugin PR checks need maintainer follow-up';
+
+            const rows = checkedPlugins.length > 0
+              ? checkedPlugins.map((entry) => {
+                  const name = String(entry?.name || 'unknown');
+                  const quality = entry?.quality || {};
+                  const sourceUrl = String(entry?.source_tree_url || '');
+                  const locator = String(entry?.source?.sha || entry?.source?.ref || 'repository');
+                  const sourceCell = sourceUrl ? `[${locator}](${sourceUrl})` : locator;
+                  return `| ${name} | ${quality.skill_validator_status || 'not_run'} | ${quality.smoke_status || 'not_run'} | ${quality.overall_status || 'not_run'} | ${sourceCell} |`;
+                })
+              : ['| _none_ | not_run | not_run | not_run | _n/a_ |'];
+
+            const body = [
+              marker,
+              header,
+              '',
+              `- **Changed entries detected:** ${changedCount}`,
+              `- **Workflow state label:** \`${stateLabel}\``,
+              '',
+              '### Per-plugin quality summary',
+              '',
+              '| Plugin | skill-validator | install smoke test | overall | source tree |',
+              '|---|---|---|---|---|',
+              ...rows,
+              '',
+              String(qualityResult.summary || '').trim() || '_No summary provided._',
+            ].join('\n');
+
+            await intakeState.upsertExternalPluginIntakeComment({
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issueNumber: context.issue.number,
+              marker,
+              body,
+            });

--- a/.github/workflows/external-plugin-pr-quality-gates.yml
+++ b/.github/workflows/external-plugin-pr-quality-gates.yml
@@ -13,8 +13,6 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 jobs:
   detect-changed-plugins:
@@ -113,6 +111,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-changed-plugins, run-quality-gates]
     if: always()
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout staged branch
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -122,6 +123,7 @@ jobs:
       - name: Sync labels and PR status comment
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
+          DETECT_JOB_RESULT: ${{ needs.detect-changed-plugins.result }}
           SHOULD_RUN: ${{ needs.detect-changed-plugins.outputs.should-run }}
           CHANGED_COUNT: ${{ needs.detect-changed-plugins.outputs.changed-count }}
           QUALITY_RESULT_JSON: ${{ needs.run-quality-gates.outputs.quality-result }}
@@ -134,6 +136,7 @@ jobs:
             const intakeState = await import(pathToFileURL(path.join(process.env.GITHUB_WORKSPACE, 'eng', 'external-plugin-intake-state.mjs')).href);
             const marker = '<!-- external-plugin-pr-quality -->';
 
+            const detectJobResult = process.env.DETECT_JOB_RESULT;
             const shouldRun = process.env.SHOULD_RUN === 'true';
             const changedCount = Number.parseInt(process.env.CHANGED_COUNT || '0', 10);
             const qualityJobResult = process.env.QUALITY_JOB_RESULT;
@@ -145,7 +148,7 @@ jobs:
               summary: 'No changed external plugin entries were detected in this PR.',
             };
 
-            if ('${{ needs.detect-changed-plugins.result }}' === 'failure' || '${{ needs.detect-changed-plugins.result }}' === 'cancelled') {
+            if (detectJobResult === 'failure' || detectJobResult === 'cancelled') {
               qualityResult = {
                 overall_status: 'infra_error',
                 failure_class: 'infra',
@@ -190,7 +193,7 @@ jobs:
             const checkedPlugins = Array.isArray(qualityResult.checked_plugins) ? qualityResult.checked_plugins : [];
             const header = qualityResult.failure_class === 'submitter_fixes'
               ? '## ⚠️ External plugin PR checks require submitter fixes'
-              : qualityResult.overall_status === 'pass'
+              : qualityResult.overall_status === 'pass' || !shouldRun
                 ? '## ✅ External plugin PR checks passed'
                 : '## ⚠️ External plugin PR checks need maintainer follow-up';
 

--- a/.github/workflows/external-plugin-pr-quality-gates.yml
+++ b/.github/workflows/external-plugin-pr-quality-gates.yml
@@ -145,7 +145,14 @@ jobs:
               summary: 'No changed external plugin entries were detected in this PR.',
             };
 
-            if (shouldRun) {
+            if ('${{ needs.detect-changed-plugins.result }}' === 'failure' || '${{ needs.detect-changed-plugins.result }}' === 'cancelled') {
+              qualityResult = {
+                overall_status: 'infra_error',
+                failure_class: 'infra',
+                checked_plugins: [],
+                summary: 'External plugin PR change detection failed unexpectedly. Re-run this workflow.',
+              };
+            } else if (shouldRun) {
               if (qualityJobResult === 'failure' || qualityJobResult === 'cancelled') {
                 qualityResult = {
                   overall_status: 'infra_error',
@@ -167,7 +174,7 @@ jobs:
 
             const stateLabel = qualityResult.failure_class === 'submitter_fixes'
               ? 'requires-submitter-fixes'
-              : qualityResult.overall_status === 'pass'
+              : qualityResult.overall_status === 'pass' || !shouldRun
                 ? 'ready-for-review'
                 : 'awaiting-review';
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,6 +241,18 @@ The public-submission policy builds on those rules and also requires `license` p
 9. **Approval path**: on `/approve`, automation removes `ready-for-review`, adds `approved`, closes the issue, and opens or updates a PR against `staged` that updates `plugins/external.json` and generated marketplace outputs.
 10. **Rejection path**: on `/reject <reason>`, automation removes `ready-for-review`, adds `rejected`, closes the issue, and records the reason in an issue comment. After addressing the feedback, update the same issue and use `/rerun-intake` to re-queue intake.
 
+##### Updating listed external plugins via PR
+
+When a pull request updates `plugins/external.json` (for example, version updates for a previously approved listing), automation runs PR quality checks and posts the result directly on the PR:
+
+1. **Detect changed entries**: automation identifies added/updated external plugin entries in the PR.
+2. **Run quality gates**: automation runs install smoke tests and `skill-validator` checks against each changed plugin source ref/SHA/path.
+3. **Post source links**: automation updates a bot comment with per-plugin results and direct GitHub tree links to each plugin source location.
+4. **Sync workflow-state labels on the PR**:
+   - `ready-for-review` when all checks pass
+   - `requires-submitter-fixes` when quality checks fail due to plugin issues
+   - `awaiting-review` when checks cannot complete because of infrastructure/transient errors
+
 ##### Maintainer review responsibilities
 
 Maintainers are responsible for confirming that the submission:

--- a/eng/external-plugin-pr-quality-gates.mjs
+++ b/eng/external-plugin-pr-quality-gates.mjs
@@ -28,7 +28,7 @@ export function buildSourceTreeUrl(plugin) {
     return `https://github.com/${sourceRepo}`;
   }
 
-  const encodedLocator = encodePathLikeValue(sourceLocator);
+  const encodedLocator = encodeURIComponent(sourceLocator);
   const normalizedPath = normalizePluginPath(plugin?.source?.path);
   if (!normalizedPath) {
     return `https://github.com/${sourceRepo}/tree/${encodedLocator}`;

--- a/eng/external-plugin-pr-quality-gates.mjs
+++ b/eng/external-plugin-pr-quality-gates.mjs
@@ -34,7 +34,8 @@ export function buildSourceTreeUrl(plugin) {
     return `https://github.com/${sourceRepo}/tree/${encodedLocator}`;
   }
 
-  return `https://github.com/${sourceRepo}/tree/${encodedLocator}/${normalizedPath}`;
+  const encodedPath = encodePathLikeValue(normalizedPath);
+  return `https://github.com/${sourceRepo}/tree/${encodedLocator}/${encodedPath}`;
 }
 
 function aggregateResultStatus(pluginResults) {

--- a/eng/external-plugin-pr-quality-gates.mjs
+++ b/eng/external-plugin-pr-quality-gates.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { runExternalPluginQualityGates } from "./external-plugin-quality-gates.mjs";
+
+function normalizePluginPath(pluginPath) {
+  if (!pluginPath || pluginPath === "/") {
+    return "";
+  }
+
+  return String(pluginPath).trim().replace(/^\/+|\/+$/g, "");
+}
+
+function encodePathLikeValue(value) {
+  return String(value)
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+export function buildSourceTreeUrl(plugin) {
+  const sourceRepo = plugin?.source?.repo;
+  if (!sourceRepo) {
+    return "";
+  }
+
+  const sourceLocator = plugin?.source?.sha || plugin?.source?.ref;
+  if (!sourceLocator) {
+    return `https://github.com/${sourceRepo}`;
+  }
+
+  const encodedLocator = encodePathLikeValue(sourceLocator);
+  const normalizedPath = normalizePluginPath(plugin?.source?.path);
+  if (!normalizedPath) {
+    return `https://github.com/${sourceRepo}/tree/${encodedLocator}`;
+  }
+
+  return `https://github.com/${sourceRepo}/tree/${encodedLocator}/${normalizedPath}`;
+}
+
+function aggregateResultStatus(pluginResults) {
+  if (pluginResults.some((entry) => entry.quality?.overall_status === "fail")) {
+    return {
+      overallStatus: "fail",
+      failureClass: "submitter_fixes",
+    };
+  }
+
+  if (pluginResults.some((entry) => entry.quality?.overall_status === "infra_error")) {
+    return {
+      overallStatus: "infra_error",
+      failureClass: "infra",
+    };
+  }
+
+  if (pluginResults.length === 0) {
+    return {
+      overallStatus: "not_run",
+      failureClass: "none",
+    };
+  }
+
+  return {
+    overallStatus: "pass",
+    failureClass: "none",
+  };
+}
+
+export function runExternalPluginPrQualityGates(plugins) {
+  if (!Array.isArray(plugins)) {
+    throw new Error("plugins must be an array");
+  }
+
+  const checkedPlugins = plugins.map((plugin) => {
+    const quality = runExternalPluginQualityGates(plugin);
+    return {
+      name: plugin?.name ?? "unknown",
+      source: plugin?.source ?? {},
+      source_tree_url: buildSourceTreeUrl(plugin),
+      quality,
+    };
+  });
+
+  const aggregate = aggregateResultStatus(checkedPlugins);
+  const summary = checkedPlugins.length === 0
+    ? "No changed external plugin entries were detected in plugins/external.json."
+    : checkedPlugins
+      .map((entry) =>
+        `- ${entry.name}: skill-validator=${entry.quality.skill_validator_status}, install-smoke=${entry.quality.smoke_status}, overall=${entry.quality.overall_status}`
+      )
+      .join("\n");
+
+  return {
+    overall_status: aggregate.overallStatus,
+    failure_class: aggregate.failureClass,
+    summary,
+    checked_plugins: checkedPlugins,
+  };
+}
+
+function parseCliArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      continue;
+    }
+
+    args[key.slice(2)] = argv[index + 1];
+    index += 1;
+  }
+  return args;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseCliArgs(process.argv.slice(2));
+  if (!args["plugins-json"]) {
+    console.error("Usage: node ./eng/external-plugin-pr-quality-gates.mjs --plugins-json '<json-array>'");
+    process.exit(1);
+  }
+
+  const plugins = JSON.parse(args["plugins-json"]);
+  const result = runExternalPluginPrQualityGates(plugins);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [x] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

External plugin update PRs like #2004 currently rely on manual review context, while issue intake already has automated quality gates. This adds equivalent automation to PRs that modify `plugins/external.json` so reviewers get consistent, actionable state signals.

The change introduces a new PR workflow that detects changed external plugin entries, runs the existing smoke install and skill-validator gates for each changed entry, then syncs PR labels to workflow state (`ready-for-review`, `requires-submitter-fixes`, `awaiting-review`). It also upserts a marker-based PR comment with per-plugin gate results and a direct source tree link (`repo + ref/sha + path`) for each changed plugin. A small script (`eng/external-plugin-pr-quality-gates.mjs`) aggregates per-plugin execution and summary output, and CONTRIBUTING guidance now documents this PR update path.

Follow-up fixes from review feedback are also included so the workflow matches the intended behavior: repository-level permissions stay read-only by default, PR write access is scoped to the sync job that applies labels/comments, and the sync job keeps the permissions and YAML structure needed to check out `staged` and run successfully.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [x] Update to existing instruction, prompt, agent, plugin, skill, or workflow.
- [ ] Other (please specify):

---

## Additional Notes

Validated with `npm run build`, `npm run plugin:validate`, `npm run skill:validate`, and targeted workflow/YAML verification after the review-driven fixes.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.