### PR TITLE
dotnet-test: polyglot description + keywords (mirror 0.2.0)

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -348,8 +348,8 @@
     },
     {
       "name": "dotnet-test",
-      "description": "Skills for running, writing, diagnosing, and migrating .NET tests: test execution, filtering, platform detection, coverage analysis, and MSTest workflows.",
-      "version": "0.1.0",
+      "description": "Polyglot unit-test generation via a multi-agent Research-Plan-Implement pipeline — writes and runs tests for .NET/C#, Python, TypeScript/JavaScript, Java, Go, Ruby, Rust, C++, Kotlin, Swift, and PowerShell. Plus .NET-focused test execution, coverage and CRAP analysis, testability review, platform detection, and MSTest/xUnit migration.",
+      "version": "0.2.0",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -357,13 +357,15 @@
       "homepage": "https://github.com/dotnet/skills",
       "keywords": [
         "dotnet",
+        "polyglot",
         "testing",
-        "mstest",
-        "xunit",
-        "nunit",
         "test-generation",
-        "coverage",
-        "migration"
+        "unit-tests",
+        "python",
+        "typescript",
+        "java",
+        "go",
+        "rust"
       ],
       "license": "MIT",
       "repository": "https://github.com/dotnet/skills",

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -235,8 +235,8 @@
   },
   {
     "name": "dotnet-test",
-    "description": "Skills for running, writing, diagnosing, and migrating .NET tests: test execution, filtering, platform detection, coverage analysis, and MSTest workflows.",
-    "version": "0.1.0",
+    "description": "Polyglot unit-test generation via a multi-agent Research-Plan-Implement pipeline — writes and runs tests for .NET/C#, Python, TypeScript/JavaScript, Java, Go, Ruby, Rust, C++, Kotlin, Swift, and PowerShell. Plus .NET-focused test execution, coverage and CRAP analysis, testability review, platform detection, and MSTest/xUnit migration.",
+    "version": "0.2.0",
     "author": {
       "name": "Microsoft",
       "url": "https://www.microsoft.com"
@@ -244,13 +244,15 @@
     "homepage": "https://github.com/dotnet/skills",
     "keywords": [
       "dotnet",
+      "polyglot",
       "testing",
-      "mstest",
-      "xunit",
-      "nunit",
       "test-generation",
-      "coverage",
-      "migration"
+      "unit-tests",
+      "python",
+      "typescript",
+      "java",
+      "go",
+      "rust"
     ],
     "license": "MIT",
     "repository": "https://github.com/dotnet/skills",


### PR DESCRIPTION
Reframes the `dotnet-test` external catalog entry to reflect the plugin's polyglot test-generation pipeline (11 languages: .NET/C#, Python, TypeScript/JavaScript, Java, Go, Ruby, Rust, C++, Kotlin, Swift, PowerShell) and adds polyglot keywords so non-.NET developers can discover it. Mirrors the dotnet/skills 0.2.0 bump (dotnet/skills#852). `source` stays unpinned (tracks `main`), so no behavior change. Edited the source `plugins/external.json`; `.github/plugin/marketplace.json` regenerated via `npm run build`.

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968). <!-- N/A: free / open-source -->
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory. <!-- N/A: updates an existing external entry -->
- [ ] The file follows the required naming convention. <!-- N/A: no new file -->
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `main` branch for this pull request.

---

## Description

The `dotnet-test` marketplace entry read as ".NET-only", but the plugin ships a multi-agent (Research → Plan → Implement) test-generation pipeline with per-language guidance for 11 languages. Developers in Python, TypeScript, Java, Go, Rust, etc. couldn't find it via marketplace search.

- **Description** reframed to lead with polyglot test generation, keeping the .NET-focused analysis (coverage/CRAP, testability, platform detection, MSTest/xUnit migration).
- **Keywords** add polyglot terms (`polyglot, test-generation, unit-tests, python, typescript, java, go, rust`) alongside `dotnet`/`testing`, within the 10-keyword limit.
- **Version** mirrored to `0.2.0` to match the plugin manifest (dotnet/skills#852, merged).

Edited in the source `plugins/external.json`; `.github/plugin/marketplace.json` regenerated via `npm run build`. `npm run plugin:validate` passes.

---

## Type of Contribution

- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.

---

## Additional Notes

- `source` stays unpinned (tracks dotnet/skills `main`) — discoverability/metadata only, no behavior change.
- Complements dotnet/skills#847, which enabled VS Code subagent fan-out for these `code-testing-*` agents.
- Keyword set is capped at 10 by the catalog validator; the full 11-language list lives in the description.

By submitting this pull request, I confirm that my contribution abides by the Code of Conduct and will be licensed under the MIT License.