### PR TITLE
Add author attribution to Site Studio canvas

### DIFF
--- a/extensions/site-studio/canvas.json
+++ b/extensions/site-studio/canvas.json
@@ -3,6 +3,10 @@
   "name": "Site Studio",
   "description": "Plan, draft, and track a personal website section by section — a shared canvas where you and your agent author content, watch progress, and review every change.",
   "version": "1.0.0",
+  "author": {
+    "name": "Ayan Gupta",
+    "url": "https://github.com/ayangupt"
+  },
   "keywords": [
     "agent-collaboration",
     "content-authoring",


### PR DESCRIPTION
Small follow-up to #2117 (now merged). Adds the `author` block to `extensions/site-studio/canvas.json` so the Canvas Extensions gallery renders attribution ("by @ayangupt"), matching the other extensions (e.g. accessibility-kanban, where-was-i). Metadata-only; no code change.

```json
"author": { "name": "Ayan Gupta", "url": "https://github.com/ayangupt" }
```