### PR TITLE
Fix README generation: make yaml-parser compatible with js-yaml 5.x

### DIFF
--- a/eng/yaml-parser.mjs
+++ b/eng/yaml-parser.mjs
@@ -1,6 +1,7 @@
 // YAML parser for frontmatter parsing using vfile-matter
 import fs from "fs";
-import yaml from "js-yaml";
+import * as _yaml from "js-yaml";
+const yaml = _yaml.default ?? _yaml;
 import path from "path";
 import { VFile } from "vfile";
 import { matter } from "vfile-matter";


### PR DESCRIPTION
### What

`npm start` (the README + marketplace generator) currently fails on a fresh `main`. `package.json` pins `js-yaml@^5.2.0`, and js-yaml 5.x is published as ESM with **named exports only** (no default export), so the default import in `eng/yaml-parser.mjs` throws at module load:

```
file:///.../eng/yaml-parser.mjs:3
import yaml from "js-yaml";
       ^^^^
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
```

### Fix

Switch to a namespace import with a default fallback:

```js
import * as _yaml from "js-yaml";
const yaml = _yaml.default ?? _yaml;
```

This works with both js-yaml 4.x (default export) and 5.x (named exports), with no behavior change. After it, `npm start` runs cleanly and regenerates the indexes with **no diff**.

Happy to take the other route instead (pinning `js-yaml` back to `^4.3.0`) if that's preferred — whatever fits the project better.
