### PR TITLE
Fix Copilot SDK session event handler compile issue

### DIFF
--- a/cookbook/copilot-sdk/dotnet/recipe/pr-visualization.cs
+++ b/cookbook/copilot-sdk/dotnet/recipe/pr-visualization.cs
@@ -153,7 +153,7 @@ The current working directory is: {Environment.CurrentDirectory}
 });
 
 // Set up event handling
-session.On(evt =>
+session.On<SessionEvent>(evt =>
 {
     switch (evt)
     {


### PR DESCRIPTION
## Summary
- Updates the Copilot SDK PR visualization recipe to subscribe with `session.On<SessionEvent>(...)`.
- Fixes a compile issue caused by the SDK breaking change that now requires the event type for this handler.
- Supersedes #2054, which was opened with an incorrect revert-focused title/base for this fix.

## Testing
- Not run. This recipe invokes live Copilot/GitHub tooling, so I kept validation to the focused one-line diff.