### PR TITLE
test: verify pr-duplicate-check positive path (#2082) — DO NOT MERGE

### DIFF
--- a/instructions/rust-coding-guidelines.instructions.md
+++ b/instructions/rust-coding-guidelines.instructions.md
@@ -1,0 +1,32 @@
+---
+description: 'Rust programming language coding conventions, guidelines, and best practices'
+applyTo: '**/*.rs'
+---
+
+# Rust Coding Guidelines and Best Practices
+
+Follow idiomatic Rust practices and community standards when writing Rust code.
+
+## General Principles
+
+- Write clear, idiomatic, and efficient Rust code.
+- Prefer safe Rust; isolate and document any `unsafe` blocks.
+- Use the type system to make invalid states unrepresentable.
+- Favor iterators and combinators over manual index-based loops.
+
+## Naming Conventions
+
+- Use `snake_case` for functions, variables, and modules.
+- Use `PascalCase` for types, traits, and enum variants.
+- Use `SCREAMING_SNAKE_CASE` for constants and statics.
+
+## Error Handling
+
+- Return `Result<T, E>` for fallible operations; avoid `unwrap()`/`expect()` outside tests.
+- Use the `?` operator to propagate errors.
+- Prefer `thiserror` for library errors and `anyhow` for application errors.
+
+## Tooling
+
+- Format with `rustfmt` and lint with `clippy` before committing.
+- Keep `Cargo.toml` dependencies minimal and pinned where appropriate.


### PR DESCRIPTION
> ⚠️ **Throwaway test PR — do not merge.** Opened to verify the *positive* path of the `pr-duplicate-check` agentic workflow (the one remaining acceptance criterion in #2082) on gh-aw `v0.80.9`. It adds an intentional near-duplicate of `instructions/rust.instructions.md`. I will close it as soon as the bot posts (or doesn't post) its advisory comment.

## What this tests
`pr-duplicate-check` should detect that the new `instructions/rust-coding-guidelines.instructions.md` overlaps the existing `instructions/rust.instructions.md` (same `applyTo: '**/*.rs'`, near-identical description and scope) and post a single `🔍 Potential Duplicate Resources Detected` advisory comment.

Tracking: #2082 (part of #2076).
