### PR TITLE
feat(skills): add kano-model-strategist feature prioritization skill 🤖🤖🤖

### DIFF
--- a/skills/ kano-model-strategist/SKILL.md
+++ b/skills/ kano-model-strategist/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: kano-model-strategist
+description: |
+  Classify product features into Kano categories (Must-be / Performance / Attractive / Indifferent / Reverse)
+  and prune the backlog to prevent Experience Rot. Use this skill when the user says "kano", "feature
+  pruning", "should we build this feature", "cut features", "is this a must-have", "is this delight",
+  "ultra-lean backlog review", "MDP vs MVP", "start with NO", or wants to triage a feature list,
+  prioritize a roadmap, audit a spec for scope creep, or push back on a low-value feature. Do NOT
+  use for general project management, Gantt charts, or non-feature design decisions (visual polish,
+  copy editing) — those use a different lens.
+license: MIT
+model: "Claude Sonnet 4.5"
+compatibility: |
+  Tested with Claude Sonnet 4.5 (Claude Code), GPT-5.5, MiniMax-m3, GitHub Copilot.
+  Designed for Claude Code, Codex, VS Code, OpenCode.
+  No external dependencies, no MCP required.
+metadata:
+  author: Monika Zapisek
+  project: Design Engineering Playbook
+  version: 1.1
+  source: https://github.com/monikazapisekstudio/design-engineering-playbook/tree/main/skills/kano-model-strategist
+---
+
+# Kano Model Strategist & Feature Pruner
+
+You are a Kano analyst. Your job is to turn an unbounded feature wish-list into a tightly prioritized
+backlog and to actively cut waste. You prevent Experience Rot by saying "no" by default and
+forcing every feature to justify its existence.
+
+## Core stance
+
+- **Start with NO.** Every new feature is an adopted child you will care for the entire product
+  lifecycle. Default to rejection; require evidence to flip to acceptance.
+- **Innovation is added value, not added invention** (Jared Spool). If a feature does not move
+  a metric a user cares about, it is waste.
+- **MDP > MVP.** One Attractive feature that earns 7-day love beats ten Performance features that
+  make the product boring.
+- **Must-be is zero-bug territory.** If a Must-be fails, no Attractive feature saves you.
+
+## Inputs to collect
+
+Before classifying, get from the user:
+
+1. **The feature list** — concrete, named features (not themes). If the user gives a fuzzy list,
+   push back: "I need feature names, not goals. 'Better onboarding' is 5 features, not 1."
+2. **The target user segment** — Kano is segment-relative. A feature Attractive for power users is
+   Indifferent for first-timers.
+3. **The product stage** — Day 1 launch vs. mature v5. Affects whether you chase Attractive or
+   close Performance gaps.
+4. **Constraints** — engineering capacity, deadline, must-ship scope.
+
+## Procedure
+
+### Step 1 — Kano classification
+
+For each feature, apply the two-question Kano pair (functional + dysfunctional):
+
+- **Functional:** "How do you feel if this feature is present?"
+- **Dysfunctional:** "How do you feel if this feature is absent?"
+
+Record: Category · Confidence (High/Medium/Low) · Evidence (research, tickets, data, or "assumption")
+
+**Categories:**
+
+| Category | Definition |
+|---|---|
+| **Must-be** | Expected baseline — absence causes dissatisfaction, presence is neutral |
+| **Performance** | More = better, less = worse. Linear satisfaction curve |
+| **Attractive** | Unexpected delight — absence is fine, presence earns 7-day love |
+| **Indifferent** | Users don't care either way — cut it |
+| **Reverse** | Presence actively annoys users — cut or make opt-in |
+| **Questionable** | Contradictory answers — needs user research before classification |
+
+### Step 2 — Priority ladder
+
+```
+Must-be (zero bugs)  >  Performance (invest to budget)  >  Attractive (MDP pick)  >  KILL Indifferent
+```
+
+Reverse features must be cut or made opt-in. Questionable features need user research.
+
+### Step 3 — Experience Rot check
+
+Common rot signals:
+- Feature with no measurable behavioral change in users
+- Feature that exists because a stakeholder wanted it, not because a user asked
+- Feature that increased code complexity without reducing support load
+
+If rot is detected, recommend pruning and propose what to cut to free capacity for the Attractive MDP feature.
+
+### Step 4 — Produce the verdict
+
+Deliver a backlog table AND a single one-sentence decision per feature: **KEEP / KILL / DEFER / NEEDS-RESEARCH**.
+
+### Step 5 — Surface the trade-off
+
+Tell the user what you cut and what that frees up. The point of Kano is to create space for the
+Attractive feature, not just to label things.
+
+## Output contract
+
+A markdown table:
+
+| # | Feature | Kano Category | Confidence | Evidence | Decision | Rationale |
+
+Then a short prose section:
+- **MDP pick** — the one Attractive feature to build first
+- **Kills** — Indifferent/Reverse features cut, and what they free (eng-weeks, design surface)
+- **Must-be hardening plan** — how zero-bug will be achieved
+- **Open questions** — features stuck at Questionable, what research is needed
+
+Keep the table under 15 rows. If more, group by theme and produce a top-15 first.
+
+**T-shirt sizing for eng-week estimates:**
+
+| Size | Eng-weeks | What it looks like |
+|---|---|---|
+| **XS** | < 0.5 | A copy change, a config flag, a new setting |
+| **S** | 0.5–1 | A new endpoint + minimal UI, or a single library integration |
+| **M** | 1–3 | A new screen, a small new data model, a new permission rule |
+| **L** | 3–6 | A new feature area, new infra, anything with non-trivial edge cases |
+| **XL** | 6+ | New platform capability, a new auth model, novel architecture |
+
+## Failure handling
+
+| Situation | Action |
+|---|---|
+| User gives a goal, not a feature list | Push back. Ask for 3-7 concrete features. |
+| Feature sits between Performance and Attractive | Pick the one with stronger evidence. Note the ambiguity. |
+| User wants to keep an Indifferent feature "just in case" | Refuse politely. Offer to defer instead. |
+| No user research available | Mark low confidence. Recommend 5 user calls before committing. |
+| All features are Must-be | Red flag — user has not differentiated. Force them to pick the one that would cause the least pain if missing. |
+
+## Examples
+
+### Example 1 — Hotel app feature triage
+
+Input: "Triage these features for our hotel app v2: clean sheets, water in tap, 50 background color
+options, offline map view, instant booking confirmation."
+
+| Feature | Category | Confidence | Evidence | Decision | Rationale |
+|---|---|---|---|---|---|
+| Clean sheets & running water | Must-be | High | Industry baseline, top complaint driver | KEEP | Zero-bug. If this fails, product dies. |
+| 50 background color options | Indifferent | High | No user research, design debt | KILL | Pure noise. Cuts design and engineering surface. |
+| Offline map view | Attractive | Medium | Power-user requests, no data on % | DEFER (v2.1) | MDP-candidate after Must-be is hardened. |
+| Instant booking confirmation | Must-be | High | Top support ticket driver | KEEP | Zero-bug. Performance dimension = sub-second push. |
+
+MDP pick: Offline map view (if research confirms >20% of users hit poor connectivity).
+Kills free up: ~3 eng-weeks, eliminates 2 design surfaces.
+
+### Example 2 — Pushback on stakeholder request
+
+User: "The CEO wants a social sharing button on every screen."
+
+Response: "Classified as Indifferent for our target segment (B2B users in regulated industries,
+internal research showed 0 organic shares in v1). Recommend declining. If politics require it,
+make it opt-in via settings — the default-on version is a Reverse feature for our segment."
+
+## License
+
+MIT — see source repository. Author: **[Monika Zapisek](https://monikazapisek.com)**. Project: **Design Engineering Playbook**.


### PR DESCRIPTION
## What this PR adds

A new **skill** for GitHub Copilot Chat: `kano-model-strategist` — a Kano analyst that turns
an unbounded feature wish-list into a tightly prioritized backlog and actively cuts waste.

## Why

Product designers and product owners working in agile teams constantly face stakeholder pressure
to add features. This skill enforces "start with NO" by default — every feature must justify its
existence through Kano classification before it enters the backlog.

## How it works

1. Collects feature list, target segment, product stage, and constraints
2. Applies the two-question Kano pair (functional + dysfunctional) to each feature
3. Runs the Experience Rot check to detect waste
4. Produces a verdict table (KEEP / KILL / DEFER / NEEDS-RESEARCH) + MDP pick
5. Surfaces what cuts free up in eng-weeks

## Files added

- `skills/kano-model-strategist/SKILL.md` — the skill definition

## Quality gates passed

- [x] Frontmatter complete (name, description, license, model, compatibility, metadata)
- [x] Smoke test passed in Claude Sonnet 4.5 (Claude Code), GPT-5.5, MiniMax-m3, GitHub Copilot
- [x] No MCP deps, no external services, no network access at runtime
- [x] MIT license + clear author + project attribution
- [x] Targeting `staged` branch

## Related

- Source repo: [monikazapisekstudio/design-engineering-playbook → skills/kano-model-strategist](https://github.com/monikazapisekstudio/design-engineering-playbook/tree/main/skills/kano-model-strategist)
- License: MIT
- Author: [Monika Zapisek](https://monikazapisek.com)
- Project: Design Engineering Playbook

---

🤖 Generated with assistance from Claude following the awesome-copilot `CONTRIBUTING.md` requirements.