### PR TITLE
Fix install dropdown render2

### DIFF
--- a/website/src/scripts/utils.ts
+++ b/website/src/scripts/utils.ts
@@ -554,6 +554,18 @@ export function setupDropdownCloseHandlers(): void {
           e.preventDefault();
           const isOpen = dropdown.classList.toggle("open");
           toggle.setAttribute("aria-expanded", String(isOpen));
+
+          if (isOpen) {
+            document
+              .querySelectorAll('.install-dropdown[data-install-scope="list"].open')
+              .forEach((openDropdown) => {
+                if (openDropdown === dropdown) return;
+                openDropdown.classList.remove("open");
+                openDropdown.querySelector(".install-btn-toggle")
+                  ?.setAttribute("aria-expanded", "false");
+              });
+          }
+
           return;
         }
 

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -868,7 +868,6 @@ body:has(#main-content) {
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius);
   box-shadow: var(--shadow-md);
-  z-index: 1000;
   opacity: 0;
   visibility: hidden;
   transform: translateY(-8px);
@@ -1875,6 +1874,11 @@ body:has(#main-content) {
   transform: translateX(4px);
   box-shadow: var(--shadow);
   border-radius: 0px var(--border-radius-lg) var(--border-radius-lg) 0px;
+  z-index: 1;
+}
+
+.resource-item:has(.install-dropdown.open) {
+  z-index: 2;
 }
 
 .resource-item:hover::before,


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `staged` branch for this pull request.

---

## Description

  - Dropdowns in the list view now close each other — opening one will automatically close any previously open dropdown instead of leaving multiple open at once.
  - Fixed z-index so the active dropdown renders above sibling items by moving z-index from the dropdown menu element to the parent .resource-item, applied only when the dropdown is open.

Before:

<img width="579" height="392" alt="Screenshot 2026-06-24 at 21 36 03" src="https://github.com/user-attachments/assets/ee04e43f-e6c4-4615-9188-bf5a89d13bd0" />

After (only one can be opened at a time):

<img width="568" height="343" alt="Screenshot 2026-06-24 at 21 36 51" src="https://github.com/user-attachments/assets/930e2e55-237e-419d-a9ea-c87dba05ba37" />

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [ ] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [x] Other (please specify): Minor JS / CSS fix on the website

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
