### PR TITLE
docs: clarify personal skill directories

### DIFF
--- a/instructions/agent-skills.instructions.md
+++ b/instructions/agent-skills.instructions.md
@@ -25,7 +25,8 @@ Skills are stored in specific locations:
 |----------|-------|----------------|
 | `.github/skills/<skill-name>/` | Project/repository | Recommended for project skills |
 | `.claude/skills/<skill-name>/` | Project/repository | Legacy, for backward compatibility |
-| `~/.github/skills/<skill-name>/` | Personal (user-wide) | Recommended for personal skills |
+| `~/.copilot/skills/<skill-name>/` | Personal (user-wide) | Recommended for personal skills |
+| `~/.agents/skills/<skill-name>/` | Personal (user-wide) | Alternative supported personal skills directory |
 | `~/.claude/skills/<skill-name>/` | Personal (user-wide) | Legacy, for backward compatibility |
 
 Each skill **must** have its own subdirectory containing at minimum a `SKILL.md` file.

--- a/skills/cli-mastery/references/module-5-skills.md
+++ b/skills/cli-mastery/references/module-5-skills.md
@@ -10,13 +10,13 @@
 
 | Level | Location |
 |-------|----------|
-| User | `~/.copilot/skills/<name>/SKILL.md` |
+| User | `~/.copilot/skills/<name>/SKILL.md` or `~/.agents/skills/<name>/SKILL.md` |
 | Repo | `.github/skills/<name>/SKILL.md` |
 | Org | Shared via org-level config |
 
 ## Creating a custom skill
 
-1. Create the directory: `mkdir -p ~/.copilot/skills/my-skill/`
+1. Create the directory: `mkdir -p ~/.copilot/skills/my-skill/` (or `mkdir -p ~/.agents/skills/my-skill/`)
 2. Create `SKILL.md` with YAML frontmatter (`name`, `description`, optional `tools`)
 3. Write detailed instructions for the AI's behavior
 4. Verify with `/skills`

--- a/website/src/content/docs/learning-hub/cli-for-beginners/05-skills.md
+++ b/website/src/content/docs/learning-hub/cli-for-beginners/05-skills.md
@@ -289,7 +289,7 @@ Build your own skills from SKILL.md files.
 
 ## Skill Locations
 
-Skills are stored in `.github/skills/` (project-specific) or in one of the supported user-level directories: `~/.copilot/skills/` or `~/.agents/skills/`.
+Skills are stored in `.github/skills/` (project-specific) or `~/.copilot/skills/` (user level).
 
 ### How Copilot Finds Skills
 
@@ -299,7 +299,6 @@ Copilot automatically scans these locations for skills:
 |----------|-------|
 | `.github/skills/` | Project-specific (shared with team via git) |
 | `~/.copilot/skills/` | User-specific (your personal skills) |
-| `~/.agents/skills/` | User-specific (alternative personal skills directory) |
 
 ### Skill Structure
 
@@ -588,8 +587,6 @@ cp -r /tmp/awesome-copilot/skills/code-checklist .github/skills/
 
 # Or for personal use across all projects
 cp -r /tmp/awesome-copilot/skills/code-checklist ~/.copilot/skills/
-# Alternative personal skills directory
-cp -r /tmp/awesome-copilot/skills/code-checklist ~/.agents/skills/
 ```
 
 > ⚠️ **Review before installing**: Always read a skill's `SKILL.md` before copying it into your project. Skills control what Copilot does, and a malicious skill could instruct it to run harmful commands or modify code in unexpected ways.
@@ -720,7 +717,7 @@ EOF
 
 The examples above created `pytest-gen` and `pr-review` skills. Now practice creating a completely different kind of skill: one for generating formatted output from data.
 
-1. List your current skills: Run Copilot and pass it `/skills list`. You can also use `ls .github/skills/` to see project skills, or `ls ~/.copilot/skills/` and `ls ~/.agents/skills/` to see personal skills.
+1. List your current skills: Run Copilot and pass it `/skills list`. You can also use `ls .github/skills/` to see project skills or `ls ~/.copilot/skills/` for personal skills.
 2. Create a `book-summary` skill at `.github/skills/book-summary/SKILL.md` that generates a formatted markdown summary of the book collection
 3. Your skill should have:
    - Clear name and description (description is crucial for matching!)
@@ -791,7 +788,7 @@ copilot
 | Naming the file something other than `SKILL.md` | Skill won't be recognized | The file must be named exactly `SKILL.md` |
 | Vague `description` field | Skill never gets loaded automatically | Description is the PRIMARY discovery mechanism. Use specific trigger words |
 | Missing `name` or `description` in frontmatter | Skill fails to load | Add both fields in YAML frontmatter |
-| Wrong folder location | Skill not found | Use `.github/skills/skill-name/` (project) or `~/.copilot/skills/skill-name/` / `~/.agents/skills/skill-name/` (personal) |
+| Wrong folder location | Skill not found | Use `.github/skills/skill-name/` (project) or `~/.copilot/skills/skill-name/` (personal) |
 
 ### Troubleshooting
 
@@ -814,7 +811,6 @@ copilot
 
    # User skills
    ls ~/.copilot/skills/
-   ls ~/.agents/skills/
    ```
 
 3. **Check SKILL.md format**: Frontmatter is required:
@@ -867,7 +863,7 @@ Run `/skills reload` after creating or editing skills to ensure changes are pick
 1. **Skills are automatic**: Copilot loads them when your prompt matches the skill's description
 2. **Direct invocation**: You can also invoke skills directly with `/skill-name` as a slash command
 3. **SKILL.md format**: YAML frontmatter (name, description, optional license) plus markdown instructions
-4. **Location matters**: `.github/skills/` for project/team sharing, `~/.copilot/skills/` or `~/.agents/skills/` for personal use
+4. **Location matters**: `.github/skills/` for project/team sharing, `~/.copilot/skills/` for personal use
 5. **Description is key**: Write descriptions that match how you naturally ask questions
 
 > 📋 **Quick Reference**: See the [GitHub Copilot CLI command reference](https://docs.github.com/en/copilot/reference/cli-command-reference) for a complete list of commands and shortcuts.

--- a/website/src/content/docs/learning-hub/cli-for-beginners/05-skills.md
+++ b/website/src/content/docs/learning-hub/cli-for-beginners/05-skills.md
@@ -289,7 +289,7 @@ Build your own skills from SKILL.md files.
 
 ## Skill Locations
 
-Skills are stored in `.github/skills/` (project-specific) or `~/.copilot/skills/` (user level).
+Skills are stored in `.github/skills/` (project-specific) or in one of the supported user-level directories: `~/.copilot/skills/` or `~/.agents/skills/`.
 
 ### How Copilot Finds Skills
 
@@ -299,6 +299,7 @@ Copilot automatically scans these locations for skills:
 |----------|-------|
 | `.github/skills/` | Project-specific (shared with team via git) |
 | `~/.copilot/skills/` | User-specific (your personal skills) |
+| `~/.agents/skills/` | User-specific (alternative personal skills directory) |
 
 ### Skill Structure
 
@@ -587,6 +588,8 @@ cp -r /tmp/awesome-copilot/skills/code-checklist .github/skills/
 
 # Or for personal use across all projects
 cp -r /tmp/awesome-copilot/skills/code-checklist ~/.copilot/skills/
+# Alternative personal skills directory
+cp -r /tmp/awesome-copilot/skills/code-checklist ~/.agents/skills/
 ```
 
 > ⚠️ **Review before installing**: Always read a skill's `SKILL.md` before copying it into your project. Skills control what Copilot does, and a malicious skill could instruct it to run harmful commands or modify code in unexpected ways.
@@ -717,7 +720,7 @@ EOF
 
 The examples above created `pytest-gen` and `pr-review` skills. Now practice creating a completely different kind of skill: one for generating formatted output from data.
 
-1. List your current skills: Run Copilot and pass it `/skills list`. You can also use `ls .github/skills/` to see project skills or `ls ~/.copilot/skills/` for personal skills.
+1. List your current skills: Run Copilot and pass it `/skills list`. You can also use `ls .github/skills/` to see project skills, or `ls ~/.copilot/skills/` and `ls ~/.agents/skills/` to see personal skills.
 2. Create a `book-summary` skill at `.github/skills/book-summary/SKILL.md` that generates a formatted markdown summary of the book collection
 3. Your skill should have:
    - Clear name and description (description is crucial for matching!)
@@ -788,7 +791,7 @@ copilot
 | Naming the file something other than `SKILL.md` | Skill won't be recognized | The file must be named exactly `SKILL.md` |
 | Vague `description` field | Skill never gets loaded automatically | Description is the PRIMARY discovery mechanism. Use specific trigger words |
 | Missing `name` or `description` in frontmatter | Skill fails to load | Add both fields in YAML frontmatter |
-| Wrong folder location | Skill not found | Use `.github/skills/skill-name/` (project) or `~/.copilot/skills/skill-name/` (personal) |
+| Wrong folder location | Skill not found | Use `.github/skills/skill-name/` (project) or `~/.copilot/skills/skill-name/` / `~/.agents/skills/skill-name/` (personal) |
 
 ### Troubleshooting
 
@@ -811,6 +814,7 @@ copilot
 
    # User skills
    ls ~/.copilot/skills/
+   ls ~/.agents/skills/
    ```
 
 3. **Check SKILL.md format**: Frontmatter is required:
@@ -863,7 +867,7 @@ Run `/skills reload` after creating or editing skills to ensure changes are pick
 1. **Skills are automatic**: Copilot loads them when your prompt matches the skill's description
 2. **Direct invocation**: You can also invoke skills directly with `/skill-name` as a slash command
 3. **SKILL.md format**: YAML frontmatter (name, description, optional license) plus markdown instructions
-4. **Location matters**: `.github/skills/` for project/team sharing, `~/.copilot/skills/` for personal use
+4. **Location matters**: `.github/skills/` for project/team sharing, `~/.copilot/skills/` or `~/.agents/skills/` for personal use
 5. **Description is key**: Write descriptions that match how you naturally ask questions
 
 > 📋 **Quick Reference**: See the [GitHub Copilot CLI command reference](https://docs.github.com/en/copilot/reference/cli-command-reference) for a complete list of commands and shortcuts.

--- a/website/src/content/docs/learning-hub/copilot-configuration-basics.md
+++ b/website/src/content/docs/learning-hub/copilot-configuration-basics.md
@@ -194,7 +194,7 @@ When you work inside `packages/api/`, Copilot loads configuration from `packages
 
 ### Personal Skills Directory
 
-In addition to repository-level skills, GitHub Copilot CLI supports a **personal skills directory** at `~/.agents/skills/`. Skills you place here are discovered automatically across all your projects, making them ideal for personal workflows and reusable utilities that are not project-specific.
+In addition to repository-level skills, GitHub Copilot CLI supports **personal skills directories** at `~/.copilot/skills/` and `~/.agents/skills/`. Skills you place in either location are discovered automatically across all your projects, making them ideal for personal workflows and reusable utilities that are not project-specific.
 
 ```
 ~/.agents/
@@ -205,7 +205,7 @@ In addition to repository-level skills, GitHub Copilot CLI supports a **personal
         └── SKILL.md
 ```
 
-This personal directory aligns with the VS Code GitHub Copilot for Azure extension's default skill discovery path, so skills defined here work consistently across tools.
+The `~/.agents/skills/` path aligns with the VS Code GitHub Copilot for Azure extension's default skill discovery path, while `~/.copilot/skills/` matches the Copilot CLI configuration directory. Both are supported for personal skills.
 
 ### Custom Agents
 
@@ -402,7 +402,7 @@ In addition to the main config file, GitHub Copilot CLI reads two optional per-p
 
 These files follow the same format as `config.json` and are loaded after the global config, so they can tailor CLI behaviour—including hook definitions—per repository without touching `.github/`.
 
-> **Important (v1.0.36+)**: Custom agents, skills, and commands placed in `~/.claude/` (the Claude Code user directory) are **no longer loaded** by GitHub Copilot CLI. Only `~/.claude/settings.json` is read for configuration. If you previously stored personal agents or skills in `~/.claude/`, move them to the supported locations: `~/.agents/` for user-level agents, `~/.agents/skills/` for personal skills, or `.github/agents/` and `.github/skills/` in your repositories for project-level customizations.
+> **Important (v1.0.36+)**: Custom agents, skills, and commands placed in `~/.claude/` (the Claude Code user directory) are **no longer loaded** by GitHub Copilot CLI. Only `~/.claude/settings.json` is read for configuration. If you previously stored personal agents or skills in `~/.claude/`, move them to the supported locations: `~/.copilot/agents/` for user-level agents, `~/.copilot/skills/` or `~/.agents/skills/` for personal skills, or `.github/agents/` and `.github/skills/` in your repositories for project-level customizations.
 
 ### Model Picker
 


### PR DESCRIPTION
## Summary
- Clarify that GitHub Copilot CLI supports both `~/.copilot/skills/` and `~/.agents/skills/` for personal skills.
- Update the CLI beginner skills guide, configuration basics page, reusable CLI mastery reference, and agent-skills instruction table so they no longer conflict.
- Replace the stray `~/.github/skills/` personal path with the supported Copilot personal skill paths.

## Validation
- `npm run skill:validate`
- `npm run build`
- `bash eng/fix-line-endings.sh`

Closes #1977.