### PR TITLE
Update .NET Copilot SDK cookbook for GitHub.Copilot.SDK 1.0

### DIFF
--- a/cookbook/copilot-sdk/dotnet/accessibility-report.md
+++ b/cookbook/copilot-sdk/dotnet/accessibility-report.md
@@ -194,7 +194,7 @@ if (generateTests == "y" || generateTests == "yes")
 
 ## How it works
 
-1. **Playwright MCP server**: Configures a local MCP server running `@playwright/mcp` to provide browser automation tools
+1. **Playwright MCP server**: Configures a local stdio MCP server (`McpStdioServerConfig`, launched via `npx`) running `@playwright/mcp` to provide browser automation tools
 2. **Streaming output**: Uses `Streaming = true` and `AssistantMessageDeltaEvent` for real-time token-by-token output
 3. **Accessibility snapshot**: Playwright's `browser_snapshot` tool captures the full accessibility tree of the page
 4. **Structured report**: The prompt engineers a consistent WCAG-aligned report format with emoji severity indicators
@@ -204,7 +204,7 @@ if (generateTests == "y" || generateTests == "yes")
 
 ### MCP server configuration
 
-The recipe configures a local MCP server that runs alongside the session:
+The recipe configures a local stdio MCP server (`McpStdioServerConfig`, launched via `npx`) that runs alongside the session:
 
 ```csharp
 OnPermissionRequest = PermissionHandler.ApproveAll,

--- a/cookbook/copilot-sdk/dotnet/accessibility-report.md
+++ b/cookbook/copilot-sdk/dotnet/accessibility-report.md
@@ -32,7 +32,7 @@ dotnet run recipe/accessibility-report.cs
 ```csharp
 #:package GitHub.Copilot.SDK@*
 
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 // Create and start client
 await using var client = new CopilotClient();
@@ -65,12 +65,11 @@ await using var session = await client.CreateSessionAsync(new SessionConfig
     Model = "claude-opus-4.6",
     Streaming = true,
     OnPermissionRequest = PermissionHandler.ApproveAll,
-    McpServers = new Dictionary<string, object>()
+    McpServers = new Dictionary<string, McpServerConfig>()
     {
         ["playwright"] =
-        new McpLocalServerConfig
+        new McpStdioServerConfig
         {
-            Type = "local",
             Command = "npx",
             Args = ["@playwright/mcp@latest"],
             Tools = ["*"]
@@ -209,11 +208,10 @@ The recipe configures a local MCP server that runs alongside the session:
 
 ```csharp
 OnPermissionRequest = PermissionHandler.ApproveAll,
-McpServers = new Dictionary<string, object>()
+McpServers = new Dictionary<string, McpServerConfig>()
 {
-    ["playwright"] = new McpLocalServerConfig
+    ["playwright"] = new McpStdioServerConfig
     {
-        Type = "local",
         Command = "npx",
         Args = ["@playwright/mcp@latest"],
         Tools = ["*"]

--- a/cookbook/copilot-sdk/dotnet/error-handling.md
+++ b/cookbook/copilot-sdk/dotnet/error-handling.md
@@ -15,7 +15,7 @@ You need to handle various error conditions like connection failures, timeouts, 
 ## Basic try-catch
 
 ```csharp
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 var client = new CopilotClient();
 
@@ -134,10 +134,13 @@ Console.CancelKeyPress += async (sender, e) =>
     e.Cancel = true;
     Console.WriteLine("Shutting down...");
 
-    var errors = await client.StopAsync();
-    if (errors.Count > 0)
+    try
     {
-        Console.WriteLine($"Cleanup errors: {string.Join(", ", errors)}");
+        await client.StopAsync();
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"Cleanup error: {ex.Message}");
     }
 
     Environment.Exit(0);
@@ -163,7 +166,7 @@ var session = await client.CreateSessionAsync(new SessionConfig
 
 ## Best practices
 
-Starting with Copilot SDK v0.1.28, permission handling is opt-in. If a session may need tool, file, or system access, set `OnPermissionRequest` explicitly when creating it.
+Permission handling is opt-in. If a session may need tool, file, or system access, set `OnPermissionRequest` explicitly when creating it.
 
 1. **Always clean up**: Use try-finally or `await using` to ensure `StopAsync()` is called
 2. **Handle connection errors**: The CLI might not be installed or running

--- a/cookbook/copilot-sdk/dotnet/error-handling.md
+++ b/cookbook/copilot-sdk/dotnet/error-handling.md
@@ -147,6 +147,10 @@ Console.CancelKeyPress += async (sender, e) =>
 };
 ```
 
+> In 1.0, `StopAsync()` throws if it encounters errors during cleanup rather than returning a
+> list of cleanup errors, so wrap it in a try/catch to log failures instead of letting them
+> crash shutdown. Use `ForceStopAsync()` if a graceful stop takes too long.
+
 ## Using await using for automatic disposal
 
 ```csharp

--- a/cookbook/copilot-sdk/dotnet/managing-local-files.md
+++ b/cookbook/copilot-sdk/dotnet/managing-local-files.md
@@ -16,7 +16,7 @@ You have a folder with many files and want to organize them into subfolders base
 ## Example code
 
 ```csharp
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 // Create and start client
 await using var client = new CopilotClient();

--- a/cookbook/copilot-sdk/dotnet/multiple-sessions.md
+++ b/cookbook/copilot-sdk/dotnet/multiple-sessions.md
@@ -15,7 +15,7 @@ You need to run multiple conversations in parallel, each with its own context an
 ## C #
 
 ```csharp
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 await using var client = new CopilotClient();
 await client.StartAsync();

--- a/cookbook/copilot-sdk/dotnet/persisting-sessions.md
+++ b/cookbook/copilot-sdk/dotnet/persisting-sessions.md
@@ -88,9 +88,17 @@ foreach (var evt in events)
         case AssistantMessageEvent assistant:
             Console.WriteLine($"[assistant] {assistant.Data.Content}");
             break;
+        default:
+            // Sessions can also contain other events (tool calls, tool results, system events).
+            Console.WriteLine($"[{evt.GetType().Name}]");
+            break;
     }
 }
 ```
+
+> A session's event stream may include event kinds beyond user and assistant messages
+> (for example tool calls, tool results, and system events). Handle the ones you care
+> about and fall back to a default case so nothing is silently dropped.
 
 ## Best practices
 

--- a/cookbook/copilot-sdk/dotnet/persisting-sessions.md
+++ b/cookbook/copilot-sdk/dotnet/persisting-sessions.md
@@ -77,6 +77,8 @@ await client.DeleteSessionAsync("user-123-conversation");
 Retrieve all events from a session:
 
 ```csharp
+using GitHub.Copilot; // UserMessageEvent, AssistantMessageEvent, etc. live in this namespace
+
 var events = await session.GetEventsAsync();
 foreach (var evt in events)
 {

--- a/cookbook/copilot-sdk/dotnet/persisting-sessions.md
+++ b/cookbook/copilot-sdk/dotnet/persisting-sessions.md
@@ -16,7 +16,7 @@ You want users to be able to continue a conversation even after closing and reop
 ### Creating a session with a custom ID
 
 ```csharp
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 await using var client = new CopilotClient();
 await client.StartAsync();
@@ -74,13 +74,21 @@ await client.DeleteSessionAsync("user-123-conversation");
 
 ### Getting session history
 
-Retrieve all messages from a session:
+Retrieve all events from a session:
 
 ```csharp
-var messages = await session.GetMessagesAsync();
-foreach (var msg in messages)
+var events = await session.GetEventsAsync();
+foreach (var evt in events)
 {
-    Console.WriteLine($"[{msg.Type}] {msg.Data.Content}");
+    switch (evt)
+    {
+        case UserMessageEvent user:
+            Console.WriteLine($"[user] {user.Data.Content}");
+            break;
+        case AssistantMessageEvent assistant:
+            Console.WriteLine($"[assistant] {assistant.Data.Content}");
+            break;
+    }
 }
 ```
 

--- a/cookbook/copilot-sdk/dotnet/pr-visualization.md
+++ b/cookbook/copilot-sdk/dotnet/pr-visualization.md
@@ -36,7 +36,7 @@ dotnet run -- --repo github/copilot-sdk
 
 ```csharp
 using System.Diagnostics;
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 // ============================================================================
 // Git & GitHub Detection
@@ -159,7 +159,7 @@ var owner = parts[0];
 var repoName = parts[1];
 
 // Create Copilot client - no custom tools needed!
-await using var client = new CopilotClient(new CopilotClientOptions { LogLevel = "error" });
+await using var client = new CopilotClient(new CopilotClientOptions { LogLevel = CopilotLogLevel.Error });
 await client.StartAsync();
 
 var session = await client.CreateSessionAsync(new SessionConfig

--- a/cookbook/copilot-sdk/dotnet/ralph-loop.md
+++ b/cookbook/copilot-sdk/dotnet/ralph-loop.md
@@ -42,7 +42,7 @@ A [Ralph loop](https://ghuntley.com/ralph/) is an autonomous development workflo
 The minimal Ralph loop — the SDK equivalent of `while :; do cat PROMPT.md | copilot ; done`:
 
 ```csharp
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 var client = new CopilotClient();
 await client.StartAsync();
@@ -96,7 +96,7 @@ This is all you need to get started. The prompt file tells the agent what to do;
 The full Ralph pattern with planning and building modes, matching the [Ralph Playbook](https://github.com/ClaytonFarr/ralph-playbook) architecture:
 
 ```csharp
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 // Parse args: dotnet run [plan] [max_iterations]
 var mode = args.Contains("plan") ? "plan" : "build";

--- a/cookbook/copilot-sdk/dotnet/recipe/accessibility-report.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/accessibility-report.cs
@@ -1,5 +1,6 @@
 #:package GitHub.Copilot.SDK@*
 
+// The GitHub.Copilot.SDK package exposes the GitHub.Copilot namespace.
 using GitHub.Copilot;
 
 // Create and start client

--- a/cookbook/copilot-sdk/dotnet/recipe/accessibility-report.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/accessibility-report.cs
@@ -1,6 +1,6 @@
 #:package GitHub.Copilot.SDK@*
 
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 // Create and start client
 await using var client = new CopilotClient();
@@ -33,12 +33,11 @@ await using var session = await client.CreateSessionAsync(new SessionConfig
   Model = "claude-opus-4.6",
   Streaming = true,
   OnPermissionRequest = PermissionHandler.ApproveAll,
-  McpServers = new Dictionary<string, object>()
+  McpServers = new Dictionary<string, McpServerConfig>()
   {
     ["playwright"] =
-        new McpLocalServerConfig
+        new McpStdioServerConfig
         {
-          Type = "local",
           Command = "npx",
           Args = ["@playwright/mcp@latest"],
           Tools = ["*"]

--- a/cookbook/copilot-sdk/dotnet/recipe/error-handling.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/error-handling.cs
@@ -1,6 +1,7 @@
 #:package GitHub.Copilot.SDK@*
 #:property PublishAot=false
 
+// The GitHub.Copilot.SDK package exposes the GitHub.Copilot namespace.
 using GitHub.Copilot;
 
 var client = new CopilotClient();

--- a/cookbook/copilot-sdk/dotnet/recipe/error-handling.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/error-handling.cs
@@ -1,7 +1,7 @@
 #:package GitHub.Copilot.SDK@*
 #:property PublishAot=false
 
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 var client = new CopilotClient();
 

--- a/cookbook/copilot-sdk/dotnet/recipe/managing-local-files.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/managing-local-files.cs
@@ -1,6 +1,7 @@
 #:package GitHub.Copilot.SDK@*
 #:property PublishAot=false
 
+// The GitHub.Copilot.SDK package exposes the GitHub.Copilot namespace.
 using GitHub.Copilot;
 
 // Create and start client

--- a/cookbook/copilot-sdk/dotnet/recipe/managing-local-files.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/managing-local-files.cs
@@ -1,7 +1,7 @@
 #:package GitHub.Copilot.SDK@*
 #:property PublishAot=false
 
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 // Create and start client
 await using var client = new CopilotClient();

--- a/cookbook/copilot-sdk/dotnet/recipe/multiple-sessions.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/multiple-sessions.cs
@@ -1,6 +1,7 @@
 #:package GitHub.Copilot.SDK@*
 #:property PublishAot=false
 
+// The GitHub.Copilot.SDK package exposes the GitHub.Copilot namespace.
 using GitHub.Copilot;
 
 await using var client = new CopilotClient();

--- a/cookbook/copilot-sdk/dotnet/recipe/multiple-sessions.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/multiple-sessions.cs
@@ -1,7 +1,7 @@
 #:package GitHub.Copilot.SDK@*
 #:property PublishAot=false
 
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 await using var client = new CopilotClient();
 await client.StartAsync();

--- a/cookbook/copilot-sdk/dotnet/recipe/persisting-sessions.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/persisting-sessions.cs
@@ -1,6 +1,7 @@
 #:package GitHub.Copilot.SDK@*
 #:property PublishAot=false
 
+// The GitHub.Copilot.SDK package exposes the GitHub.Copilot namespace.
 using GitHub.Copilot;
 
 await using var client = new CopilotClient();

--- a/cookbook/copilot-sdk/dotnet/recipe/persisting-sessions.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/persisting-sessions.cs
@@ -1,7 +1,7 @@
 #:package GitHub.Copilot.SDK@*
 #:property PublishAot=false
 
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 await using var client = new CopilotClient();
 await client.StartAsync();

--- a/cookbook/copilot-sdk/dotnet/recipe/pr-visualization.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/pr-visualization.cs
@@ -2,7 +2,7 @@
 #:property PublishAot=false
 
 using System.Diagnostics;
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 // ============================================================================
 // Git & GitHub Detection
@@ -126,7 +126,7 @@ var owner = parts[0];
 var repoName = parts[1];
 
 // Create Copilot client - no custom tools needed!
-await using var client = new CopilotClient(new CopilotClientOptions { LogLevel = "error" });
+await using var client = new CopilotClient(new CopilotClientOptions { LogLevel = CopilotLogLevel.Error });
 await client.StartAsync();
 
 var session = await client.CreateSessionAsync(new SessionConfig

--- a/cookbook/copilot-sdk/dotnet/recipe/pr-visualization.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/pr-visualization.cs
@@ -2,6 +2,7 @@
 #:property PublishAot=false
 
 using System.Diagnostics;
+// The GitHub.Copilot.SDK package exposes the GitHub.Copilot namespace.
 using GitHub.Copilot;
 
 // ============================================================================

--- a/cookbook/copilot-sdk/dotnet/recipe/ralph-loop.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/ralph-loop.cs
@@ -1,6 +1,6 @@
 #:package GitHub.Copilot.SDK@*
 
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 // Ralph loop: autonomous AI task loop with fresh context per iteration.
 //

--- a/cookbook/copilot-sdk/dotnet/recipe/ralph-loop.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/ralph-loop.cs
@@ -1,5 +1,6 @@
 #:package GitHub.Copilot.SDK@*
 
+// The GitHub.Copilot.SDK package exposes the GitHub.Copilot namespace.
 using GitHub.Copilot;
 
 // Ralph loop: autonomous AI task loop with fresh context per iteration.


### PR DESCRIPTION
## Summary

Updates the **.NET Copilot SDK cookbook** (`cookbook/copilot-sdk/dotnet`) to align with the `GitHub.Copilot.SDK` **1.0.1** release. The cookbook was written against a pre-1.0 API and contained several breaking-change mismatches that would prevent the recipes from compiling/running.

## Changes

| Breaking change (1.0) | Fix applied |
|---|---|
| Namespace `GitHub.Copilot.SDK` → `GitHub.Copilot` (package id unchanged) | Updated all `using` directives across `.cs` and `.md` files |
| MCP config: `Dictionary<string, object>` + `McpLocalServerConfig` + `Type = "local"` → `Dictionary<string, McpServerConfig>` + `McpStdioServerConfig` | Updated MCP server configuration in `accessibility-report` recipe and docs; dropped the `Type` discriminator |
| `StopAsync()` no longer returns an error list | Graceful shutdown wrapped in `try`/`catch` |
| `GetMessagesAsync()` → `GetEventsAsync()` returning session events | Rewrote session-history example to pattern-match events |
| `LogLevel = "error"` string → `CopilotLogLevel.Error` enum | Strongly-typed log level |

Also removed a stale "Starting with Copilot SDK v0.1.28…" version reference in the permission-handling note.

## Files touched

- 7 recipe sources under `cookbook/copilot-sdk/dotnet/recipe/*.cs`
- 7 docs under `cookbook/copilot-sdk/dotnet/*.md`

## Notes

- Targets the `staged` branch per the contribution guidelines.
- Markdown line endings normalized to LF.
