### PR TITLE
create-implementation-plan: require unique identifiers (#1989)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -56,7 +56,9 @@
 
 # ans - bash and powershell variable short for answer
 
-ignore-words-list = numer,wit,aks,edn,ser,ois,gir,rouge,categor,aline,ative,afterall,deques,dateA,dateB,TE,FillIn,alle,vai,LOD,InOut,pixelX,aNULL,Wee,Sherif,queston,Vertexes,nin,FO,CAF,Parth,ans
+# GUD - "Guideline" identifier prefix in the create-implementation-plan skill spec (alongside REQ, SEC, CON, PAT, etc.)
+
+ignore-words-list = numer,wit,aks,edn,ser,ois,gir,rouge,categor,aline,ative,afterall,deques,dateA,dateB,TE,FillIn,alle,vai,LOD,InOut,pixelX,aNULL,Wee,Sherif,queston,Vertexes,nin,FO,CAF,Parth,ans,gud
 
 # Skip certain files and directories
 

--- a/skills/create-implementation-plan/SKILL.md
+++ b/skills/create-implementation-plan/SKILL.md
@@ -60,6 +60,34 @@ All implementation plans must strictly adhere to the following template. Each se
 - All identifier prefixes must follow the specified format
 - Tables must include all required columns
 - No placeholder text may remain in the final output
+- **Identifiers must be unique.** Every declaration of `REQ-NNN`, `SEC-NNN`, `CON-NNN`, `GUD-NNN`, `PAT-NNN`, `GOAL-NNN`, `TASK-NNN`, `ALT-NNN`, `DEP-NNN`, `FILE-NNN`, `TEST-NNN`, `RISK-NNN`, and `ASSUMPTION-NNN` must appear exactly once across the plan. `DEP-*` may appear in multiple sections (for example, Requirements and Dependencies) as a reference; that is not a declaration collision.
+
+## Identifier Uniqueness Check
+
+Run these checks before finalizing the plan. The first two must return zero rows. The third is informational.
+
+```bash
+# Set PLAN_FILE to the plan being validated.
+PLAN_FILE="/plan/<purpose>-<component>-<version>.md"
+
+# 1) Duplicate TASK / GOAL declarations in table rows.
+grep -oE '\| (TASK|GOAL)-[0-9]+ \|' "$PLAN_FILE" \
+  | sed -E 's/.*((TASK|GOAL)-[0-9]+).*/\1/' \
+  | sort | uniq -d
+
+# 2) Duplicate declaration IDs in bullet-style spec lines.
+grep -oE '^- \*\*(REQ|SEC|CON|GUD|RISK|ASSUMPTION|TASK|GOAL|FILE|TEST|PAT|ALT|DEP)-[0-9]+\*\*:' "$PLAN_FILE" \
+  | sed -E 's/^- \*\*([A-Z]+-[0-9]+)\*\*:.*/\1/' \
+  | sort | uniq -d
+
+# 3) Broad duplicate scan (diagnostic only; may include valid references).
+grep -oE '(REQ|SEC|CON|GUD|RISK|ASSUMPTION|TASK|GOAL|FILE|TEST|PAT|ALT|DEP)-[0-9]+' "$PLAN_FILE" \
+  | sort | uniq -d
+```
+
+Prerequisites: a POSIX-compatible shell (`sh` / `bash`) with `grep`, `sed`, `sort`, and `uniq`. On Windows without these tools, use equivalent platform-native commands and preserve the same declaration-vs-reference logic.
+
+If check (1) or (2) returns any row, re-number the duplicate so each identifier is declared exactly once, then re-run the checks until both are empty.
 
 ## Status
 

--- a/skills/create-implementation-plan/SKILL.md
+++ b/skills/create-implementation-plan/SKILL.md
@@ -60,11 +60,11 @@ All implementation plans must strictly adhere to the following template. Each se
 - All identifier prefixes must follow the specified format
 - Tables must include all required columns
 - No placeholder text may remain in the final output
-- **Identifiers must be unique.** Every declaration of `REQ-NNN`, `SEC-NNN`, `CON-NNN`, `GUD-NNN`, `PAT-NNN`, `GOAL-NNN`, `TASK-NNN`, `ALT-NNN`, `DEP-NNN`, `FILE-NNN`, `TEST-NNN`, `RISK-NNN`, and `ASSUMPTION-NNN` must appear exactly once across the plan. `DEP-*` may appear in multiple sections (for example, Requirements and Dependencies) as a reference; that is not a declaration collision.
+- **Identifiers must be uniquely declared.** Every identifier (`REQ-NNN`, `SEC-NNN`, `CON-NNN`, `GUD-NNN`, `PAT-NNN`, `GOAL-NNN`, `TASK-NNN`, `ALT-NNN`, `DEP-NNN`, `FILE-NNN`, `TEST-NNN`, `RISK-NNN`, `ASSUMPTION-NNN`) must be **declared exactly once**. A declaration is where the identifier introduces a row: the leading cell in a TASK/GOAL table row, or the bolded prefix in a bullet line like `- **REQ-001**: ...`. The same identifier may then appear any number of times as a **reference** elsewhere in the plan (a `TASK` body citing a `REQ`, one `TASK` citing another `TASK`, the Dependencies section pointing at a `DEP` already declared upstream, etc.). References are expected and not collisions.
 
 ## Identifier Uniqueness Check
 
-Run these checks before finalizing the plan. The first two must return zero rows. The third is informational.
+Run these checks before finalizing the plan. Checks (1) and (2) target declarations and must return zero rows. Check (3) is a broad informational scan: it will surface valid references too, so use it for awareness rather than as a gate.
 
 ```bash
 # Set PLAN_FILE to the plan being validated.


### PR DESCRIPTION
Closes #1989.

@basilevs reported that the ``create-implementation-plan`` skill occasionally produces plans with duplicate ``TASK-`` identifiers (and could just as easily collide on ``REQ-``, ``GOAL-``, etc.). The skill template defines the prefix scheme but doesn't say identifiers must be unique, and gives the agent no way to verify.

The reporter already worked out the right checks. This PR drops them into the skill.

## Changes

**``skills/create-implementation-plan/SKILL.md``** picks up:

1. A new bullet under ``Template Validation Rules``: identifiers must be declared exactly once across the plan. ``DEP-*`` is called out as the deliberate exception because it commonly appears as a reference in both Requirements and Dependencies.
2. A new ``Identifier Uniqueness Check`` section with the reporter's three POSIX one-liners:
   - Check 1: duplicate ``TASK`` / ``GOAL`` declarations in table rows.
   - Check 2: duplicate declaration IDs in bullet-style spec lines.
   - Check 3: broad diagnostic scan (informational, may flag valid references).

   Checks 1 and 2 must return empty before finalizing. The section also notes the POSIX prereqs and what to substitute on Windows.

## Why this shape

- Reporter @basilevs already wrote and proposed the exact validation commands in the issue thread. Lifting them in verbatim respects their work and matches what they intended.
- Adding the rule under the existing ``Template Validation Rules`` keeps it visible at the same scan depth as the other invariants.
- The bash block is presented as a quality gate the agent runs at the end, not a runtime dependency. The agent can also do the equivalent check by other means if it prefers.

## Verification

- ``npm run skill:validate`` reports ``create-implementation-plan`` as valid.
- ``npm run build`` exits 0, regenerates ``marketplace.json``.
- 1 file touched. No README diff because the skill description is unchanged.