### PR TITLE
Add AI Catalog generation for .well-known manifest

### DIFF
--- a/eng/generate-website-data.mjs
+++ b/eng/generate-website-data.mjs
@@ -35,6 +35,11 @@ const __filename = fileURLToPath(import.meta.url);
 const WEBSITE_DIR = path.join(ROOT_FOLDER, "website");
 const WEBSITE_DATA_DIR = path.join(WEBSITE_DIR, "public", "data");
 const WEBSITE_SOURCE_DATA_DIR = path.join(WEBSITE_DIR, "data");
+const WEBSITE_BASE_URL = "https://awesome-copilot.github.com";
+const RAW_CONTENT_BASE_URL =
+  "https://raw.githubusercontent.com/github/awesome-copilot/main";
+const WELL_KNOWN_DIR = path.join(WEBSITE_DIR, "public", ".well-known");
+const AI_CATALOG_FILE = path.join(WELL_KNOWN_DIR, "ai-catalog.json");
 
 /**
  * Ensure the output directory exists
@@ -42,6 +47,15 @@ const WEBSITE_SOURCE_DATA_DIR = path.join(WEBSITE_DIR, "data");
 function ensureDataDir() {
   if (!fs.existsSync(WEBSITE_DATA_DIR)) {
     fs.mkdirSync(WEBSITE_DATA_DIR, { recursive: true });
+  }
+}
+
+/**
+ * Ensure the .well-known output directory exists
+ */
+function ensureWellKnownDir() {
+  if (!fs.existsSync(WELL_KNOWN_DIR)) {
+    fs.mkdirSync(WELL_KNOWN_DIR, { recursive: true });
   }
 }
 
@@ -99,6 +113,187 @@ function formatDisplayName(value) {
 
 function normalizeText(value, fallback = "") {
   return typeof value === "string" ? value.trim() : fallback;
+}
+
+function normalizeRepoPath(value) {
+  return normalizeText(value).replace(/\\/g, "/").replace(/^\/+/, "");
+}
+
+function buildRawContentUrl(relativePath) {
+  return `${RAW_CONTENT_BASE_URL}/${normalizeRepoPath(relativePath)}`;
+}
+
+function buildWebsiteUrl(route) {
+  const normalizedRoute = route.startsWith("/") ? route : `/${route}`;
+  return new URL(normalizedRoute, `${WEBSITE_BASE_URL}/`).toString();
+}
+
+function normalizeDescription(value) {
+  const description = normalizeText(value);
+  return description || "No description provided.";
+}
+
+function toUrnSegment(value) {
+  const normalized = normalizeText(value).toLowerCase();
+  const segment = normalized
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return segment || "unknown";
+}
+
+function createAiCatalogEntry({
+  category,
+  id,
+  displayName,
+  description,
+  type,
+  url,
+}) {
+  return {
+    identifier: `urn:ai:awesome-copilot.github.com:${category}:${toUrnSegment(id)}`,
+    displayName: normalizeText(displayName, id),
+    type,
+    url,
+    description: normalizeDescription(description),
+  };
+}
+
+function generateAiCatalogData({
+  agents,
+  instructions,
+  skills,
+  hooks,
+  workflows,
+  plugins,
+}) {
+  const entries = [];
+
+  for (const agent of agents) {
+    entries.push(
+      createAiCatalogEntry({
+        category: "agent",
+        id: agent.id,
+        displayName: agent.title,
+        description: agent.description,
+        type: "text/markdown",
+        url: buildRawContentUrl(agent.path),
+      })
+    );
+  }
+
+  for (const instruction of instructions) {
+    entries.push(
+      createAiCatalogEntry({
+        category: "instruction",
+        id: instruction.id,
+        displayName: instruction.title,
+        description: instruction.description,
+        type: "text/markdown",
+        url: buildRawContentUrl(instruction.path),
+      })
+    );
+  }
+
+  for (const skill of skills) {
+    entries.push(
+      createAiCatalogEntry({
+        category: "skill",
+        id: skill.id,
+        displayName: skill.title,
+        description: skill.description,
+        type: "text/markdown",
+        url: buildRawContentUrl(skill.skillFile),
+      })
+    );
+  }
+
+  for (const hook of hooks) {
+    entries.push(
+      createAiCatalogEntry({
+        category: "hook",
+        id: hook.id,
+        displayName: hook.title,
+        description: hook.description,
+        type: "text/markdown",
+        url: buildRawContentUrl(hook.readmeFile),
+      })
+    );
+  }
+
+  for (const workflow of workflows) {
+    entries.push(
+      createAiCatalogEntry({
+        category: "workflow",
+        id: workflow.id,
+        displayName: workflow.title,
+        description: workflow.description,
+        type: "text/markdown",
+        url: buildRawContentUrl(workflow.path),
+      })
+    );
+  }
+
+  for (const plugin of plugins) {
+    const pluginUrl = plugin.external
+      ? plugin.homepage ||
+        plugin.repository ||
+        buildWebsiteUrl(`/plugins/?q=${encodeURIComponent(plugin.name)}`)
+      : buildRawContentUrl(`${plugin.path}/.github/plugin/plugin.json`);
+
+    entries.push(
+      createAiCatalogEntry({
+        category: "plugin",
+        id: plugin.id || plugin.name,
+        displayName: plugin.name,
+        description: plugin.description,
+        type: plugin.external ? "text/html" : "application/json",
+        url: pluginUrl,
+      })
+    );
+  }
+
+  entries.sort((a, b) => a.displayName.localeCompare(b.displayName));
+
+  return {
+    specVersion: "1.0",
+    host: {
+      displayName: "Awesome GitHub Copilot",
+      identifier: "awesome-copilot.github.com",
+    },
+    entries,
+    collections: [
+      {
+        displayName: "Agents",
+        url: buildWebsiteUrl("/agents/"),
+        description: "Specialized GitHub Copilot agents.",
+      },
+      {
+        displayName: "Instructions",
+        url: buildWebsiteUrl("/instructions/"),
+        description: "Custom coding instructions for Copilot.",
+      },
+      {
+        displayName: "Skills",
+        url: buildWebsiteUrl("/skills/"),
+        description: "Agent Skills with bundled assets and instructions.",
+      },
+      {
+        displayName: "Hooks",
+        url: buildWebsiteUrl("/hooks/"),
+        description: "Hooks for automated Copilot coding agent workflows.",
+      },
+      {
+        displayName: "Workflows",
+        url: buildWebsiteUrl("/workflows/"),
+        description: "Agentic workflows for GitHub Actions automation.",
+      },
+      {
+        displayName: "Plugins",
+        url: buildWebsiteUrl("/plugins/"),
+        description: "Curated plugin bundles for common scenarios.",
+      },
+    ],
+  };
 }
 
 /**
@@ -1593,6 +1788,16 @@ async function main() {
   );
   console.log(`✓ Generated search index with ${searchIndex.length} items`);
 
+  const aiCatalogData = generateAiCatalogData({
+    agents,
+    instructions,
+    skills,
+    hooks,
+    workflows,
+    plugins,
+  });
+  console.log(`✓ Generated AI Catalog with ${aiCatalogData.entries.length} entries`);
+
   // Write JSON files
   fs.writeFileSync(
     path.join(WEBSITE_DATA_DIR, "agents.json"),
@@ -1669,7 +1874,11 @@ async function main() {
     JSON.stringify(manifest, null, 2)
   );
 
+  ensureWellKnownDir();
+  fs.writeFileSync(AI_CATALOG_FILE, JSON.stringify(aiCatalogData, null, 2));
+
   console.log(`\n✓ All data written to website/public/data/`);
+  console.log(`✓ AI Catalog written to website/public/.well-known/ai-catalog.json`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [ ] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

This adds phase 1 ARD support by publishing an AI Catalog manifest from the repository's existing metadata pipeline. The goal is to make Awesome Copilot resources discoverable by external ARD-compatible discovery services (for example, Agent Finder) without introducing a new runtime API service.

Implementation details:
- Extend `eng/generate-website-data.mjs` to build AI Catalog entries from existing generated resource sets: agents, instructions, skills, hooks, workflows, and plugins.
- Add normalized URL and identifier helpers, including stable URN-style identifiers for entries.
- Handle plugin URLs for both local and external plugins.
- Add host and collection metadata in the AI Catalog output.
- Write output to `website/public/.well-known/ai-catalog.json` during `npm run website:data`.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [x] Other (please specify): Build/data generation enhancement for website discovery metadata.

---

## Additional Notes

This PR intentionally focuses on static publication only. It does not add ARD `POST /search` or `POST /explore` endpoints, which would require a separate hosted service beyond the current static website model.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.