### PR TITLE
Fix Canvas Extensions install URLs for Copilot app

### DIFF
--- a/eng/generate-website-data.mjs
+++ b/eng/generate-website-data.mjs
@@ -1018,7 +1018,7 @@ function generateCanvasManifest(gitDates, commitSha) {
     const canvasEntries = canvases.length > 0
       ? canvases
       : [{ id: dir.name, displayName: formatDisplayName(dir.name), description: extensionDescription }];
-    const installUrl = `https://github.com/github/awesome-copilot/tree/${commitSha}/${relPath.replace(
+    const installUrl = `https://github.com/github/awesome-copilot/tree/main/${relPath.replace(
       /\\/g,
       "/"
     )}`;

--- a/website/src/pages/extensions.astro
+++ b/website/src/pages/extensions.astro
@@ -16,6 +16,11 @@ const initialItems = sortExtensions(extensionsData.items, 'title');
 
     <div class="page-content">
       <div class="container">
+        <div class="how-to-install">
+          <p><strong>Installing in the GitHub Copilot app:</strong> Click <strong>Copy URL</strong>, then ask Copilot to install that extension URL.</p>
+          <p><strong>Example:</strong> <code>Install this extension: https://github.com/github/awesome-copilot/tree/main/extensions/accessibility-kanban</code></p>
+        </div>
+
         <div class="listing-toolbar">
           <div class="listing-toolbar-row">
             <div class="results-count" id="results-count" aria-live="polite">{initialItems.length} extensions</div>
@@ -66,6 +71,31 @@ const initialItems = sortExtensions(extensionsData.items, 'title');
   </script>
 
   <style>
+    .how-to-install {
+      background: var(--sl-color-bg-nav);
+      border: 1px solid var(--sl-color-hairline);
+      border-radius: 0.5rem;
+      padding: 1rem 1.25rem;
+      margin-bottom: 1.5rem;
+      font-size: 0.9rem;
+      line-height: 1.6;
+    }
+
+    .how-to-install p {
+      margin: 0 0 0.5rem;
+    }
+
+    .how-to-install p:last-child {
+      margin-bottom: 0;
+    }
+
+    .how-to-install code {
+      background: var(--sl-color-bg-inline-code);
+      padding: 0.1em 0.35em;
+      border-radius: 0.2rem;
+      font-size: 0.85em;
+    }
+
     .extensions-page .resource-preview {
       cursor: default;
     }

--- a/website/src/scripts/pages/extensions-render.ts
+++ b/website/src/scripts/pages/extensions-render.ts
@@ -113,7 +113,7 @@ export function renderExtensionsHtml(items: RenderableExtension[]): string {
               title="Copy install URL"
               ${installUrl ? "" : "disabled"}
             >
-              Install
+              Copy URL
             </button>
             ${
               sourceUrl

--- a/website/src/scripts/pages/extensions.ts
+++ b/website/src/scripts/pages/extensions.ts
@@ -136,7 +136,7 @@ function setupActionHandlers(list: HTMLElement | null): void {
     }
     const success = await copyToClipboard(installUrl);
     showToast(
-      success ? "Install URL copied!" : "Failed to copy install URL",
+      success ? "Extension URL copied!" : "Failed to copy extension URL",
       success ? "success" : "error"
     );
   });


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, or workflow file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, or workflow with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

Canvas extension install links on the website were copied as SHA-pinned `tree/<sha>/...` URLs, which do not work reliably in extension install flows for nested extension paths. This updates the generated and rendered install links to use stable `tree/main/...` URLs so copied links are installable in the GitHub Copilot app flow.

The Extensions page now also includes explicit app-native install guidance and a concrete example prompt. The action label and toast text were updated to make it clear that the button copies an install URL.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [x] Update to existing instruction, prompt, agent, plugin, skill, or workflow.
- [ ] Other (please specify):

---

## Additional Notes

- This change is scoped to the Canvas Extensions website experience.
- No source issue reference was provided for automatic closing.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.