### PR TITLE
Add spring boot 4 trailing slash migration

### DIFF
--- a/instructions/springboot-4-migration.instructions.md
+++ b/instructions/springboot-4-migration.instructions.md
@@ -961,6 +961,35 @@ class WebConfig {
 }
 ```
 
+### Trailing Slash URL Matching Removed
+
+`PathMatchConfigurer#setUseTrailingSlashMatch(true)` is **removed** in Spring Framework 7 / Spring Boot 4.
+There is no replacement configuration knob — `/foo` and `/foo/` are no longer treated as the same route.
+
+**Migration:** register Spring Framework's `UrlHandlerFilter` as a
+`FilterRegistrationBean` so it runs ahead of the security chain. `wrapRequest()` makes it forward transparently (no
+redirect), preserving the old behavior end-to-end:
+
+```java
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.web.filter.UrlHandlerFilter;
+
+@Configuration
+class WebConfig {
+
+    // After ForwardedHeaderFilter, before ServletRequestPathFilter and security filters.
+    private static final int BEFORE_SECURITY_FILTER_ORDER = -101;
+
+    @Bean
+    FilterRegistrationBean<UrlHandlerFilter> trailingSlashHandlerFilter() {
+        UrlHandlerFilter filter = UrlHandlerFilter.trailingSlashHandler("/**").wrapRequest().build();
+        FilterRegistrationBean<UrlHandlerFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.setOrder(BEFORE_SECURITY_FILTER_ORDER);
+        return registration;
+    }
+}
+```
+
 ### Jersey and Jackson 3 Incompatibility
 
 **Jersey 4.0 limitation:** Spring Boot 4.0 supports Jersey 4.0, which **does not yet support Jackson 3**.


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [x] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

I bumped into this issue with trailing slash config removal in spring boot 4 that was not properly handled by open-rewrite recipe, because it was set dynamically (based on a flag). The open-rewrite recipe just deleted the setting, which is dangerous if it remains unnoticed and reaches production and if other services depend on this.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
