### PR TITLE
Fix fork PR permissions in external plugin quality workflow

### DIFF
--- a/.github/workflows/external-plugin-pr-quality-gates.yml
+++ b/.github/workflows/external-plugin-pr-quality-gates.yml
@@ -1,7 +1,7 @@
 name: External Plugin PR Quality Gates
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [staged]
     paths:
       - "plugins/external.json"


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

Fork-based PRs were failing in `external-plugin-pr-quality-gates.yml` with `Resource not accessible by integration` when the workflow tried to apply labels and update the PR status comment.

This change switches the trigger from `pull_request` to `pull_request_target` so the workflow runs with base-repo token permissions for those write operations. The workflow remains safe because it does not execute untrusted PR head code: the quality job and state-sync job both check out `staged`, and change detection reads `plugins/external.json` via the GitHub API.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

## Additional Notes

This PR addresses the workflow permission failure mode for fork PRs. A separate data validation error in the sample failing run (missing `source.ref` or `source.sha` for `modernize-dotnet`) is not changed here.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.