### PR TITLE
Fix contributor reputation check comment deduping

### DIFF
--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -195,7 +195,7 @@ jobs:
           comment_ids=$(
             gh api "repos/${{ github.repository }}/issues/$number/comments" --paginate \
               --arg marker "$marker" \
-              --jq '.[] | select((.body // "") | contains($marker)) | .id'
+              --jq '.[] | select(.user.login == "github-actions[bot]" and ((.body // "") | contains($marker))) | .id'
           )
           comment_id=$(printf "%s\n" "$comment_ids" | sed -n '1p')
 

--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -192,17 +192,22 @@ jobs:
           profile="${{ steps.results.outputs.profile }}"
           cred="${{ steps.results.outputs.credential }}"
           marker="<!-- agt-contributor-check -->"
-          comment_id=$(
+          comment_ids=$(
             gh api "repos/${{ github.repository }}/issues/$number/comments" --paginate \
               --arg marker "$marker" \
-              --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains($marker))) | .id' \
-              | head -n 1
+              --jq '.[] | select((.body // "") | contains($marker)) | .id'
           )
+          comment_id=$(printf "%s\n" "$comment_ids" | sed -n '1p')
 
           if [ "$risk" != "MEDIUM" ] && [ "$risk" != "HIGH" ]; then
             if [ -n "$comment_id" ]; then
-              gh api --method DELETE "repos/${{ github.repository }}/issues/comments/$comment_id" \
-                || echo "Comment $comment_id could not be deleted; continuing because the comment may have already been removed or changed."
+              # Keep one canonical comment thread by removing all matching comments
+              # when risk drops below MEDIUM.
+              while IFS= read -r id; do
+                [ -z "$id" ] && continue
+                gh api --method DELETE "repos/${{ github.repository }}/issues/comments/$id" \
+                  || echo "Comment $id could not be deleted; continuing because the comment may have already been removed or changed."
+              done <<< "$comment_ids"
             fi
             exit 0
           fi
@@ -226,6 +231,11 @@ jobs:
 
           if [ -n "$comment_id" ]; then
             gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$comment_id" -f body="$body"
+            # Clean up any stale duplicates after updating the canonical comment.
+            printf "%s\n" "$comment_ids" | sed '1d' | while IFS= read -r id; do
+              [ -z "$id" ] && continue
+              gh api --method DELETE "repos/${{ github.repository }}/issues/comments/$id" >/dev/null 2>&1 || true
+            done
           else
             gh api --method POST "repos/${{ github.repository }}/issues/$number/comments" -f body="$body"
           fi


### PR DESCRIPTION
## Pull Request Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `main` branch for this pull request.

---

## Description

The contributor reputation workflow was leaving repeated PR comments across runs, which made review threads noisy. This change makes the risk comment behavior idempotent so each PR keeps a single canonical AGT comment.

The workflow now collects all comments containing the AGT marker, updates the first match, and removes any duplicates. When risk is below MEDIUM, it deletes all matching marker comments so stale warnings do not remain.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

## Additional Notes

N/A

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.