### PR TITLE
feat(website): redesign UX across landing and all listing pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "website:data": "node ./eng/generate-website-data.mjs",
     "website:dev": "npm run website:data && npm run --prefix website dev",
     "website:build": "npm run build && npm run website:data && npm run --prefix website build",
+    "website:a11y": "npm run website:build && npm run --prefix website a11y",
     "website:preview": "npm run --prefix website preview"
   },
   "repository": {

--- a/website/README.md
+++ b/website/README.md
@@ -12,6 +12,14 @@ npm run website:dev     # generate data + start the dev server
 npm run website:build   # full production build
 ```
 
+## Accessibility
+
+The website has an automated axe-core + Playwright audit. Run it locally with `npm run website:a11y` from the repository root, or run `npm run a11y` from `website/` after building `dist` first.
+
+CI blocks on critical and serious violations. Minor and moderate best-practice issues are reported as non-blocking.
+
+Authoring conventions: resource cards use `div[role="listitem"]` wrappers, not `<article>`; only add `role="list"` to containers whose direct children are list items; do not nest interactive controls inside another focusable element; `.btn-primary` and ToC links must meet WCAG AA (4.5:1) contrast in both light and dark themes.
+
 ## Social preview cards (LinkedIn, etc.)
 
 Shared links render as large preview cards driven by Open Graph / Twitter meta tags.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -24,7 +24,13 @@ export default defineConfig({
       title: "Awesome GitHub Copilot",
       favicon: "/images/favicon.svg",
       description: siteDescription,
-      social: [],
+      social: [
+        {
+          icon: "github",
+          label: "View on GitHub",
+          href: "https://github.com/github/awesome-copilot",
+        },
+      ],
       head: [
         {
           tag: "meta",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -18,6 +18,10 @@
         "jszip": "^3.10.1",
         "marked": "^18.0.2",
         "shiki": "^4.0.2"
+      },
+      "devDependencies": {
+        "axe-core": "^4.10.2",
+        "playwright": "^1.49.0"
       }
     },
     "node_modules/@astrojs/compiler-binding": {
@@ -79,9 +83,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -97,9 +98,6 @@
       "integrity": "sha512-O3e2CbN4yTsRguWYNnRd0p5YQ0H3fb7KpcR0W4R319q/gq5B1pJ7eqNbiO3b8g2AuiEcRTiUz5jeGT9j69cxOQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -117,9 +115,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -135,9 +130,6 @@
       "integrity": "sha512-vIiEvOwrJfHZMaTmqUCrFTIwMYL0+PD3Rvy7kFDQgERyx3zhaw8CPa01MCCqa+/sj344BGrXKZ6ti37SgNLMhw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -454,9 +446,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -468,9 +457,6 @@
       "integrity": "sha512-Wjzu9hmmAbfmDkBfPI1VdZygJtYz9uYZQnkEyrXi6S2JFi+2pXQ1A5irj38bqm0IZmWcTbk0cVG4NZnPdtVNJA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "optional": true,
       "os": [
@@ -484,9 +470,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -498,9 +481,6 @@
       "integrity": "sha512-T4gxhXve3zyNAZesrXAd/rDZOGRkbfFIUFld4TGsw6BsjoIteCcDji6IMqeXyaWEVSykY2X8Eid2hr6aXGYAaw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "optional": true,
       "os": [
@@ -1182,9 +1162,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1200,9 +1177,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1220,9 +1194,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1238,9 +1209,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1258,9 +1226,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1276,9 +1241,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1296,9 +1258,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1315,9 +1274,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1333,9 +1289,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1359,9 +1312,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1383,9 +1333,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1409,9 +1356,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1433,9 +1377,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1459,9 +1400,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1484,9 +1422,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1508,9 +1443,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1863,9 +1795,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1881,9 +1810,6 @@
       "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1901,9 +1827,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1919,9 +1842,6 @@
       "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1939,9 +1859,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1957,9 +1874,6 @@
       "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2475,6 +2389,16 @@
       },
       "peerDependencies": {
         "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta || ^7.0.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axobject-query": {
@@ -4212,9 +4136,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4234,9 +4155,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4258,9 +4176,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4280,9 +4195,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5760,6 +5672,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/website/package.json
+++ b/website/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "a11y": "node ./scripts/a11y-audit.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },
@@ -27,5 +28,9 @@
     "jszip": "^3.10.1",
     "marked": "^18.0.2",
     "shiki": "^4.0.2"
+  },
+  "devDependencies": {
+    "axe-core": "^4.10.2",
+    "playwright": "^1.49.0"
   }
 }

--- a/website/scripts/a11y-audit.mjs
+++ b/website/scripts/a11y-audit.mjs
@@ -14,6 +14,15 @@ const distDir = path.join(websiteDir, 'dist');
 const axeMainPath = require.resolve('axe-core');
 const axeSourcePath = path.join(path.dirname(axeMainPath), 'axe.min.js');
 
+// Resolve Astro's CLI entry point so the preview server can be launched with `node <bin>`
+// directly — no shell and no `npx` shim. This keeps signal delivery / detached-PGID shutdown
+// predictable (see startPreviewServer) and works identically on Windows and POSIX (spawning a
+// .cmd shim without a shell throws EINVAL on modern Node).
+const astroPackageJsonPath = require.resolve('astro/package.json');
+const astroBinField = require(astroPackageJsonPath).bin;
+const astroBinRelative = typeof astroBinField === 'string' ? astroBinField : astroBinField.astro;
+const astroBinPath = path.join(path.dirname(astroPackageJsonPath), astroBinRelative);
+
 const routes = [
   '/',
   '/agents/',
@@ -90,10 +99,14 @@ function getPort() {
 }
 
 function startPreviewServer(port) {
-  const child = spawn('npx', ['astro', 'preview', '--port', String(port), '--host'], {
+  // Launch `node <astro-bin> preview` directly — no shell layer and no npx shim. A shell
+  // (shell:true) spawns an extra intermediate process that makes signal delivery / PGID-based
+  // shutdown (detached + process.kill(-pid) below) unreliable, and spawning the npx.cmd shim
+  // without a shell throws EINVAL on modern Node for Windows. Invoking the resolved bin with
+  // process.execPath sidesteps both problems on every platform.
+  const child = spawn(process.execPath, [astroBinPath, 'preview', '--port', String(port), '--host'], {
     cwd: websiteDir,
     detached: process.platform !== 'win32',
-    shell: true,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 
@@ -195,7 +208,19 @@ async function auditSite(browser, baseUrl) {
       // 'load' (not 'networkidle') keeps the audit robust: cards are server-rendered
       // into the initial HTML, and lazy images / search-index requests can otherwise
       // keep the network busy indefinitely and stall navigation.
-      await page.goto(url, { waitUntil: 'load', timeout: 45_000 });
+      const response = await page.goto(url, { waitUntil: 'load', timeout: 45_000 });
+
+      // Fail fast on broken/missing routes. page.goto() resolves even for 4xx/5xx responses,
+      // so without this check axe would run against an error page and the guardrail could
+      // "pass" while silently masking a broken route.
+      if (!response) {
+        throw new Error(`No navigation response for ${url} (theme: ${theme}).`);
+      }
+
+      if (!response.ok()) {
+        throw new Error(`Route ${url} (theme: ${theme}) returned HTTP ${response.status()}.`);
+      }
+
       await page.waitForTimeout(500);
 
       // Disable CSS transitions/animations before switching themes. Theme changes animate

--- a/website/scripts/a11y-audit.mjs
+++ b/website/scripts/a11y-audit.mjs
@@ -1,0 +1,359 @@
+import { execFile, spawn } from 'node:child_process';
+import { access } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { chromium } from 'playwright';
+
+const require = createRequire(import.meta.url);
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const websiteDir = path.resolve(scriptDir, '..');
+const distDir = path.join(websiteDir, 'dist');
+const axeMainPath = require.resolve('axe-core');
+const axeSourcePath = path.join(path.dirname(axeMainPath), 'axe.min.js');
+
+const routes = [
+  '/',
+  '/agents/',
+  '/instructions/',
+  '/skills/',
+  '/hooks/',
+  '/workflows/',
+  '/extensions/',
+  '/plugins/',
+  '/tools/',
+  '/contributors/',
+  '/learning-hub/cookbook/',
+  '/learning-hub/github-copilot-app/',
+];
+
+const themes = ['dark', 'light'];
+const blockingImpacts = new Set(['critical', 'serious']);
+const serverTimeoutMs = 60_000;
+const fetchTimeoutMs = 2_000;
+
+async function main() {
+  const port = getPort();
+  const providedBaseUrl = process.env.A11Y_BASE_URL?.trim();
+  const baseUrl = providedBaseUrl || `http://localhost:${port}/`;
+  let previewServer;
+  let browser;
+
+  try {
+    await access(axeSourcePath);
+
+    if (!providedBaseUrl) {
+      await access(distDir);
+      previewServer = startPreviewServer(port);
+    }
+
+    await waitForServer(new URL('/', baseUrl).toString(), previewServer);
+
+    browser = await chromium.launch();
+    const violations = await auditSite(browser, baseUrl);
+    printReport(violations);
+
+    // Gate only critical and serious violations; moderate/minor findings are reported but non-blocking.
+    const blockingCount = violations.filter((violation) => blockingImpacts.has(violation.impact)).length;
+    const nonBlockingCount = violations.length - blockingCount;
+
+    console.log(
+      `\nSummary: ${blockingCount} blocking (critical/serious), ${nonBlockingCount} non-blocking (moderate/minor) violation(s).`,
+    );
+
+    if (blockingCount > 0) {
+      process.exitCode = 1;
+      console.error(`Accessibility audit FAILED — ${blockingCount} blocking violation(s)`);
+    } else {
+      process.exitCode = 0;
+      console.log('Accessibility audit PASSED (no critical/serious violations)');
+    }
+  } catch (error) {
+    process.exitCode = 1;
+    console.error(`Accessibility audit ERROR — ${error instanceof Error ? error.message : String(error)}`);
+  } finally {
+    await closeBrowser(browser);
+    await stopPreviewServer(previewServer);
+  }
+}
+
+function getPort() {
+  const port = Number.parseInt(process.env.A11Y_PORT || '4322', 10);
+
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error(`Invalid A11Y_PORT value: ${process.env.A11Y_PORT}`);
+  }
+
+  return port;
+}
+
+function startPreviewServer(port) {
+  const child = spawn('npx', ['astro', 'preview', '--port', String(port), '--host'], {
+    cwd: websiteDir,
+    detached: process.platform !== 'win32',
+    shell: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const server = {
+    child,
+    exited: false,
+    exitCode: null,
+    signal: null,
+    spawnError: null,
+    logs: [],
+  };
+
+  const rememberOutput = (chunk) => {
+    const lines = String(chunk)
+      .split(/\r?\n/)
+      .map((line) => line.trimEnd())
+      .filter(Boolean);
+
+    server.logs.push(...lines);
+
+    if (server.logs.length > 60) {
+      server.logs.splice(0, server.logs.length - 60);
+    }
+  };
+
+  child.stdout.on('data', rememberOutput);
+  child.stderr.on('data', rememberOutput);
+  child.on('error', (error) => {
+    server.spawnError = error;
+    rememberOutput(`Failed to start preview server: ${error.message}`);
+  });
+  child.on('exit', (code, signal) => {
+    server.exited = true;
+    server.exitCode = code;
+    server.signal = signal;
+  });
+
+  return server;
+}
+
+async function waitForServer(url, server) {
+  const deadline = Date.now() + serverTimeoutMs;
+  let lastError;
+
+  while (Date.now() < deadline) {
+    if (server?.spawnError) {
+      throw new Error(`${server.spawnError.message}${formatServerLogs(server)}`);
+    }
+
+    if (server?.exited) {
+      throw new Error(
+        `Astro preview exited before it was ready (code ${server.exitCode ?? 'null'}, signal ${
+          server.signal ?? 'null'
+        }).${formatServerLogs(server)}`,
+      );
+    }
+
+    try {
+      const response = await fetchWithTimeout(url);
+
+      if (response.ok) {
+        return;
+      }
+
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await delay(500);
+  }
+
+  throw new Error(
+    `Timed out after ${serverTimeoutMs / 1000}s waiting for ${url}.${
+      lastError ? ` Last error: ${lastError.message}` : ''
+    }${formatServerLogs(server)}`,
+  );
+}
+
+async function fetchWithTimeout(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), fetchTimeoutMs);
+
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function auditSite(browser, baseUrl) {
+  const page = await browser.newPage();
+  const violations = [];
+
+  for (const route of routes) {
+    for (const theme of themes) {
+      const url = new URL(route, baseUrl).toString();
+
+      // 'load' (not 'networkidle') keeps the audit robust: cards are server-rendered
+      // into the initial HTML, and lazy images / search-index requests can otherwise
+      // keep the network busy indefinitely and stall navigation.
+      await page.goto(url, { waitUntil: 'load', timeout: 45_000 });
+      await page.waitForTimeout(500);
+
+      // Disable CSS transitions/animations before switching themes. Theme changes animate
+      // background/text colors over ~0.2s; if axe runs mid-transition it samples intermediate
+      // colors (e.g. a dark card background bleeding through a light page) and reports
+      // false-positive contrast violations that no real user ever sees. Killing transitions
+      // makes axe measure the settled, steady-state colors — the actual conformance target.
+      await page.addStyleTag({
+        content: '*,*::before,*::after{transition:none!important;animation:none!important;transition-duration:0s!important;animation-duration:0s!important;}',
+      });
+
+      // Force both theme modes so persisted user preference logic cannot hide regressions.
+      await page.evaluate((selectedTheme) => {
+        document.documentElement.setAttribute('data-theme', selectedTheme);
+        localStorage.setItem('awesome-copilot-theme', selectedTheme);
+      }, theme);
+
+      // Let the forced theme settle (style recalc / reflow) before sampling colors.
+      await page.waitForTimeout(150);
+
+      await page.addScriptTag({ path: axeSourcePath });
+
+      const results = await page.evaluate(async () => await axe.run(document, { resultTypes: ['violations'] }));
+
+      for (const violation of results.violations) {
+        violations.push({
+          route,
+          theme,
+          id: violation.id,
+          impact: violation.impact ?? 'unknown',
+          help: violation.help,
+          helpUrl: violation.helpUrl,
+          nodeCount: violation.nodes.length,
+        });
+      }
+    }
+  }
+
+  await page.close();
+  return violations;
+}
+
+function printReport(violations) {
+  console.log(`Audited ${routes.length} route(s) across ${themes.length} theme(s).`);
+
+  if (violations.length === 0) {
+    console.log('\nNo axe violations found.');
+    return;
+  }
+
+  const groupedViolations = new Map();
+
+  for (const violation of violations) {
+    const pageTheme = `${violation.route} [${violation.theme}]`;
+    const pageViolations = groupedViolations.get(pageTheme) || [];
+
+    pageViolations.push(violation);
+    groupedViolations.set(pageTheme, pageViolations);
+  }
+
+  for (const [pageTheme, pageViolations] of groupedViolations) {
+    console.log(`\n${pageTheme}`);
+
+    for (const violation of pageViolations) {
+      const gate = blockingImpacts.has(violation.impact) ? 'BLOCKING' : 'NON-BLOCKING';
+
+      console.log(`  - ${violation.id} (${violation.impact}, ${gate})`);
+      console.log(`    ${violation.help}`);
+      console.log(`    ${violation.helpUrl}`);
+      console.log(`    Nodes: ${violation.nodeCount}`);
+    }
+  }
+}
+
+async function closeBrowser(browser) {
+  if (!browser) {
+    return;
+  }
+
+  try {
+    await browser.close();
+  } catch (error) {
+    process.exitCode = 1;
+    console.error(`Failed to close browser cleanly: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function stopPreviewServer(server) {
+  if (!server || server.exited || !server.child.pid) {
+    return;
+  }
+
+  await new Promise((resolve) => {
+    let resolved = false;
+    const finish = () => {
+      if (!resolved) {
+        resolved = true;
+        clearTimeout(timeout);
+        resolve();
+      }
+    };
+
+    const timeout = setTimeout(() => {
+      forceKill(server.child);
+      finish();
+    }, 5_000);
+
+    server.child.once('exit', finish);
+
+    if (process.platform === 'win32') {
+      execFile('taskkill', ['/pid', String(server.child.pid), '/T', '/F'], (error) => {
+        if (error && !server.exited) {
+          server.child.kill();
+        }
+      });
+      return;
+    }
+
+    try {
+      process.kill(-server.child.pid, 'SIGTERM');
+    } catch {
+      server.child.kill('SIGTERM');
+    }
+  });
+}
+
+function forceKill(child) {
+  if (!child.pid) {
+    return;
+  }
+
+  try {
+    if (process.platform === 'win32') {
+      child.kill();
+    } else {
+      process.kill(-child.pid, 'SIGKILL');
+    }
+  } catch {
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      // The process already exited.
+    }
+  }
+}
+
+function formatServerLogs(server) {
+  if (!server?.logs.length) {
+    return '';
+  }
+
+  return `\n\nAstro preview output:\n${server.logs.join('\n')}`;
+}
+
+function delay(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+await main();

--- a/website/src/components/PageHeader.astro
+++ b/website/src/components/PageHeader.astro
@@ -1,23 +1,26 @@
 ---
 import Icon from './Icon.astro';
 
+type Accent = 'ai' | 'docs' | 'power' | 'automation' | 'extension' | 'dev' | 'learn';
+
 interface Props {
   title: string;
   description: string;
   icon?: 'robot' | 'document' | 'lightning' | 'hook' | 'workflow' | 'plug' | 'wrench' | 'book';
+  accent?: Accent;
 }
 
-const { title, description, icon } = Astro.props;
+const { title, description, icon, accent } = Astro.props;
 const contributingUrl = 'https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md';
 ---
 
-<div class="page-header">
+<div class="page-header" data-accent={accent}>
   <div class="container">
     <div class="page-header-row">
-      <div>
+      <div class="page-header-lede">
         <h1>
-          {icon && <Icon name={icon} size={28} />}
-          <Fragment set:html={title} />
+          {icon && <span class="page-header-icon"><Icon name={icon} size={24} /></span>}
+          <span class="page-header-title"><Fragment set:html={title} /></span>
         </h1>
         <p><slot><Fragment set:html={description} /></slot></p>
       </div>
@@ -33,6 +36,33 @@ const contributingUrl = 'https://github.com/github/awesome-copilot/blob/main/CON
   .page-header h1 {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.75rem;
   }
+
+  .page-header-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    flex: none;
+    border-radius: 14px;
+    color: var(--accent-color, var(--sl-color-accent));
+    background: color-mix(in srgb, var(--accent-color, var(--sl-color-accent)) 14%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-color, var(--sl-color-accent)) 32%, transparent);
+  }
+
+  /* Accent-tinted heading matches the landing category cards, but uses the
+     theme-aware TEXT token so it stays AA-legible in light mode. */
+  .page-header[data-accent] .page-header-title {
+    color: var(--accent-text);
+  }
+
+  .page-header[data-accent='ai'] { --accent-color: var(--category-ai); --accent-text: var(--category-ai-text); }
+  .page-header[data-accent='docs'] { --accent-color: var(--category-docs); --accent-text: var(--category-docs-text); }
+  .page-header[data-accent='power'] { --accent-color: var(--category-power); --accent-text: var(--category-power-text); }
+  .page-header[data-accent='automation'] { --accent-color: var(--category-automation); --accent-text: var(--category-automation-text); }
+  .page-header[data-accent='extension'] { --accent-color: var(--category-extension); --accent-text: var(--category-extension-text); }
+  .page-header[data-accent='dev'] { --accent-color: var(--category-dev); --accent-text: var(--category-dev-text); }
+  .page-header[data-accent='learn'] { --accent-color: var(--category-learn); --accent-text: var(--category-learn-text); }
 </style>

--- a/website/src/components/ThemeToggle.astro
+++ b/website/src/components/ThemeToggle.astro
@@ -1,64 +1,69 @@
 ---
-// Theme Toggle Component - 3 state slider: Auto | Dark | Light
+// Theme Toggle Component — single icon that cycles Dark → Light → Auto.
+// Shows the icon for the active theme; a11y label announces current + next.
 ---
 
 <div class="theme-toggle-container">
   <button
     id="theme-toggle"
     class="theme-toggle"
+    type="button"
     aria-label="Toggle theme"
     title="Change theme"
   >
     <span class="theme-icon moon" aria-hidden="true">
-      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
       </svg>
     </span>
     <span class="theme-icon auto" aria-hidden="true">
-      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
-        <circle cx="12" cy="12" r="10"/>
-        <path d="M12 2v10l4.5 4.5"/>
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="2" y="4" width="20" height="14" rx="2"/>
+        <path d="M8 21h8M12 18v3"/>
       </svg>
     </span>
     <span class="theme-icon sun" aria-hidden="true">
-      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2">
-        <circle cx="12" cy="12" r="5"/>
-        <line x1="12" y1="1" x2="12" y2="3"/>
-        <line x1="12" y1="21" x2="12" y2="23"/>
-        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
-        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
-        <line x1="1" y1="12" x2="3" y2="12"/>
-        <line x1="21" y1="12" x2="23" y2="12"/>
-        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
-        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="4.5"/>
+        <path d="M12 2v2M12 20v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M2 12h2M20 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
       </svg>
     </span>
-    <span class="theme-slider"></span>
   </button>
 </div>
 
 <script>
-  (function() {
-    // Move theme toggle to body level to escape any stacking contexts
+  (function () {
     const container = document.querySelector('.theme-toggle-container');
-    if (container && container.parentElement !== document.body) {
-      document.body.appendChild(container);
+    // Place the toggle in the header's action cluster, just left of the
+    // GitHub social icon, so flexbox lays them out together. Fall back to
+    // <body> if the header isn't present (keeps the button usable).
+    if (container) {
+      const social = document.querySelector('header .social-icons');
+      if (social && social.parentElement) {
+        social.parentElement.insertBefore(container, social);
+      } else if (container.parentElement !== document.body) {
+        document.body.appendChild(container);
+      }
     }
 
     const STORAGE_KEY = 'awesome-copilot-theme';
     const toggle = document.getElementById('theme-toggle');
     const html = document.documentElement;
 
-    const themes = ['dark', 'auto', 'light'];
-    const icons = ['moon', 'auto', 'sun'];
+    const themes = ['dark', 'light', 'auto'];
+    const labels: Record<string, string> = {
+      dark: 'Dark',
+      light: 'Light',
+      auto: 'Auto (system)',
+    };
 
     function getThemeIndex() {
       const stored = localStorage.getItem(STORAGE_KEY);
       if (stored && themes.includes(stored)) {
         return themes.indexOf(stored);
       }
-      // Default to light theme
-      return 2;
+      // No stored preference → follow system (auto).
+      return themes.indexOf('auto');
     }
 
     function applyTheme(index: number) {
@@ -70,31 +75,27 @@
         html.setAttribute('data-theme', theme);
       }
 
-      // Move slider
-      const slider = toggle?.querySelector('.theme-slider') as HTMLElement;
-      if (slider) {
-        slider.style.transform = `translateX(${index * 100}%)`;
+      if (toggle) {
+        toggle.setAttribute('data-theme-mode', theme);
+        const next = themes[(index + 1) % themes.length];
+        toggle.setAttribute(
+          'aria-label',
+          `Theme: ${labels[theme]}. Activate to switch to ${labels[next]}.`
+        );
+        toggle.setAttribute('title', `Theme: ${labels[theme]}`);
       }
-
-      // Highlight active icon
-      const themeToggle = document.querySelector('.theme-toggle');
-      themeToggle?.setAttribute('data-active', String(index));
     }
 
     function cycleTheme() {
-      const currentIndex = getThemeIndex();
-      const nextIndex = (currentIndex + 1) % themes.length;
+      const nextIndex = (getThemeIndex() + 1) % themes.length;
       localStorage.setItem(STORAGE_KEY, themes[nextIndex]);
       applyTheme(nextIndex);
     }
 
-    // Initialize
     applyTheme(getThemeIndex());
 
-    // Click handler
     toggle?.addEventListener('click', cycleTheme);
 
-    // Keyboard shortcut
     document.addEventListener('keydown', (e) => {
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'L') {
         e.preventDefault();
@@ -102,10 +103,9 @@
       }
     });
 
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-      if (localStorage.getItem(STORAGE_KEY) === 'auto') {
-        applyTheme(1); // auto
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+      if ((localStorage.getItem(STORAGE_KEY) || 'auto') === 'auto') {
+        applyTheme(themes.indexOf('auto'));
       }
     });
   })();
@@ -118,53 +118,52 @@
   }
 
   .theme-toggle {
-    display: flex;
-    position: relative;
-    width: 108px;
-    height: 36px;
-    padding: 3px;
-    border: 1px solid var(--color-border);
-    border-radius: 20px;
-    background: var(--color-bg-secondary);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+    border: none;
+    border-radius: var(--radius-pill, 999px);
+    background: transparent;
+    color: var(--sl-color-gray-2);
     cursor: pointer;
-    transition: all 0.2s ease;
-    overflow: hidden;
+    line-height: 0;
+    transition:
+      color 0.2s ease,
+      background-color 0.2s ease,
+      transform 0.1s ease;
   }
 
   .theme-toggle:hover {
-    border-color: var(--color-accent);
+    color: var(--sl-color-white);
+    background: var(--sl-color-gray-5);
+  }
+
+  .theme-toggle:active {
+    transform: scale(0.9);
   }
 
   .theme-toggle:focus-visible {
-    outline: 2px solid var(--color-accent);
+    outline: 2px solid var(--sl-color-accent);
     outline-offset: 2px;
   }
 
   .theme-icon {
-    display: flex;
+    display: none;
     align-items: center;
     justify-content: center;
-    width: 36px;
-    height: 30px;
-    border-radius: 16px;
-    color: var(--color-text-muted);
-    transition: all 0.2s ease;
-    z-index: 1;
-    font-weight: 400;
+    line-height: 0;
   }
 
-  .theme-icon.moon { color: #9898a6; }
-  .theme-icon.auto { color: #9898a6; }
-  .theme-icon.sun { color: #9898a6; }
-
-  .theme-toggle[data-active="0"] .moon,
-  .theme-toggle[data-active="1"] .auto,
-  .theme-toggle[data-active="2"] .sun {
-    color: var(--color-text);
-    font-weight: 700;
+  /* Show only the icon for the active theme mode. */
+  .theme-toggle[data-theme-mode='dark'] .moon,
+  .theme-toggle[data-theme-mode='light'] .sun,
+  .theme-toggle[data-theme-mode='auto'] .auto {
+    display: inline-flex;
   }
 
-  .theme-slider {
-    display: none;
+  /* Fallback before JS runs: show the moon so the button is never empty. */
+  .theme-toggle:not([data-theme-mode]) .moon {
+    display: inline-flex;
   }
 </style>

--- a/website/src/pages/agents.astro
+++ b/website/src/pages/agents.astro
@@ -6,37 +6,63 @@ import EmbeddedPageData from '../components/EmbeddedPageData.astro';
 import PageHeader from '../components/PageHeader.astro';
 import BackToTop from '../components/BackToTop.astro';
 import Modal from '../components/Modal.astro';
-import { renderAgentsHtml, sortAgents } from '../scripts/pages/agents-render';
+import {
+  getCapabilityFacets,
+  getModelFamilies,
+  renderAgentsHtml,
+  sortAgents,
+} from '../scripts/pages/agents-render';
 
 const initialItems = sortAgents(agentsData.items, 'title');
+const modelFamilies = getModelFamilies(agentsData.items);
+const capabilityFacets = getCapabilityFacets(agentsData.items);
 ---
 
 <StarlightPage frontmatter={{ title: 'Custom Agents', description: 'Specialized agents that enhance GitHub Copilot for specific technologies, workflows, and domains', template: 'splash', prev: false, next: false, editUrl: false }}>
   <div id="main-content" class="agents-page listing-cards-page">
-    <PageHeader title="Custom Agents" description="Specialized agents that enhance GitHub Copilot for specific technologies, workflows, and domains" icon="robot" />
+    <PageHeader title="Custom Agents" description="Specialized agents that enhance GitHub Copilot for specific technologies, workflows, and domains" icon="robot" accent="ai" />
 
     <div class="page-content">
       <div class="container">
-        <div class="listing-toolbar">
-          <div class="listing-toolbar-row">
-            <div class="results-count" id="results-count" aria-live="polite">{initialItems.length} agents</div>
-            <details class="listing-controls">
-              <summary class="listing-controls-trigger btn btn-secondary btn-small">Sort</summary>
-              <div class="listing-controls-panel">
-                <div class="filters-bar" id="filters-bar">
-                  <div class="filter-group">
-                    <label for="sort-select">Sort:</label>
-                    <select id="sort-select" aria-label="Sort by">
-                      <option value="title">Name (A-Z)</option>
-                      <option value="lastUpdated">Recently Updated</option>
-                    </select>
-                  </div>
-                </div>
-              </div>
-            </details>
+        <div class="filter-bar" data-accent="ai">
+          <div class="filter-bar-search">
+            <svg class="filter-bar-search-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"/></svg>
+            <input
+              id="listing-search"
+              type="search"
+              class="filter-bar-input"
+              placeholder="Search agents by name, description, or tool"
+              aria-label="Search agents"
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="filter-bar-controls">
+            <div class="facet-chips" role="group" aria-label="Filter agents">
+              {modelFamilies.map((family) => (
+                <button type="button" class="facet-chip" data-family={family.key} aria-pressed="false">{family.label}</button>
+              ))}
+              {capabilityFacets.map((facet) => (
+                <button type="button" class="facet-chip facet-chip-capability" data-capability={facet.key} aria-pressed="false">{facet.label}</button>
+              ))}
+            </div>
+
+            <label class="filter-bar-sort">
+              <span class="sr-only">Sort agents</span>
+              <select id="sort-select" aria-label="Sort agents">
+                <option value="title">Name (A-Z)</option>
+                <option value="lastUpdated">Recently updated</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="filter-bar-meta">
+            <span class="results-count" id="results-count" aria-live="polite">{initialItems.length} agents</span>
+            <button type="button" class="filter-bar-clear" id="clear-filters" hidden>Clear filters</button>
           </div>
         </div>
-        <div class="resource-list" id="resource-list" role="list" set:html={renderAgentsHtml(initialItems)}></div>
+
+        <div class="resource-list rcard-grid" id="resource-list" role="list" set:html={renderAgentsHtml(initialItems)}></div>
         <ContributeCTA resourceType="agents" />
       </div>
     </div>

--- a/website/src/pages/contributors.astro
+++ b/website/src/pages/contributors.astro
@@ -9,7 +9,7 @@ import PageHeader from '../components/PageHeader.astro';
 
     <div class="page-content">
       <div class="container">
-        <div class="contributor-grid" id="contributor-grid" role="list">
+        <div class="contributor-grid" id="contributor-grid">
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->

--- a/website/src/pages/extensions.astro
+++ b/website/src/pages/extensions.astro
@@ -12,8 +12,8 @@ const initialItems = sortExtensions(extensionsData.items, 'title');
 ---
 
 <StarlightPage frontmatter={{ title: 'Canvas Extensions', description: 'Canvas extensions for GitHub Copilot app experiences', template: 'splash', prev: false, next: false, editUrl: false }}>
-  <div id="main-content" class="extensions-page">
-    <PageHeader title="Canvas Extensions" description="Canvas extensions for GitHub Copilot app experiences" icon="plug" />
+  <div id="main-content" class="extensions-page listing-cards-page">
+    <PageHeader title="Canvas Extensions" description="Canvas extensions for GitHub Copilot app experiences" icon="browser" accent="extension" />
 
     <div class="page-content">
       <div class="container">
@@ -22,31 +22,41 @@ const initialItems = sortExtensions(extensionsData.items, 'title');
           <p><strong>Example:</strong> <code>Install this extension: https://github.com/github/awesome-copilot/tree/main/extensions/accessibility-kanban</code></p>
         </div>
 
-        <div class="listing-toolbar">
-          <div class="listing-toolbar-row">
-            <div class="results-count" id="results-count" aria-live="polite">{initialItems.length} extensions</div>
-            <details class="listing-controls">
-              <summary class="listing-controls-trigger btn btn-secondary btn-small">Sort &amp; Filter</summary>
-              <div class="listing-controls-panel">
-                <div class="filters-bar" id="filters-bar">
-                  <div class="filter-group">
-                    <label for="filter-keyword">Keyword:</label>
-                    <select id="filter-keyword" multiple aria-label="Filter by keyword"></select>
-                  </div>
-                  <div class="filter-group">
-                    <label for="sort-select">Sort:</label>
-                    <select id="sort-select" aria-label="Sort extensions">
-                      <option value="title">Name (A-Z)</option>
-                      <option value="lastUpdated">Recently Updated</option>
-                    </select>
-                  </div>
-                  <button id="clear-filters" class="btn btn-secondary btn-small">Clear Filters</button>
-                </div>
-              </div>
-            </details>
+        <div class="filter-bar" data-accent="extension">
+          <div class="filter-bar-search">
+            <svg class="filter-bar-search-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"/></svg>
+            <input
+              id="listing-search"
+              type="search"
+              class="filter-bar-input"
+              placeholder="Search extensions by name, description, author, or keyword"
+              aria-label="Search extensions"
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="filter-bar-controls">
+            <div class="facet-chips" role="group" aria-label="Filter by source">
+              <button type="button" class="facet-chip" data-facet-group="source" data-facet-value="local" aria-pressed="false">Local</button>
+              <button type="button" class="facet-chip" data-facet-group="source" data-facet-value="external" aria-pressed="false">External</button>
+            </div>
+
+            <label class="filter-bar-sort">
+              <span class="sr-only">Sort extensions</span>
+              <select id="sort-select" aria-label="Sort extensions">
+                <option value="title">Name (A-Z)</option>
+                <option value="lastUpdated">Recently updated</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="filter-bar-meta">
+            <span class="results-count" id="results-count" aria-live="polite">{initialItems.length} extensions</span>
+            <button type="button" class="filter-bar-clear" id="clear-filters" hidden>Clear filters</button>
           </div>
         </div>
-        <div class="resource-list" id="resource-list" role="list" set:html={renderExtensionsHtml(initialItems)}></div>
+
+        <div class="resource-list rcard-grid" id="resource-list" role="list" set:html={renderExtensionsHtml(initialItems)}></div>
         <ContributeCTA resourceType="extensions" />
       </div>
     </div>

--- a/website/src/pages/hooks.astro
+++ b/website/src/pages/hooks.astro
@@ -9,39 +9,66 @@ import hooksData from '../../public/data/hooks.json';
 import { renderHooksHtml, sortHooks } from '../scripts/pages/hooks-render';
 
 const initialItems = sortHooks(hooksData.items, 'title');
+
+// Lifecycle events become the quick filters, ordered by frequency.
+const eventCounts = new Map<string, number>();
+for (const item of hooksData.items) {
+  for (const evt of item.hooks ?? []) {
+    eventCounts.set(evt, (eventCounts.get(evt) ?? 0) + 1);
+  }
+}
+const topEvents = [...eventCounts.entries()]
+  .sort((a, b) => b[1] - a[1])
+  .map(([key]) => key);
+
+const humanizeEvent = (evt: string) =>
+  evt
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/^\w/, (c) => c.toUpperCase());
 ---
 
 <StarlightPage frontmatter={{ title: 'Hooks', description: 'Automated workflows triggered by Copilot coding agent events', template: 'splash', prev: false, next: false, editUrl: false }}>
   <div id="main-content" class="hooks-page listing-cards-page">
-    <PageHeader title="Hooks" description="Automated workflows triggered by Copilot coding agent events" icon="hook" />
+    <PageHeader title="Hooks" description="Automated workflows triggered by Copilot coding agent events" icon="hook" accent="automation" />
 
     <div class="page-content">
       <div class="container">
-        <div class="listing-toolbar">
-          <div class="listing-toolbar-row">
-            <div class="results-count" id="results-count" aria-live="polite">{initialItems.length} hooks</div>
-            <details class="listing-controls">
-              <summary class="listing-controls-trigger btn btn-secondary btn-small">Sort &amp; Filter</summary>
-              <div class="listing-controls-panel">
-                <div class="filters-bar" id="filters-bar">
-                  <div class="filter-group">
-                    <label for="filter-tag">Tag:</label>
-                    <select id="filter-tag" multiple aria-label="Filter by tag"></select>
-                  </div>
-                  <div class="filter-group">
-                    <label for="sort-select">Sort:</label>
-                    <select id="sort-select" aria-label="Sort by">
-                      <option value="title">Name (A-Z)</option>
-                      <option value="lastUpdated">Recently Updated</option>
-                    </select>
-                  </div>
-                  <button id="clear-filters" class="btn btn-secondary btn-small">Clear Filters</button>
-                </div>
-              </div>
-            </details>
+        <div class="filter-bar" data-accent="automation">
+          <div class="filter-bar-search">
+            <svg class="filter-bar-search-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"/></svg>
+            <input
+              id="listing-search"
+              type="search"
+              class="filter-bar-input"
+              placeholder="Search hooks by name, description, or event"
+              aria-label="Search hooks"
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="filter-bar-controls">
+            <div class="facet-chips" role="group" aria-label="Filter by lifecycle event">
+              {topEvents.map((evt) => (
+                <button type="button" class="facet-chip" data-facet-group="event" data-facet-value={evt} aria-pressed="false">{humanizeEvent(evt)}</button>
+              ))}
+            </div>
+
+            <label class="filter-bar-sort">
+              <span class="sr-only">Sort hooks</span>
+              <select id="sort-select" aria-label="Sort hooks">
+                <option value="title">Name (A-Z)</option>
+                <option value="lastUpdated">Recently updated</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="filter-bar-meta">
+            <span class="results-count" id="results-count" aria-live="polite">{initialItems.length} hooks</span>
+            <button type="button" class="filter-bar-clear" id="clear-filters" hidden>Clear filters</button>
           </div>
         </div>
-        <div class="resource-list" id="resource-list" role="list" set:html={renderHooksHtml(initialItems)}></div>
+
+        <div class="resource-list rcard-grid" id="resource-list" role="list" set:html={renderHooksHtml(initialItems)}></div>
         <ContributeCTA resourceType="hooks" />
       </div>
     </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -33,6 +33,10 @@ const base = import.meta.env.BASE_URL;
     <!-- Hero Section -->
     <section class="hero" aria-labelledby="hero-heading">
       <div class="container">
+        <span class="hero-chip">
+          <Icon name="lightning" size={15} />
+          Curated by the community
+        </span>
         <h1 id="hero-heading">
           <span class="gradient-text">Awesome GitHub Copilot</span>
         </h1>
@@ -40,16 +44,23 @@ const base = import.meta.env.BASE_URL;
           Community-contributed agents, instructions, and skills to enhance your
           GitHub Copilot experience
         </p>
-        <p>
-          <a href="https://github.com/github/awesome-copilot/" target="_blank" rel="noopener noreferrer">
-            View the Awesome Copilot repository on GitHub
+        <div class="hero-actions">
+          <a href="#browse" class="btn btn-primary">
+            Browse resources
           </a>
-        </p>
+          <a href={`${base}learning-hub/`} class="btn btn-secondary">
+            Explore the Learning Hub
+          </a>
+        </div>
       </div>
     </section>
 
     <!-- Quick Links -->
-    <section class="quick-links" aria-labelledby="quick-links-heading">
+    <section
+      id="browse"
+      class="quick-links"
+      aria-labelledby="quick-links-heading"
+    >
       <h2 id="quick-links-heading" class="sr-only">Browse Resources</h2>
       <div class="container">
         <div class="cards-grid">

--- a/website/src/pages/instructions.astro
+++ b/website/src/pages/instructions.astro
@@ -9,39 +9,61 @@ import Modal from '../components/Modal.astro';
 import { renderInstructionsHtml, sortInstructions } from '../scripts/pages/instructions-render';
 
 const initialItems = sortInstructions(instructionsData.items, 'title');
+
+// Most common file extensions become quick-filter chips; the rest stay searchable.
+const extensionCounts = new Map<string, number>();
+for (const item of instructionsData.items) {
+  const exts = item.extensions && item.extensions.length > 0 ? item.extensions : ['(none)'];
+  for (const ext of exts) extensionCounts.set(ext, (extensionCounts.get(ext) ?? 0) + 1);
+}
+const topExtensions = [...extensionCounts.entries()]
+  .sort((a, b) => b[1] - a[1])
+  .slice(0, 12)
+  .map(([key]) => key);
 ---
 
 <StarlightPage frontmatter={{ title: 'Instructions', description: 'Coding standards and best practices for GitHub Copilot', template: 'splash', prev: false, next: false, editUrl: false }}>
   <div id="main-content" class="instructions-page listing-cards-page">
-    <PageHeader title="Instructions" description="Coding standards and best practices for GitHub Copilot" icon="document" />
+    <PageHeader title="Instructions" description="Coding standards and best practices for GitHub Copilot" icon="document" accent="docs" />
 
     <div class="page-content">
       <div class="container">
-        <div class="listing-toolbar">
-          <div class="listing-toolbar-row">
-            <div class="results-count" id="results-count" aria-live="polite">{initialItems.length} instructions</div>
-            <details class="listing-controls">
-              <summary class="listing-controls-trigger btn btn-secondary btn-small">Sort &amp; Filter</summary>
-              <div class="listing-controls-panel">
-                <div class="filters-bar" id="filters-bar">
-                  <div class="filter-group">
-                    <label for="filter-extension">File Extension:</label>
-                    <select id="filter-extension" multiple aria-label="Filter by file extension"></select>
-                  </div>
-                  <div class="filter-group">
-                    <label for="sort-select">Sort:</label>
-                    <select id="sort-select" aria-label="Sort by">
-                      <option value="title">Name (A-Z)</option>
-                      <option value="lastUpdated">Recently Updated</option>
-                    </select>
-                  </div>
-                  <button id="clear-filters" class="btn btn-secondary btn-small">Clear Filters</button>
-                </div>
-              </div>
-            </details>
+        <div class="filter-bar" data-accent="docs">
+          <div class="filter-bar-search">
+            <svg class="filter-bar-search-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"/></svg>
+            <input
+              id="listing-search"
+              type="search"
+              class="filter-bar-input"
+              placeholder="Search instructions by name, description, or file glob"
+              aria-label="Search instructions"
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="filter-bar-controls">
+            <div class="facet-chips" role="group" aria-label="Filter by file type">
+              {topExtensions.map((ext) => (
+                <button type="button" class="facet-chip" data-facet-group="extension" data-facet-value={ext} aria-pressed="false">{ext === '(none)' ? 'No extension' : ext}</button>
+              ))}
+            </div>
+
+            <label class="filter-bar-sort">
+              <span class="sr-only">Sort instructions</span>
+              <select id="sort-select" aria-label="Sort instructions">
+                <option value="title">Name (A-Z)</option>
+                <option value="lastUpdated">Recently updated</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="filter-bar-meta">
+            <span class="results-count" id="results-count" aria-live="polite">{initialItems.length} instructions</span>
+            <button type="button" class="filter-bar-clear" id="clear-filters" hidden>Clear filters</button>
           </div>
         </div>
-        <div class="resource-list" id="resource-list" role="list" set:html={renderInstructionsHtml(initialItems)}></div>
+
+        <div class="resource-list rcard-grid" id="resource-list" role="list" set:html={renderInstructionsHtml(initialItems)}></div>
         <ContributeCTA resourceType="instructions" />
       </div>
     </div>

--- a/website/src/pages/learning-hub/cookbook/index.astro
+++ b/website/src/pages/learning-hub/cookbook/index.astro
@@ -53,7 +53,7 @@ const languageOptions = Array.from(
 
     <div class="results-count" id="results-count" aria-live="polite">{getRecipeResultsCountText(samplesData.totalRecipes, samplesData.totalRecipes)}</div>
 
-    <div id="samples-list" role="list" set:html={renderCookbookSectionsHtml(initialRecipeMatches)}></div>
+    <div id="samples-list" set:html={renderCookbookSectionsHtml(initialRecipeMatches)}></div>
   </div>
 
   <Modal />

--- a/website/src/pages/plugins.astro
+++ b/website/src/pages/plugins.astro
@@ -13,7 +13,7 @@ const initialItems = sortPlugins(pluginsData.items, 'title');
 
 <StarlightPage frontmatter={{ title: 'Plugins', description: 'Curated plugins of agents, hooks, and skills for specific workflows', template: 'splash', prev: false, next: false, editUrl: false }}>
   <div id="main-content" class="plugins-page listing-cards-page">
-    <PageHeader title="Plugins" description="Curated plugins of agents, hooks, and skills for specific workflows" icon="plug" />
+    <PageHeader title="Plugins" description="Curated plugins of agents, hooks, and skills for specific workflows" icon="plug" accent="extension" />
 
     <div class="page-content">
       <div class="container">
@@ -26,31 +26,41 @@ const initialItems = sortPlugins(pluginsData.items, 'title');
           <p>Install any plugin with: <code>copilot plugin install &lt;plugin-name&gt;@awesome-copilot</code></p>
         </div>
 
-        <div class="listing-toolbar">
-          <div class="listing-toolbar-row">
-            <div class="results-count" id="results-count" aria-live="polite">{initialItems.length} plugins</div>
-            <details class="listing-controls">
-              <summary class="listing-controls-trigger btn btn-secondary btn-small">Sort &amp; Filter</summary>
-              <div class="listing-controls-panel">
-                <div class="filters-bar" id="filters-bar">
-                  <div class="filter-group">
-                    <label for="filter-tag">Tag:</label>
-                    <select id="filter-tag" multiple aria-label="Filter by tag"></select>
-                  </div>
-                  <div class="filter-group">
-                    <label for="sort-select">Sort:</label>
-                    <select id="sort-select" aria-label="Sort plugins">
-                      <option value="title">Title</option>
-                      <option value="lastUpdated">Recently Updated</option>
-                    </select>
-                  </div>
-                  <button id="clear-filters" class="btn btn-secondary btn-small">Clear Filters</button>
-                </div>
-              </div>
-            </details>
+        <div class="filter-bar" data-accent="extension">
+          <div class="filter-bar-search">
+            <svg class="filter-bar-search-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"/></svg>
+            <input
+              id="listing-search"
+              type="search"
+              class="filter-bar-input"
+              placeholder="Search plugins by name, description, author, or tag"
+              aria-label="Search plugins"
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="filter-bar-controls">
+            <div class="facet-chips" role="group" aria-label="Filter by source">
+              <button type="button" class="facet-chip" data-facet-group="source" data-facet-value="local" aria-pressed="false">Local</button>
+              <button type="button" class="facet-chip" data-facet-group="source" data-facet-value="external" aria-pressed="false">External</button>
+            </div>
+
+            <label class="filter-bar-sort">
+              <span class="sr-only">Sort plugins</span>
+              <select id="sort-select" aria-label="Sort plugins">
+                <option value="title">Name (A-Z)</option>
+                <option value="lastUpdated">Recently updated</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="filter-bar-meta">
+            <span class="results-count" id="results-count" aria-live="polite">{initialItems.length} plugins</span>
+            <button type="button" class="filter-bar-clear" id="clear-filters" hidden>Clear filters</button>
           </div>
         </div>
-        <div class="resource-list" id="resource-list" role="list" set:html={renderPluginsHtml(initialItems)}></div>
+
+        <div class="resource-list rcard-grid" id="resource-list" role="list" set:html={renderPluginsHtml(initialItems)}></div>
         <ContributeCTA resourceType="plugins" />
       </div>
     </div>

--- a/website/src/pages/skills.astro
+++ b/website/src/pages/skills.astro
@@ -6,37 +6,65 @@ import EmbeddedPageData from '../components/EmbeddedPageData.astro';
 import BackToTop from '../components/BackToTop.astro';
 import Modal from '../components/Modal.astro';
 import skillsData from '../../public/data/skills.json';
-import { renderSkillsHtml, sortSkills } from '../scripts/pages/skills-render';
+import { renderSkillsHtml, skillAssetKinds, sortSkills } from '../scripts/pages/skills-render';
 
 const initialItems = sortSkills(skillsData.items, 'title');
+
+// Bundled-resource kinds (scripts, references, assets, …) become quick filters.
+const kindCounts = new Map<string, number>();
+for (const item of skillsData.items) {
+  for (const kind of skillAssetKinds(item)) {
+    kindCounts.set(kind, (kindCounts.get(kind) ?? 0) + 1);
+  }
+}
+const topKinds = [...kindCounts.entries()]
+  .sort((a, b) => b[1] - a[1])
+  .slice(0, 8)
+  .map(([key]) => key);
 ---
 
 <StarlightPage frontmatter={{ title: 'Skills', description: 'Self-contained agent skills with instructions and bundled resources', template: 'splash', prev: false, next: false, editUrl: false }}>
   <div id="main-content" class="skills-page listing-cards-page">
-    <PageHeader title="Skills" description="Self-contained agent skills with instructions and bundled resources" icon="lightning" />
+    <PageHeader title="Skills" description="Self-contained agent skills with instructions and bundled resources" icon="lightning" accent="power" />
 
     <div class="page-content">
       <div class="container">
-        <div class="listing-toolbar">
-          <div class="listing-toolbar-row">
-            <div class="results-count" id="results-count" aria-live="polite">{initialItems.length} skills</div>
-            <details class="listing-controls">
-              <summary class="listing-controls-trigger btn btn-secondary btn-small">Sort</summary>
-              <div class="listing-controls-panel">
-                <div class="filters-bar" id="filters-bar">
-                  <div class="filter-group">
-                    <label for="sort-select">Sort:</label>
-                    <select id="sort-select" aria-label="Sort by">
-                      <option value="title">Name (A-Z)</option>
-                      <option value="lastUpdated">Recently Updated</option>
-                    </select>
-                  </div>
-                </div>
-              </div>
-            </details>
+        <div class="filter-bar" data-accent="power">
+          <div class="filter-bar-search">
+            <svg class="filter-bar-search-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"/></svg>
+            <input
+              id="listing-search"
+              type="search"
+              class="filter-bar-input"
+              placeholder="Search skills by name, description, or bundled resource"
+              aria-label="Search skills"
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="filter-bar-controls">
+            <div class="facet-chips" role="group" aria-label="Filter by bundled resource">
+              {topKinds.map((kind) => (
+                <button type="button" class="facet-chip" data-facet-group="resource" data-facet-value={kind} aria-pressed="false">{kind}</button>
+              ))}
+            </div>
+
+            <label class="filter-bar-sort">
+              <span class="sr-only">Sort skills</span>
+              <select id="sort-select" aria-label="Sort skills">
+                <option value="title">Name (A-Z)</option>
+                <option value="lastUpdated">Recently updated</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="filter-bar-meta">
+            <span class="results-count" id="results-count" aria-live="polite">{initialItems.length} skills</span>
+            <button type="button" class="filter-bar-clear" id="clear-filters" hidden>Clear filters</button>
           </div>
         </div>
-        <div class="resource-list" id="resource-list" role="list" set:html={renderSkillsHtml(initialItems)}></div>
+
+        <div class="resource-list rcard-grid" id="resource-list" role="list" set:html={renderSkillsHtml(initialItems)}></div>
         <ContributeCTA resourceType="skills" />
       </div>
     </div>

--- a/website/src/pages/tools.astro
+++ b/website/src/pages/tools.astro
@@ -53,7 +53,7 @@ const initialItems = sortTools(
           </div>
         </div>
 
-        <div id="tools-list" role="list" set:html={renderToolsHtml(initialItems)}></div>
+        <div id="tools-list" set:html={renderToolsHtml(initialItems)}></div>
 
         <div class="coming-soon">
           <h2>More Tools Coming Soon</h2>

--- a/website/src/pages/tools.astro
+++ b/website/src/pages/tools.astro
@@ -13,53 +13,58 @@ const initialItems = sortTools(
     ...item,
     title: item.name,
   })),
-  "title"
+  "featured"
 );
 ---
 
 <StarlightPage frontmatter={{ title: 'Tools', description: 'MCP servers and developer tools for GitHub Copilot', template: 'splash', prev: false, next: false, editUrl: false }}>
-  <div id="main-content">
-    <PageHeader title="Tools" description="MCP servers and developer tools for GitHub Copilot" icon="wrench" />
+  <div id="main-content" class="tools-page listing-cards-page">
+    <PageHeader title="Tools" description="MCP servers and developer tools for GitHub Copilot" icon="wrench" accent="dev" />
 
     <div class="page-content">
       <div class="container">
-        <div class="listing-toolbar">
-          <div class="listing-toolbar-row">
-            <div id="results-count" class="results-count" aria-live="polite">{initialItems.length} tools</div>
-            <details class="listing-controls">
-              <summary class="listing-controls-trigger btn btn-secondary btn-small">Sort &amp; Filter</summary>
-              <div class="listing-controls-panel">
-                <div class="filters-bar" id="filters-bar">
-                  <div class="filter-group">
-                    <label for="filter-category">Category:</label>
-                    <select id="filter-category" class="filter-select" aria-label="Filter by category">
-                      <option value="">All Categories</option>
-                      {toolsData.filters.categories.map((category) => (
-                        <option value={category}>{category}</option>
-                      ))}
-                    </select>
-                  </div>
-                  <div class="filter-group">
-                    <label for="sort-select">Sort:</label>
-                    <select id="sort-select" class="filter-select" aria-label="Sort tools">
-                      <option value="featured">Featured First</option>
-                      <option value="title">Title</option>
-                    </select>
-                  </div>
-                  <button id="clear-filters" class="btn btn-secondary btn-small">Clear</button>
-                </div>
-              </div>
-            </details>
+        <div class="filter-bar" data-accent="dev">
+          <div class="filter-bar-search">
+            <svg class="filter-bar-search-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"/></svg>
+            <input
+              id="listing-search"
+              type="search"
+              class="filter-bar-input"
+              placeholder="Search tools by name, description, category, or feature"
+              aria-label="Search tools"
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="filter-bar-controls">
+            <div class="facet-chips" role="group" aria-label="Filter by category">
+              {toolsData.filters.categories.map((category) => (
+                <button type="button" class="facet-chip" data-facet-group="category" data-facet-value={category} aria-pressed="false">{category}</button>
+              ))}
+            </div>
+
+            <label class="filter-bar-sort">
+              <span class="sr-only">Sort tools</span>
+              <select id="sort-select" aria-label="Sort tools">
+                <option value="featured">Featured first</option>
+                <option value="title">Name (A-Z)</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="filter-bar-meta">
+            <span class="results-count" id="results-count" aria-live="polite">{initialItems.length} tools</span>
+            <button type="button" class="filter-bar-clear" id="clear-filters" hidden>Clear filters</button>
           </div>
         </div>
 
-        <div id="tools-list" set:html={renderToolsHtml(initialItems)}></div>
+        <div class="resource-list rcard-grid" id="resource-list" role="list" set:html={renderToolsHtml(initialItems)}></div>
 
         <div class="coming-soon">
-          <h2>More Tools Coming Soon</h2>
+          <h2>More tools coming soon</h2>
           <p>
             We're working on additional tools to enhance your GitHub Copilot
-            experience. Check back soon!
+            experience. Check back soon.
           </p>
         </div>
         <ContributeCTA resourceType="tools" />
@@ -72,157 +77,13 @@ const initialItems = sortTools(
   <EmbeddedPageData filename="tools.json" data={toolsData} />
 
   <style is:global>
-    .empty-state {
-      text-align: center;
-      padding: 48px;
-      background-color: var(--color-bg-secondary);
-      border-radius: var(--border-radius-lg);
-    }
-
-    .empty-state h3 {
-      color: var(--color-text-muted);
-      margin-bottom: 8px;
-    }
-
-    .empty-state p {
-      color: var(--color-text-muted);
-    }
-
-    .tool-card {
-      background-color: var(--color-card-bg);
-      border: 1px solid var(--color-border);
-      border-radius: var(--border-radius-lg);
-      padding: 32px;
-      margin-bottom: 24px;
-    }
-
-    .tool-header {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      margin-bottom: 16px;
-      flex-wrap: wrap;
-    }
-
-    .tool-header h2 {
-      margin: 0;
-      font-size: 24px;
-      color: var(--color-text-emphasis);
-    }
-
-    .tool-badges {
-      display: flex;
-      gap: 8px;
-      flex-wrap: wrap;
-    }
-
-    .tool-badge {
-      padding: 4px 12px;
-      border-radius: 4px;
-      font-size: 12px;
-      font-weight: 500;
-    }
-
-    .tool-badge.featured {
-      background-color: var(--color-primary);
-      color: white;
-    }
-
-    .tool-badge.category {
-      background-color: var(--color-purple-light);
-      color: var(--color-purple-dark);
-    }
-
-    .tool-description {
-      color: var(--color-text-secondary);
-      font-size: 16px;
-      line-height: 1.6;
-      margin-bottom: 24px;
-    }
-
-    .tool-section {
-      margin-top: 24px;
-    }
-
-    .tool-section h3 {
-      margin-bottom: 12px;
-      font-size: 16px;
-      font-weight: 600;
-      color: var(--color-text-emphasis);
-    }
-
-    .tool-section ul {
-      margin: 0;
-      padding-left: 24px;
-      color: var(--color-text-muted);
-    }
-
-    .tool-section li {
-      margin-bottom: 8px;
-    }
-
-    .tool-tags {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-      margin-top: 20px;
-    }
-
-    .tool-tag {
-      background-color: var(--color-bg-secondary);
-      color: var(--color-text-muted);
-      padding: 4px 12px;
-      border-radius: 16px;
-      font-size: 12px;
-      border: 1px solid var(--color-border);
-    }
-
-    .tool-config {
-      margin-top: 24px;
-    }
-
-    .tool-config h3 {
-      margin-bottom: 12px;
-      font-size: 16px;
-      font-weight: 600;
-      color: var(--color-text-emphasis);
-    }
-
-    .tool-config-wrapper {
-      position: relative;
-    }
-
-    .tool-config pre {
-      background-color: var(--color-bg-secondary);
-      border: 1px solid var(--color-border);
-      border-radius: var(--border-radius);
-      padding: 16px;
-      overflow-x: auto;
-      margin: 0;
-    }
-
-    .tool-config code {
-      font-family: var(--font-mono);
-      font-size: 13px;
-      color: var(--color-text-primary);
-      white-space: pre;
-    }
-
-    .tool-actions {
-      margin-top: 24px;
-      padding-top: 24px;
-      border-top: 1px solid var(--color-border);
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
-    }
-
     .coming-soon {
       text-align: center;
       padding: 48px;
       background-color: var(--color-bg-secondary);
       border: 1px dashed var(--color-border);
       border-radius: var(--border-radius-lg);
+      margin-top: 32px;
     }
 
     .coming-soon h2 {
@@ -232,6 +93,77 @@ const initialItems = sortTools(
 
     .coming-soon p {
       color: var(--color-text-muted);
+    }
+
+    /* Details-modal sections (reused for the tool detail view) */
+    .tool-details-modal .tool-section {
+      margin-top: 20px;
+    }
+
+    .tool-details-modal .tool-section h3,
+    .tool-details-modal .tool-config h3 {
+      margin: 0 0 10px;
+      font-size: 14px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      color: var(--color-text-emphasis);
+    }
+
+    .tool-details-modal .tool-section ul {
+      margin: 0;
+      padding-left: 20px;
+      color: var(--color-text-secondary);
+      line-height: 1.6;
+    }
+
+    .tool-details-modal .tool-section li {
+      margin-bottom: 6px;
+    }
+
+    .tool-details-modal .tool-config {
+      margin-top: 20px;
+    }
+
+    .tool-details-modal .tool-config-wrapper {
+      position: relative;
+    }
+
+    .tool-details-modal .tool-config pre {
+      background-color: var(--color-bg-secondary);
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius);
+      padding: 16px;
+      overflow-x: auto;
+      margin: 0;
+    }
+
+    .tool-details-modal .tool-config code {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      color: var(--color-text-primary);
+      white-space: pre;
+    }
+
+    .tool-details-modal .tool-tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 20px;
+    }
+
+    .tool-details-modal .tool-tag {
+      background-color: var(--color-bg-secondary);
+      color: var(--color-text-muted);
+      padding: 4px 12px;
+      border-radius: 16px;
+      font-size: 12px;
+      border: 1px solid var(--color-border);
+    }
+
+    .tool-details-modal .resource-tag.tag-featured {
+      background-color: color-mix(in srgb, var(--category-dev, #60a5fa) 16%, transparent);
+      color: var(--category-dev, #60a5fa);
+      border-color: color-mix(in srgb, var(--category-dev, #60a5fa) 32%, transparent);
     }
 
     .copy-config-btn {
@@ -259,6 +191,22 @@ const initialItems = sortTools(
       background-color: var(--color-success);
       color: white;
       border-color: var(--color-success);
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 48px;
+      background-color: var(--color-bg-secondary);
+      border-radius: var(--border-radius-lg);
+    }
+
+    .empty-state h3 {
+      color: var(--color-text-muted);
+      margin-bottom: 8px;
+    }
+
+    .empty-state p {
+      color: var(--color-text-muted);
     }
 
     /* Search highlight */

--- a/website/src/pages/workflows.astro
+++ b/website/src/pages/workflows.astro
@@ -6,42 +6,64 @@ import EmbeddedPageData from '../components/EmbeddedPageData.astro';
 import PageHeader from '../components/PageHeader.astro';
 import BackToTop from '../components/BackToTop.astro';
 import Modal from '../components/Modal.astro';
-import { renderWorkflowsHtml, sortWorkflows } from '../scripts/pages/workflows-render';
+import { renderWorkflowsHtml, sortWorkflows, humanizeTrigger, workflowTriggers } from '../scripts/pages/workflows-render';
 
 const initialItems = sortWorkflows(workflowsData.items, 'title');
+
+// Triggers become the quick filters, ordered by frequency.
+const triggerCounts = new Map<string, number>();
+for (const item of workflowsData.items) {
+  for (const trigger of workflowTriggers(item)) {
+    triggerCounts.set(trigger, (triggerCounts.get(trigger) ?? 0) + 1);
+  }
+}
+const topTriggers = [...triggerCounts.entries()]
+  .sort((a, b) => b[1] - a[1])
+  .map(([key]) => key);
 ---
 
 <StarlightPage frontmatter={{ title: 'Agentic Workflows', description: 'AI-powered repository automations that run coding agents in GitHub Actions', template: 'splash', prev: false, next: false, editUrl: false }}>
   <div id="main-content" class="workflows-page listing-cards-page">
-    <PageHeader title="Agentic Workflows" description="AI-powered repository automations that run coding agents in GitHub Actions" icon="workflow" />
+    <PageHeader title="Agentic Workflows" description="AI-powered repository automations that run coding agents in GitHub Actions" icon="workflow" accent="automation" />
 
     <div class="page-content">
       <div class="container">
-        <div class="listing-toolbar">
-          <div class="listing-toolbar-row">
-            <div class="results-count" id="results-count" aria-live="polite">{initialItems.length} workflows</div>
-            <details class="listing-controls">
-              <summary class="listing-controls-trigger btn btn-secondary btn-small">Sort &amp; Filter</summary>
-              <div class="listing-controls-panel">
-                <div class="filters-bar" id="filters-bar">
-                  <div class="filter-group">
-                    <label for="filter-trigger">Trigger:</label>
-                    <select id="filter-trigger" multiple aria-label="Filter by trigger"></select>
-                  </div>
-                  <div class="filter-group">
-                    <label for="sort-select">Sort:</label>
-                    <select id="sort-select" aria-label="Sort by">
-                      <option value="title">Name (A-Z)</option>
-                      <option value="lastUpdated">Recently Updated</option>
-                    </select>
-                  </div>
-                  <button id="clear-filters" class="btn btn-secondary btn-small">Clear Filters</button>
-                </div>
-              </div>
-            </details>
+        <div class="filter-bar" data-accent="automation">
+          <div class="filter-bar-search">
+            <svg class="filter-bar-search-icon" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"/></svg>
+            <input
+              id="listing-search"
+              type="search"
+              class="filter-bar-input"
+              placeholder="Search workflows by name, description, or trigger"
+              aria-label="Search workflows"
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="filter-bar-controls">
+            <div class="facet-chips" role="group" aria-label="Filter by trigger">
+              {topTriggers.map((trigger) => (
+                <button type="button" class="facet-chip" data-facet-group="trigger" data-facet-value={trigger} aria-pressed="false">{humanizeTrigger(trigger)}</button>
+              ))}
+            </div>
+
+            <label class="filter-bar-sort">
+              <span class="sr-only">Sort workflows</span>
+              <select id="sort-select" aria-label="Sort workflows">
+                <option value="title">Name (A-Z)</option>
+                <option value="lastUpdated">Recently updated</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="filter-bar-meta">
+            <span class="results-count" id="results-count" aria-live="polite">{initialItems.length} workflows</span>
+            <button type="button" class="filter-bar-clear" id="clear-filters" hidden>Clear filters</button>
           </div>
         </div>
-        <div class="resource-list" id="resource-list" role="list" set:html={renderWorkflowsHtml(initialItems)}></div>
+
+        <div class="resource-list rcard-grid" id="resource-list" role="list" set:html={renderWorkflowsHtml(initialItems)}></div>
         <ContributeCTA resourceType="workflows" />
       </div>
     </div>

--- a/website/src/scripts/pages/agents-render.ts
+++ b/website/src/scripts/pages/agents-render.ts
@@ -5,7 +5,14 @@ import {
   getInstallDropdownHtml,
   getLastUpdatedHtml,
 } from "../utils";
-import { renderEmptyStateHtml, renderSharedCardHtml } from "./card-render";
+import {
+  FACT_ICONS,
+  GITHUB_MARK,
+  TYPE_ICONS,
+  renderResourceGridHtml,
+  type RCardFact,
+  type RCardModel,
+} from "./resource-card";
 
 export interface RenderableAgent {
   title: string;
@@ -14,12 +21,93 @@ export interface RenderableAgent {
   model?: string | string[];
   tools?: string[];
   hasHandoffs?: boolean;
+  mcpServers?: string[];
   lastUpdated?: string | null;
 }
 
 export type AgentSortOption = "title" | "lastUpdated";
 
+export interface AgentFilterState {
+  query: string;
+  families: string[];
+  capabilities: string[];
+}
+
 const resourceType = "agent";
+
+export interface ModelFamily {
+  key: string;
+  label: string;
+}
+
+export interface Facet {
+  key: string;
+  label: string;
+}
+
+const FAMILY_RULES: { key: string; label: string; test: RegExp }[] = [
+  { key: "gpt", label: "GPT", test: /gpt|o1|o3|o4|codex/i },
+  { key: "claude", label: "Claude", test: /claude|sonnet|opus|haiku/i },
+  { key: "gemini", label: "Gemini", test: /gemini/i },
+  { key: "grok", label: "Grok", test: /grok/i },
+  { key: "llama", label: "Llama", test: /llama/i },
+  { key: "mistral", label: "Mistral", test: /mistral|mixtral/i },
+];
+
+/** Split a possibly array/pipe-delimited model field into cleaned model names. */
+export function normalizeModelList(model?: string | string[]): string[] {
+  if (!model) return [];
+  const raw = Array.isArray(model) ? model : [model];
+  const out: string[] = [];
+  for (const entry of raw) {
+    for (const part of String(entry).split(/[|,]/)) {
+      const cleaned = part.replace(/['"]/g, "").trim();
+      if (cleaned) out.push(cleaned);
+    }
+  }
+  return out;
+}
+
+function familyOf(modelName: string): ModelFamily {
+  for (const rule of FAMILY_RULES) {
+    if (rule.test.test(modelName)) return { key: rule.key, label: rule.label };
+  }
+  return { key: "other", label: "Other" };
+}
+
+/** Distinct model-family keys for a single agent. */
+export function agentModelFamilies(item: RenderableAgent): string[] {
+  const set = new Set<string>();
+  for (const m of normalizeModelList(item.model)) set.add(familyOf(m).key);
+  return [...set];
+}
+
+/** Model families present across all items, ordered by frequency. */
+export function getModelFamilies(items: RenderableAgent[]): ModelFamily[] {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    for (const key of agentModelFamilies(item)) {
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+  const labelFor = (key: string) =>
+    FAMILY_RULES.find((r) => r.key === key)?.label ?? "Other";
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([key]) => ({ key, label: labelFor(key) }));
+}
+
+/** Capability facets present across items (handoffs, MCP). */
+export function getCapabilityFacets(items: RenderableAgent[]): Facet[] {
+  const facets: Facet[] = [];
+  if (items.some((i) => (i.mcpServers?.length ?? 0) > 0)) {
+    facets.push({ key: "mcp", label: "MCP servers" });
+  }
+  if (items.some((i) => i.hasHandoffs)) {
+    facets.push({ key: "handoffs", label: "Handoffs" });
+  }
+  return facets;
+}
 
 export function sortAgents<T extends RenderableAgent>(
   items: T[],
@@ -31,62 +119,97 @@ export function sortAgents<T extends RenderableAgent>(
       const dateB = b.lastUpdated ? new Date(b.lastUpdated).getTime() : 0;
       return dateB - dateA;
     }
-
     return a.title.localeCompare(b.title);
   });
 }
 
+export function filterAgents<T extends RenderableAgent>(
+  items: T[],
+  state: AgentFilterState
+): T[] {
+  const query = state.query.trim().toLowerCase();
+  const families = new Set(state.families);
+  const capabilities = new Set(state.capabilities);
+
+  return items.filter((item) => {
+    if (capabilities.has("handoffs") && !item.hasHandoffs) return false;
+    if (capabilities.has("mcp") && !(item.mcpServers?.length ?? 0)) return false;
+
+    if (families.size > 0) {
+      const itemFamilies = agentModelFamilies(item);
+      if (!itemFamilies.some((f) => families.has(f))) return false;
+    }
+
+    if (query) {
+      const haystack = [
+        item.title,
+        item.description ?? "",
+        normalizeModelList(item.model).join(" "),
+        (item.tools ?? []).join(" "),
+      ]
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(query)) return false;
+    }
+
+    return true;
+  });
+}
+
 export function renderAgentsHtml(items: RenderableAgent[]): string {
-  if (items.length === 0) {
-    return renderEmptyStateHtml("No agents found", "No agents are available right now.");
-  }
+  const models: RCardModel[] = items.map((item) => {
+    const modelNames = normalizeModelList(item.model);
+    const badge = modelNames.length
+      ? {
+          text: modelNames[0],
+          title: modelNames.join(", "),
+          moreCount: modelNames.length - 1,
+          mono: true,
+        }
+      : null;
 
-  return items
-    .map((item) => {
-      const metaHtml = `
-        ${
-          item.model
-            ? `<span class="resource-tag tag-model">${escapeHtml(
-                Array.isArray(item.model) ? item.model.join(", ") : item.model
-              )}</span>`
-            : ""
-        }
-        ${
-          item.tools
-            ?.slice(0, 3)
-            .map((tool) => `<span class="resource-tag">${escapeHtml(tool)}</span>`)
-            .join("") || ""
-        }
-        ${
-          item.tools && item.tools.length > 3
-            ? `<span class="resource-tag">+${item.tools.length - 3} more</span>`
-            : ""
-        }
-        ${
-          item.hasHandoffs
-            ? `<span class="resource-tag tag-handoffs">handoffs</span>`
-            : ""
-        }
-        ${getLastUpdatedHtml(item.lastUpdated)}
-      `;
-
-      const actionsHtml = `
-        ${getInstallDropdownHtml(resourceType, item.path, true)}
-        ${getActionButtonsHtml(item.path, true)}
-        <a href="${getGitHubUrl(item.path)}" class="btn btn-secondary btn-small" target="_blank" onclick="event.stopPropagation()" title="View on GitHub">
-          GitHub
-        </a>
-      `;
-
-      return renderSharedCardHtml({
-        title: item.title,
-        description: item.description || "No description",
-        articleAttributes: {
-          "data-path": item.path,
-        },
-        metaHtml,
-        actionsHtml,
+    const facts: RCardFact[] = [];
+    if (item.tools && item.tools.length) {
+      facts.push({
+        icon: FACT_ICONS.tools,
+        label: `${item.tools.length} tool${item.tools.length === 1 ? "" : "s"}`,
       });
-    })
-    .join("");
+    }
+    if (item.mcpServers && item.mcpServers.length) {
+      facts.push({ icon: FACT_ICONS.mcp, label: `${item.mcpServers.length} MCP` });
+    }
+    if (item.hasHandoffs) {
+      facts.push({ icon: FACT_ICONS.handoffs, label: "Handoffs" });
+    }
+
+    const actionsHtml = `
+      ${getInstallDropdownHtml(resourceType, item.path, true)}
+      ${getActionButtonsHtml(item.path, true)}
+      <a href="${getGitHubUrl(
+        item.path
+      )}" class="btn btn-secondary btn-small action-github" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="View on GitHub" aria-label="View ${escapeHtml(
+        item.title
+      )} on GitHub">
+        ${GITHUB_MARK}
+      </a>
+    `;
+
+    return {
+      accent: "ai",
+      icon: TYPE_ICONS.robot,
+      title: item.title,
+      description: item.description || "No description",
+      path: item.path,
+      badge,
+      facts,
+      lastUpdatedHtml: getLastUpdatedHtml(item.lastUpdated),
+      actionsHtml,
+    };
+  });
+
+  return renderResourceGridHtml(
+    models,
+    "No agents match your filters",
+    "Try a different search term or clear the active filters."
+  );
 }

--- a/website/src/scripts/pages/agents.ts
+++ b/website/src/scripts/pages/agents.ts
@@ -13,6 +13,7 @@ import {
 } from '../utils';
 import { openCardDetailsModal, setupModal } from '../modal';
 import {
+  filterAgents,
   renderAgentsHtml,
   sortAgents,
   type AgentSortOption,
@@ -31,16 +32,38 @@ interface AgentsData {
 let allItems: Agent[] = [];
 let agentByPath = new Map<string, Agent>();
 let currentSort: AgentSortOption = 'title';
+let currentQuery = '';
+let activeFamilies = new Set<string>();
+let activeCapabilities = new Set<string>();
 let resourceListHandlersReady = false;
 let modalReady = false;
 
+function hasActiveFilters(): boolean {
+  return (
+    currentQuery.trim() !== '' ||
+    activeFamilies.size > 0 ||
+    activeCapabilities.size > 0
+  );
+}
+
 function applyFiltersAndRender(): void {
   const countEl = document.getElementById('results-count');
-  const results = sortAgents(allItems, currentSort);
+  const clearBtn = document.getElementById('clear-filters');
+
+  const filtered = filterAgents(allItems, {
+    query: currentQuery,
+    families: [...activeFamilies],
+    capabilities: [...activeCapabilities],
+  });
+  const results = sortAgents(filtered, currentSort);
 
   renderItems(results);
+
   if (countEl) {
     countEl.textContent = `${results.length} agent${results.length === 1 ? '' : 's'}`;
+  }
+  if (clearBtn) {
+    clearBtn.hidden = !hasActiveFilters();
   }
 }
 
@@ -137,17 +160,92 @@ function setupResourceListHandlers(list: HTMLElement | null): void {
 
 function syncUrlState(): void {
   updateQueryParams({
-    q: '',
-    model: [],
-    tool: [],
-    handoffs: false,
+    q: currentQuery.trim(),
+    model: [...activeFamilies],
+    cap: [...activeCapabilities],
     sort: currentSort === 'title' ? '' : currentSort,
+  });
+}
+
+function setupFilterBar(): void {
+  const searchInput = document.getElementById('listing-search') as HTMLInputElement | null;
+  const sortSelect = document.getElementById('sort-select') as HTMLSelectElement | null;
+  const chips = Array.from(document.querySelectorAll<HTMLButtonElement>('.facet-chip'));
+  const clearBtn = document.getElementById('clear-filters') as HTMLButtonElement | null;
+
+  // Hydrate state from the URL so shared/bookmarked filters survive reloads.
+  const initialQuery = getQueryParam('q');
+  if (initialQuery && searchInput) {
+    currentQuery = initialQuery;
+    searchInput.value = initialQuery;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  activeFamilies = new Set(params.getAll('model'));
+  activeCapabilities = new Set(params.getAll('cap'));
+
+  const initialSort = getQueryParam('sort');
+  if (initialSort === 'lastUpdated') {
+    currentSort = initialSort;
+    if (sortSelect) sortSelect.value = initialSort;
+  }
+
+  chips.forEach((chip) => {
+    const family = chip.dataset.family;
+    const capability = chip.dataset.capability;
+    const isActive =
+      (family && activeFamilies.has(family)) ||
+      (capability && activeCapabilities.has(capability));
+    chip.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+
+    chip.addEventListener('click', () => {
+      const pressed = chip.getAttribute('aria-pressed') === 'true';
+      const next = !pressed;
+      chip.setAttribute('aria-pressed', next ? 'true' : 'false');
+
+      if (family) {
+        if (next) activeFamilies.add(family);
+        else activeFamilies.delete(family);
+      } else if (capability) {
+        if (next) activeCapabilities.add(capability);
+        else activeCapabilities.delete(capability);
+      }
+
+      applyFiltersAndRender();
+      syncUrlState();
+    });
+  });
+
+  let searchTimer: number | undefined;
+  searchInput?.addEventListener('input', () => {
+    window.clearTimeout(searchTimer);
+    searchTimer = window.setTimeout(() => {
+      currentQuery = searchInput.value;
+      applyFiltersAndRender();
+      syncUrlState();
+    }, 150);
+  });
+
+  sortSelect?.addEventListener('change', () => {
+    currentSort = sortSelect.value as AgentSortOption;
+    applyFiltersAndRender();
+    syncUrlState();
+  });
+
+  clearBtn?.addEventListener('click', () => {
+    currentQuery = '';
+    activeFamilies.clear();
+    activeCapabilities.clear();
+    if (searchInput) searchInput.value = '';
+    chips.forEach((chip) => chip.setAttribute('aria-pressed', 'false'));
+    applyFiltersAndRender();
+    syncUrlState();
+    searchInput?.focus();
   });
 }
 
 export async function initAgentsPage(): Promise<void> {
   const list = document.getElementById('resource-list');
-  const sortSelect = document.getElementById('sort-select') as HTMLSelectElement;
 
   if (!modalReady) {
     setupModal();
@@ -165,17 +263,7 @@ export async function initAgentsPage(): Promise<void> {
   allItems = data.items;
   agentByPath = new Map(allItems.map((item) => [item.path, item]));
 
-  const initialSort = getQueryParam('sort');
-  if (initialSort === 'lastUpdated') {
-    currentSort = initialSort;
-    if (sortSelect) sortSelect.value = initialSort;
-  }
-
-  sortSelect?.addEventListener('change', () => {
-    currentSort = sortSelect.value as AgentSortOption;
-    applyFiltersAndRender();
-    syncUrlState();
-  });
+  setupFilterBar();
 
   applyFiltersAndRender();
   setupDropdownCloseHandlers();

--- a/website/src/scripts/pages/card-render.ts
+++ b/website/src/scripts/pages/card-render.ts
@@ -36,7 +36,7 @@ export function renderSharedCardHtml(item: SharedCardRenderItem): string {
     : "resource-item";
 
   return `
-    <article class="${articleClass}" role="${escapeHtml(role)}"${item.tabIndex !== undefined ? ` tabindex="${String(item.tabIndex)}"` : ""}${renderAttributes(item.articleAttributes)}>
+    <div class="${articleClass}" role="${escapeHtml(role)}"${item.tabIndex !== undefined ? ` tabindex="${String(item.tabIndex)}"` : ""}${renderAttributes(item.articleAttributes)}>
       <button type="button" class="resource-preview">
         ${item.previewMediaHtml || ""}
         <div class="resource-info">
@@ -49,6 +49,6 @@ export function renderSharedCardHtml(item: SharedCardRenderItem): string {
         </div>
       </button>
       ${item.actionsHtml ? `<div class="resource-actions">${item.actionsHtml}</div>` : ""}
-    </article>
+    </div>
   `;
 }

--- a/website/src/scripts/pages/extensions-render.ts
+++ b/website/src/scripts/pages/extensions-render.ts
@@ -3,7 +3,6 @@ import {
   getGitHubHandle,
   getGitHubUrl,
   getLastUpdatedHtml,
-  sanitizeUrl,
 } from "../utils";
 import { renderEmptyStateHtml, renderSharedCardHtml } from "./card-render";
 
@@ -106,15 +105,9 @@ export function renderExtensionsHtml(items: RenderableExtension[]): string {
           ? getGitHubHandle(authorUrl, authorName)
           : authorName || "";
       const authorHtml = authorName
-        ? `<span class="resource-tag resource-author">by ${
-            authorUrl
-              ? `<a href="${escapeHtml(
-                  sanitizeUrl(authorUrl)
-                )}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(
-                  authorName
-                )}">${escapeHtml(authorHandle)}</a>`
-              : escapeHtml(authorName)
-          }</span>`
+        ? `<span class="resource-tag resource-author" title="${escapeHtml(
+            authorName
+          )}">by ${escapeHtml(authorHandle || authorName)}</span>`
         : "";
 
       const metaHtml = `
@@ -148,7 +141,6 @@ export function renderExtensionsHtml(items: RenderableExtension[]): string {
         infoExtraHtml,
         metaHtml,
         actionsHtml,
-        tabIndex: 0,
         articleAttributes: {
           id: item.id,
           "data-extension-id": item.id,

--- a/website/src/scripts/pages/extensions-render.ts
+++ b/website/src/scripts/pages/extensions-render.ts
@@ -1,10 +1,12 @@
+import { escapeHtml, getGitHubHandle, getGitHubUrl } from "../utils";
 import {
-  escapeHtml,
-  getGitHubHandle,
-  getGitHubUrl,
-  getLastUpdatedHtml,
-} from "../utils";
-import { renderEmptyStateHtml, renderSharedCardHtml } from "./card-render";
+  FACT_ICONS,
+  GITHUB_MARK,
+  TYPE_ICONS,
+  renderResourceGridHtml,
+  type RCardFact,
+  type RCardModel,
+} from "./resource-card";
 
 export interface RenderableExtension {
   id: string;
@@ -59,93 +61,97 @@ export function sortExtensions<T extends RenderableExtension>(
   });
 }
 
+export function getExtensionInstallUrl(item: RenderableExtension): string {
+  return (
+    item.installUrl ||
+    (item.path && item.ref
+      ? `https://github.com/github/awesome-copilot/tree/${item.ref}/${item.path.replace(
+          /\\/g,
+          "/"
+        )}`
+      : "")
+  );
+}
+
+export function getExtensionSourceUrl(item: RenderableExtension): string {
+  return item.sourceUrl || (item.path ? getGitHubUrl(item.path) : "");
+}
+
+export function extensionAuthorHandle(item: RenderableExtension): string {
+  const authorName = item.author?.name;
+  const authorUrl = item.author?.url;
+  if (!authorName) return "";
+  return authorUrl ? getGitHubHandle(authorUrl, authorName) : authorName;
+}
+
+export function extensionSource(item: RenderableExtension): string[] {
+  return item.external ? ["external"] : ["local"];
+}
+
+export function extensionSearchText(item: RenderableExtension): string {
+  return [
+    item.name,
+    item.description ?? "",
+    item.author?.name ?? "",
+    (item.keywords ?? []).join(" "),
+    item.external ? "external" : "local",
+  ].join(" ");
+}
+
 export function renderExtensionsHtml(items: RenderableExtension[]): string {
-  if (items.length === 0) {
-    return renderEmptyStateHtml(
-      "No extensions found",
-      "No canvas extensions are available right now."
-    );
-  }
+  const models: RCardModel[] = items.map((item) => {
+    const safeName = escapeHtml(item.name);
+    const installUrl = getExtensionInstallUrl(item);
+    const sourceUrl = getExtensionSourceUrl(item);
 
-  return items
-    .map((item) => {
-      const installUrl =
-        item.installUrl ||
-        (item.path && item.ref
-          ? `https://github.com/github/awesome-copilot/tree/${item.ref}/${item.path.replace(
-             /\\/g,
-             "/"
-           )}`
-          : "");
-      const sourceUrl =
-        item.sourceUrl || (item.path ? getGitHubUrl(item.path) : "");
+    const mediaHtml = item.imageUrl
+      ? `<img src="${escapeHtml(item.imageUrl)}" alt="" loading="lazy" />`
+      : undefined;
 
-      const previewMediaHtml = item.imageUrl
-        ? `<div class="resource-thumbnail-btn" data-extension-id="${escapeHtml(item.id)}" aria-hidden="true">
-            <img class="resource-thumbnail" src="${escapeHtml(item.imageUrl)}" alt="${escapeHtml(item.name)} preview" loading="lazy" />
-           </div>`
-        : `<div class="resource-thumbnail resource-thumbnail-placeholder" aria-hidden="true">Canvas</div>`;
-
-      const infoExtraHtml = `
-        <div class="resource-keywords">
-          ${
-           item.keywords && item.keywords.length > 0
-             ? item.keywords
-                 .map((kw) => `<span class="keyword-tag">${escapeHtml(kw)}</span>`)
-                 .join("")
-             : ""
-          }
-        </div>
-      `;
-
-      const authorName = item.author?.name;
-      const authorUrl = item.author?.url;
-      const authorHandle =
-        authorName && authorUrl
-          ? getGitHubHandle(authorUrl, authorName)
-          : authorName || "";
-      const authorHtml = authorName
-        ? `<span class="resource-tag resource-author" title="${escapeHtml(
-            authorName
-          )}">by ${escapeHtml(authorHandle || authorName)}</span>`
-        : "";
-
-      const metaHtml = `
-        ${item.external ? '<span class="resource-tag">External</span>' : ""}
-        ${authorHtml}
-        ${getLastUpdatedHtml(item.lastUpdated)}
-      `;
-
-      const actionsHtml = `
-        <button
-          class="btn btn-primary btn-small copy-install-url-btn"
-          data-install-url="${escapeHtml(installUrl)}"
-          title="Copy install URL"
-          ${installUrl ? "" : "disabled"}
-        >
-          Copy URL
-        </button>
-        ${
-          sourceUrl
-           ? `<a href="${escapeHtml(
-               sourceUrl
-             )}" class="btn btn-secondary btn-small" target="_blank" rel="noopener noreferrer" title="View source">Source</a>`
-           : ""
-        }
-      `;
-
-      return renderSharedCardHtml({
-        title: item.name,
-        description: item.description || "Canvas extension",
-        previewMediaHtml,
-        infoExtraHtml,
-        metaHtml,
-        actionsHtml,
-        articleAttributes: {
-          id: item.id,
-          "data-extension-id": item.id,
-        },
+    const facts: RCardFact[] = [];
+    const handle = extensionAuthorHandle(item);
+    if (handle) {
+      facts.push({ icon: FACT_ICONS.author, label: `by ${handle}` });
+    }
+    if (item.keywords?.length) {
+      facts.push({
+        icon: FACT_ICONS.tag,
+        label: `${item.keywords.length} keyword${
+          item.keywords.length === 1 ? "" : "s"
+        }`,
       });
-    })
-    .join("");
+    }
+
+    const installHtml = `<button type="button" class="btn btn-primary btn-small copy-install-url-btn" data-install-url="${escapeHtml(
+      installUrl
+    )}" ${
+      installUrl ? "" : "disabled"
+    } onclick="event.stopPropagation()" title="Copy install URL"><span>Copy URL</span></button>`;
+
+    const sourceHtml = sourceUrl
+      ? `<a href="${escapeHtml(
+          sourceUrl
+        )}" class="btn btn-secondary btn-small action-github rcard-lead" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()" title="View source" aria-label="View ${safeName} source">${GITHUB_MARK}</a>`
+      : "";
+
+    return {
+      accent: "extension",
+      icon: TYPE_ICONS.browser,
+      title: item.name,
+      description: item.description || "Canvas extension",
+      path: item.id,
+      badge: item.external ? { text: "External" } : null,
+      facts,
+      actionsHtml: `${installHtml}${sourceHtml}`,
+      attributes: { "data-extension-id": item.id },
+      articleClassName: item.external ? "resource-item-external" : undefined,
+      mediaHtml,
+    };
+  });
+
+  return renderResourceGridHtml(
+    models,
+    "No extensions found",
+    "No canvas extensions match your filters."
+  );
 }

--- a/website/src/scripts/pages/extensions.ts
+++ b/website/src/scripts/pages/extensions.ts
@@ -2,58 +2,32 @@
  * Canvas extensions page functionality
  */
 import {
-  createChoices,
-  getChoicesValues,
-  setChoicesValues,
-  type Choices,
-} from "../choices";
-import {
-  escapeHtml,
   copyToClipboard,
-  fetchData,
+  escapeHtml,
   formatRelativeTime,
   getGitHubHandle,
-  getGitHubUrl,
-  getQueryParam,
-  getQueryParamValues,
   sanitizeUrl,
   showToast,
-  updateQueryParams,
 } from "../utils";
-import { openCardDetailsModal, setupModal } from "../modal";
+import { openCardDetailsModal } from "../modal";
+import { initListingPage } from "./listing-controller";
 import {
+  extensionSearchText,
+  extensionSource,
+  getExtensionInstallUrl,
+  getExtensionSourceUrl,
   renderExtensionsHtml,
   sortExtensions,
   type ExtensionSortOption,
   type RenderableExtension,
 } from "./extensions-render";
 
-interface Extension extends RenderableExtension {
-  lastUpdated?: string | null;
-  keywords?: string[];
-}
-
-interface ExtensionsData {
-  items: Extension[];
-  filters?: {
-    keywords?: string[];
-  };
-}
+interface Extension extends RenderableExtension {}
 
 interface ExtensionScreenshot {
   path?: string | null;
   type?: string | null;
 }
-
-let allItems: Extension[] = [];
-let extensionById = new Map<string, Extension>();
-let currentSort: ExtensionSortOption = "title";
-let keywordSelect: Choices;
-let currentFilters = {
-  keywords: [] as string[],
-};
-let actionHandlersReady = false;
-let modalReady = false;
 
 function normalizeScreenshotEntries(value: unknown): ExtensionScreenshot[] {
   if (!value) return [];
@@ -66,23 +40,10 @@ function normalizeScreenshotEntries(value: unknown): ExtensionScreenshot[] {
   return [];
 }
 
-function getInstallUrl(item: Extension): string {
-  return (
-    item.installUrl ||
-    (item.path && item.ref
-      ? `https://github.com/github/awesome-copilot/tree/${item.ref}/${item.path.replace(
-          /\\/g,
-          "/"
-        )}`
-      : "")
-  );
-}
-
-function getSourceUrl(item: Extension): string {
-  return item.sourceUrl || (item.path ? getGitHubUrl(item.path) : "");
-}
-
-function toRawAssetUrl(item: Extension, assetPath: string | null | undefined): string {
+function toRawAssetUrl(
+  item: Extension,
+  assetPath: string | null | undefined
+): string {
   if (!assetPath || !item.ref) return "";
   if (/^https?:\/\//i.test(assetPath)) return assetPath;
   return `https://raw.githubusercontent.com/github/awesome-copilot/${item.ref}/${assetPath.replace(
@@ -152,30 +113,24 @@ function setSelectedGalleryImage(url: string, extensionName: string): void {
   image.src = url;
   image.alt = `${extensionName} screenshot`;
 
-  gallery?.querySelectorAll<HTMLButtonElement>(".extension-details-thumbnail-btn").forEach((button) => {
-    const isActive = button.dataset.galleryImageUrl === url;
-    button.classList.toggle("active", isActive);
-    if (isActive) {
-      button.setAttribute("aria-current", "true");
-    } else {
-      button.removeAttribute("aria-current");
-    }
-  });
+  gallery
+    ?.querySelectorAll<HTMLButtonElement>(".extension-details-thumbnail-btn")
+    .forEach((button) => {
+      const isActive = button.dataset.galleryImageUrl === url;
+      button.classList.toggle("active", isActive);
+      if (isActive) {
+        button.setAttribute("aria-current", "true");
+      } else {
+        button.removeAttribute("aria-current");
+      }
+    });
 }
 
-function openDetailsModal(
-  extensionId: string,
-  preferredImageUrl?: string,
-  trigger?: HTMLElement
-): void {
-  const item = extensionById.get(extensionId);
-  if (!item) {
-    return;
-  }
-
+function openExtensionDetailsModal(item: Extension, trigger?: HTMLElement): void {
   const keywordHtml = (item.keywords || [])
     .map((keyword) => `<span class="keyword-tag">${escapeHtml(keyword)}</span>`)
     .join("");
+
   const metaParts: string[] = [];
   if (item.external) {
     metaParts.push('<span class="resource-tag">External</span>');
@@ -193,9 +148,7 @@ function openDetailsModal(
           )}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(
             authorName
           )}">${escapeHtml(authorHandle)}</a></span>`
-        : `<span class="resource-author">by ${escapeHtml(
-            authorName
-          )}</span>`
+        : `<span class="resource-author">by ${escapeHtml(authorName)}</span>`
     );
   }
   if (item.lastUpdated) {
@@ -206,8 +159,8 @@ function openDetailsModal(
     );
   }
 
-  const installUrl = getInstallUrl(item);
-  const sourceUrl = getSourceUrl(item);
+  const installUrl = getExtensionInstallUrl(item);
+  const sourceUrl = getExtensionSourceUrl(item);
   const detailsHtml = `
     <div class="extension-details-body">
       <div class="extension-details-main">
@@ -225,7 +178,7 @@ function openDetailsModal(
         <div class="resource-actions extension-details-actions">
           <button id="extension-details-install" class="btn btn-primary btn-small" type="button" data-install-url="${escapeHtml(
             installUrl
-          )}" ${installUrl ? "" : "disabled"}>Install</button>
+          )}" ${installUrl ? "" : "disabled"}>Copy URL</button>
           ${
             sourceUrl
               ? `<a id="extension-details-source" class="btn btn-secondary btn-small" href="${escapeHtml(
@@ -247,249 +200,58 @@ function openDetailsModal(
   });
 
   const galleryImages = getGalleryImages(item);
-  const initialImage = preferredImageUrl || galleryImages[0] || "";
+  const initialImage = galleryImages[0] || "";
   renderGalleryThumbnails(galleryImages, initialImage);
   if (initialImage) {
     setSelectedGalleryImage(initialImage, item.name);
   }
 }
 
-function sortItems(items: Extension[]): Extension[] {
-  return sortExtensions(items, currentSort);
-}
-
-function getCountText(resultsCount: number): string {
-  if (currentFilters.keywords.length === 0) {
-    return `${resultsCount} extension${resultsCount === 1 ? "" : "s"}`;
-  }
-
-  return `${resultsCount} of ${allItems.length} extensions (filtered by ${currentFilters.keywords.length} keyword${currentFilters.keywords.length === 1 ? "" : "s"})`;
-}
-
-function applySortAndRender(): void {
-  const countEl = document.getElementById("results-count");
-  let results = [...allItems];
-
-  if (currentFilters.keywords.length > 0) {
-    results = results.filter((item) =>
-      item.keywords?.some((keyword) => currentFilters.keywords.includes(keyword))
-    );
-  }
-
-  results = sortItems(results);
-
-  renderItems(results);
-  if (countEl) {
-    countEl.textContent = getCountText(results.length);
-  }
-}
-
-function renderItems(items: Extension[]): void {
-  const list = document.getElementById("resource-list");
-  if (!list) return;
-
-  list.innerHTML = renderExtensionsHtml(items);
-}
-
-function setupActionHandlers(list: HTMLElement | null): void {
-  if (!list || actionHandlersReady) return;
-
-  list.addEventListener("click", async (event) => {
-    const target = event.target as HTMLElement;
-
-    const installButton = target.closest(
-      ".copy-install-url-btn"
-    ) as HTMLButtonElement | null;
-
-    if (!installButton) return;
-
-    event.stopPropagation();
-    const installUrl = installButton.dataset.installUrl || "";
-    if (!installUrl) {
-      showToast("No install URL available for this extension", "error");
-      return;
-    }
-    const success = await copyToClipboard(installUrl);
-    showToast(
-      success ? "Extension URL copied!" : "Failed to copy extension URL",
-      success ? "success" : "error"
-    );
-    return;
-  });
-
-  list.addEventListener("click", (event) => {
-    const target = event.target as HTMLElement;
-
-    const thumbnailButton = target.closest(
-      ".resource-thumbnail-btn"
-    ) as HTMLElement | null;
-    if (thumbnailButton) {
-      event.preventDefault();
-      event.stopPropagation();
-      const extensionId = thumbnailButton.dataset.extensionId;
-      if (!extensionId) return;
-      const previewButton = thumbnailButton.closest(".resource-preview") as HTMLElement | null;
-      openDetailsModal(extensionId, undefined, previewButton || undefined);
-      return;
-    }
-
-    if (
-      target.closest(".resource-actions") ||
-      target.closest(".extension-details-thumbnail-btn")
-    ) {
-      return;
-    }
-
-    const card = target.closest(".resource-item") as HTMLElement | null;
-    const previewButton = card?.querySelector(".resource-preview") as HTMLElement | null;
-    const extensionId = card?.dataset.extensionId;
-    if (extensionId) {
-      openDetailsModal(extensionId, undefined, previewButton || undefined);
-    }
-  });
-
-  list.addEventListener("keydown", (event) => {
-    const target = event.target as HTMLElement;
-    const card = target.closest(".resource-item") as HTMLElement | null;
-    if (!card) return;
-
-    if (target.closest("a, button, select, input, textarea")) return;
-
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      const extensionId = card.dataset.extensionId;
-      const previewButton = card.querySelector(".resource-preview") as HTMLElement | null;
-      if (extensionId) {
-        openDetailsModal(extensionId, undefined, previewButton || undefined);
-      }
-    }
-  });
-
+/** Delegated handlers for the bespoke copy-URL buttons + gallery switching. */
+function setupExtensionActionHandlers(): void {
   document.addEventListener("click", async (event) => {
     const target = event.target as HTMLElement;
-    const detailsInstallButton = target.closest(
-      "#extension-details-install"
+
+    const copyButton = target.closest(
+      ".copy-install-url-btn, #extension-details-install"
     ) as HTMLButtonElement | null;
-    if (detailsInstallButton) {
-      const installUrl = detailsInstallButton.dataset.installUrl || "";
+    if (copyButton) {
+      event.stopPropagation();
+      const installUrl = copyButton.dataset.installUrl || "";
       if (!installUrl) {
         showToast("No install URL available for this extension", "error");
         return;
       }
-
       const success = await copyToClipboard(installUrl);
       showToast(
-        success ? "Install URL copied!" : "Failed to copy install URL",
+        success ? "Extension URL copied!" : "Failed to copy extension URL",
         success ? "success" : "error"
       );
       return;
     }
 
-    const button = target.closest(
+    const thumbnailButton = target.closest(
       ".extension-details-thumbnail-btn"
     ) as HTMLButtonElement | null;
-    if (!button) return;
-
-    const imageUrl = button.dataset.galleryImageUrl;
-    const titleText = document.getElementById("modal-title")?.textContent;
-    if (!imageUrl || !titleText) return;
-    setSelectedGalleryImage(imageUrl, titleText);
-  });
-
-  actionHandlersReady = true;
-}
-
-function syncUrlState(): void {
-  updateQueryParams({
-    q: "",
-    keyword: currentFilters.keywords,
-    sort: currentSort === "title" ? "" : currentSort,
+    if (thumbnailButton) {
+      const imageUrl = thumbnailButton.dataset.galleryImageUrl;
+      const titleText = document.getElementById("modal-title")?.textContent;
+      if (imageUrl && titleText) {
+        setSelectedGalleryImage(imageUrl, titleText);
+      }
+    }
   });
 }
 
-export async function initExtensionsPage(): Promise<void> {
-  const list = document.getElementById("resource-list");
-  const clearFiltersBtn = document.getElementById("clear-filters");
-  const sortSelect = document.getElementById(
-    "sort-select"
-  ) as HTMLSelectElement;
+setupExtensionActionHandlers();
 
-  if (!modalReady) {
-    setupModal();
-    modalReady = true;
-  }
-
-  setupActionHandlers(list as HTMLElement | null);
-
-  const data = await fetchData<ExtensionsData>("extensions.json");
-  if (!data || !data.items) {
-    if (list)
-      list.innerHTML =
-        '<div class="empty-state"><h3>Failed to load data</h3></div>';
-    return;
-  }
-
-  allItems = data.items;
-  extensionById = new Map(allItems.map((item) => [item.id, item]));
-
-  const availableKeywords = (
-    data.filters?.keywords ||
-    Array.from(
-      new Set(
-        data.items.flatMap((item) =>
-          Array.isArray(item.keywords) ? item.keywords : []
-        )
-      )
-    )
-  ).sort((a, b) => a.localeCompare(b));
-
-  keywordSelect = createChoices("#filter-keyword", {
-    placeholderValue: "All Keywords",
-  });
-  keywordSelect.setChoices(
-    availableKeywords.map((keyword) => ({ value: keyword, label: keyword })),
-    "value",
-    "label",
-    true
-  );
-
-  const initialKeywords = getQueryParamValues("keyword").filter((keyword) =>
-    availableKeywords.includes(keyword)
-  );
-  const initialSort = getQueryParam("sort");
-  if (initialKeywords.length > 0) {
-    currentFilters.keywords = initialKeywords;
-    setChoicesValues(keywordSelect, initialKeywords);
-  }
-  if (initialSort === "lastUpdated") {
-    currentSort = initialSort;
-    if (sortSelect) sortSelect.value = initialSort;
-  }
-
-  document.getElementById("filter-keyword")?.addEventListener("change", () => {
-    currentFilters.keywords = getChoicesValues(keywordSelect);
-    applySortAndRender();
-    syncUrlState();
-  });
-
-  sortSelect?.addEventListener("change", () => {
-    currentSort = sortSelect.value as ExtensionSortOption;
-    applySortAndRender();
-    syncUrlState();
-  });
-
-  clearFiltersBtn?.addEventListener("click", () => {
-    currentFilters = { keywords: [] };
-    currentSort = "title";
-    keywordSelect.removeActiveItems();
-    if (sortSelect) sortSelect.value = "title";
-    applySortAndRender();
-    syncUrlState();
-  });
-
-  applySortAndRender();
-  syncUrlState();
-}
-
-// Auto-initialize when DOM is ready
-document.addEventListener("DOMContentLoaded", initExtensionsPage);
+initListingPage<Extension>({
+  dataFile: "extensions.json",
+  keyOf: (item) => item.id,
+  search: extensionSearchText,
+  facetValues: (item) => ({ source: extensionSource(item) }),
+  sort: (items, sort) => sortExtensions(items, sort as ExtensionSortOption),
+  render: renderExtensionsHtml,
+  noun: "extension",
+  openModal: openExtensionDetailsModal,
+});

--- a/website/src/scripts/pages/hooks-render.ts
+++ b/website/src/scripts/pages/hooks-render.ts
@@ -1,9 +1,12 @@
+import { escapeHtml, getGitHubUrl, getLastUpdatedHtml } from '../utils';
 import {
-  escapeHtml,
-  getGitHubUrl,
-  getLastUpdatedHtml,
-} from "../utils";
-import { renderEmptyStateHtml, renderSharedCardHtml } from "./card-render";
+  FACT_ICONS,
+  GITHUB_MARK,
+  TYPE_ICONS,
+  renderResourceGridHtml,
+  type RCardFact,
+  type RCardModel,
+} from './resource-card';
 
 export interface RenderableHook {
   id: string;
@@ -34,57 +37,61 @@ export function sortHooks<T extends RenderableHook>(
   });
 }
 
+/** Lifecycle events a hook binds to (facet values). */
+export function hookEvents(item: RenderableHook): string[] {
+  return item.hooks ?? [];
+}
+
+export function hookSearchText(item: RenderableHook): string {
+  return [
+    item.title,
+    item.description ?? '',
+    (item.hooks ?? []).join(' '),
+    (item.tags ?? []).join(' '),
+  ].join(' ');
+}
+
+const DOWNLOAD_SVG = `<svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M7.47 10.78a.75.75 0 0 0 1.06 0l3.75-3.75a.75.75 0 0 0-1.06-1.06L8.75 8.44V1.75a.75.75 0 0 0-1.5 0v6.69L4.78 5.97a.75.75 0 0 0-1.06 1.06l3.75 3.75ZM3.75 13a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5h-8.5Z"/></svg>`;
+
 export function renderHooksHtml(items: RenderableHook[]): string {
-  if (items.length === 0) {
-    return renderEmptyStateHtml("No hooks found", "Try adjusting the selected filters.");
-  }
-
-  return items
-    .map((item) => {
-      const metaHtml = `
-        ${item.hooks
-          .map(
-            (hook) => `<span class="resource-tag tag-hook">${escapeHtml(hook)}</span>`
-          )
-          .join("")}
-        ${item.tags
-          .map((tag) => `<span class="resource-tag tag-tag">${escapeHtml(tag)}</span>`)
-          .join("")}
-        ${
-          item.assets.length > 0
-            ? `<span class="resource-tag tag-assets">${item.assets.length} asset${
-                item.assets.length === 1 ? "" : "s"
-              }</span>`
-            : ""
-        }
-        ${getLastUpdatedHtml(item.lastUpdated)}
-      `;
-
-      const actionsHtml = `
-        <button class="btn btn-primary download-hook-btn" data-hook-id="${escapeHtml(
-          item.id
-        )}" title="Download as ZIP">
-          <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
-            <path d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z"/>
-            <path d="M7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06l1.97 1.969Z"/>
-          </svg>
-          Download
-        </button>
-        <a href="${getGitHubUrl(
-          item.path
-        )}" class="btn btn-secondary" target="_blank" onclick="event.stopPropagation()" title="View on GitHub">GitHub</a>
-      `;
-
-      return renderSharedCardHtml({
-        title: item.title,
-        description: item.description || "No description",
-        articleAttributes: {
-          "data-path": item.readmeFile,
-          "data-hook-id": item.id,
-        },
-        metaHtml,
-        actionsHtml,
+  const models: RCardModel[] = items.map((item) => {
+    const facts: RCardFact[] = [];
+    if (item.assets.length) {
+      facts.push({
+        icon: FACT_ICONS.asset,
+        label: `${item.assets.length} asset${item.assets.length === 1 ? '' : 's'}`,
       });
-    })
-    .join("");
+    }
+
+    const safeTitle = escapeHtml(item.title);
+    const actionsHtml = `
+      <button type="button" class="download-hook-btn rcard-icon-btn rcard-lead" data-hook-id="${escapeHtml(
+        item.id
+      )}" title="Download as ZIP" aria-label="Download ${safeTitle} as ZIP">
+        ${DOWNLOAD_SVG}
+      </button>
+      <a href="${getGitHubUrl(item.path)}" class="action-github" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="View on GitHub" aria-label="View ${safeTitle} on GitHub">
+        ${GITHUB_MARK}
+      </a>
+    `;
+
+    return {
+      accent: 'automation',
+      icon: TYPE_ICONS.hook,
+      title: item.title,
+      description: item.description || 'No description',
+      path: item.readmeFile,
+      attributes: { 'data-hook-id': item.id },
+      badge: item.hooks[0] ? { text: item.hooks[0], mono: true, moreCount: Math.max(0, item.hooks.length - 1) } : null,
+      facts,
+      lastUpdatedHtml: getLastUpdatedHtml(item.lastUpdated),
+      actionsHtml,
+    };
+  });
+
+  return renderResourceGridHtml(
+    models,
+    'No hooks match your filters',
+    'Try a different search term or clear the active filters.'
+  );
 }

--- a/website/src/scripts/pages/hooks.ts
+++ b/website/src/scripts/pages/hooks.ts
@@ -5,15 +5,14 @@ import {
   escapeHtml,
   fetchData,
   formatRelativeTime,
-  getQueryParam,
-  getQueryParamValues,
   showToast,
   downloadZipBundle,
-  updateQueryParams,
 } from '../utils';
-import { openCardDetailsModal, setupModal } from '../modal';
-import { clearSelectValues, getSelectValues, setSelectValues } from './select-utils';
+import { openCardDetailsModal } from '../modal';
+import { initListingPage } from './listing-controller';
 import {
+  hookEvents,
+  hookSearchText,
   renderHooksHtml,
   sortHooks,
   type HookSortOption,
@@ -24,52 +23,19 @@ interface Hook extends RenderableHook {}
 
 interface HooksData {
   items: Hook[];
-  filters: {
-    tags: string[];
-  };
 }
 
-let allItems: Hook[] = [];
+const SPINNER_SVG =
+  '<svg class="spinner" viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M8 0a8 8 0 1 0 8 8h-1.5A6.5 6.5 0 1 1 8 1.5V0z"/></svg>';
+const CHECK_SVG =
+  '<svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z"/></svg>';
+const DOWNLOAD_SVG =
+  '<svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M7.47 10.78a.75.75 0 0 0 1.06 0l3.75-3.75a.75.75 0 0 0-1.06-1.06L8.75 8.44V1.75a.75.75 0 0 0-1.5 0v6.69L4.78 5.97a.75.75 0 0 0-1.06 1.06l3.75 3.75ZM3.75 13a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5h-8.5Z"/></svg>';
+
 let hookById = new Map<string, Hook>();
-let tagSelectEl: HTMLSelectElement | null = null;
-let currentFilters = {
-  tags: [] as string[],
-};
-let currentSort: HookSortOption = 'title';
-let resourceListHandlersReady = false;
-let modalReady = false;
-
-function sortItems(items: Hook[]): Hook[] {
-  return sortHooks(items, currentSort);
-}
-
-function applyFiltersAndRender(): void {
-  const countEl = document.getElementById('results-count');
-  let results = [...allItems];
-
-  if (currentFilters.tags.length > 0) {
-    results = results.filter((item) => item.tags.some((tag) => currentFilters.tags.includes(tag)));
-  }
-
-  results = sortItems(results);
-
-  renderItems(results);
-  let countText = `${results.length} hook${results.length === 1 ? '' : 's'}`;
-  if (currentFilters.tags.length > 0) {
-    countText = `${results.length} of ${allItems.length} hooks (filtered by ${currentFilters.tags.length} tag${currentFilters.tags.length > 1 ? 's' : ''})`;
-  }
-  if (countEl) countEl.textContent = countText;
-}
-
-function renderItems(items: Hook[]): void {
-  const list = document.getElementById('resource-list');
-  if (!list) return;
-
-  list.innerHTML = renderHooksHtml(items);
-}
 
 async function downloadHook(hookId: string, btn: HTMLButtonElement): Promise<void> {
-  const hook = allItems.find((item) => item.id === hookId);
+  const hook = hookById.get(hookId);
   if (!hook) {
     showToast('Hook not found.', 'error');
     return;
@@ -77,33 +43,22 @@ async function downloadHook(hookId: string, btn: HTMLButtonElement): Promise<voi
 
   const files = [
     { name: 'README.md', path: hook.readmeFile },
-    ...hook.assets.map((asset) => ({
-      name: asset,
-      path: `${hook.path}/${asset}`,
-    })),
+    ...hook.assets.map((asset) => ({ name: asset, path: `${hook.path}/${asset}` })),
   ];
 
-  if (files.length === 0) {
-    showToast('No files found for this hook.', 'error');
-    return;
-  }
-
+  const iconOnly = btn.classList.contains('rcard-icon-btn');
   const originalContent = btn.innerHTML;
   btn.disabled = true;
-  btn.innerHTML = '<svg class="spinner" viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M8 0a8 8 0 1 0 8 8h-1.5A6.5 6.5 0 1 1 8 1.5V0z"/></svg> Preparing...';
+  btn.innerHTML = iconOnly ? SPINNER_SVG : `${SPINNER_SVG}<span>Preparing…</span>`;
 
   try {
     await downloadZipBundle(hook.id, files);
-
-    btn.innerHTML = '<svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z"/></svg> Downloaded!';
-    setTimeout(() => {
-      btn.disabled = false;
-      btn.innerHTML = originalContent;
-    }, 2000);
+    btn.innerHTML = iconOnly ? CHECK_SVG : `${CHECK_SVG}<span>Downloaded!</span>`;
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Download failed.';
     showToast(message, 'error');
-    btn.innerHTML = '<svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 0 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06z"/></svg> Failed';
+    btn.innerHTML = iconOnly ? DOWNLOAD_SVG : originalContent;
+  } finally {
     setTimeout(() => {
       btn.disabled = false;
       btn.innerHTML = originalContent;
@@ -111,12 +66,7 @@ async function downloadHook(hookId: string, btn: HTMLButtonElement): Promise<voi
   }
 }
 
-function openHookDetailsModal(hookId: string, trigger?: HTMLElement): void {
-  const item = hookById.get(hookId);
-  if (!item) {
-    return;
-  }
-
+function openHookDetailsModal(item: Hook, trigger?: HTMLElement): void {
   const metaParts = item.hooks.map(
     (hookName) => `<span class="resource-tag tag-hook">${escapeHtml(hookName)}</span>`
   );
@@ -162,120 +112,35 @@ function openHookDetailsModal(hookId: string, trigger?: HTMLElement): void {
   });
 }
 
-function setupResourceListHandlers(list: HTMLElement | null): void {
-  if (!list || resourceListHandlersReady) return;
-
-  list.addEventListener('click', (event) => {
-    const target = event.target as HTMLElement;
-    const downloadButton = target.closest('.download-hook-btn') as HTMLButtonElement | null;
-    if (downloadButton) {
-      event.stopPropagation();
-      const hookId = downloadButton.dataset.hookId;
-      if (hookId) downloadHook(hookId, downloadButton);
-      return;
-    }
-
-    if (target.closest('.resource-actions')) {
-      return;
-    }
-
-    const item = target.closest('.resource-item') as HTMLElement | null;
-    const button = item?.querySelector('.resource-preview') as HTMLElement | undefined;
-    const hookId = item?.dataset.hookId;
-    if (hookId) {
-      openHookDetailsModal(hookId, button);
-    }
-  });
-
+function setupHookActionHandlers(): void {
   document.addEventListener('click', (event) => {
     const target = event.target as HTMLElement;
-    const modalDownloadButton = target.closest(
-      '#hook-details-download'
+    const downloadBtn = target.closest(
+      '.download-hook-btn, #hook-details-download'
     ) as HTMLButtonElement | null;
-    if (!modalDownloadButton) return;
-    const hookId = modalDownloadButton.dataset.hookId;
-    if (hookId) downloadHook(hookId, modalDownloadButton);
-  });
-
-  resourceListHandlersReady = true;
-}
-
-function syncUrlState(): void {
-  updateQueryParams({
-    q: '',
-    hook: [],
-    tag: currentFilters.tags,
-    sort: currentSort === 'title' ? '' : currentSort,
+    if (downloadBtn) {
+      event.stopPropagation();
+      const hookId = downloadBtn.dataset.hookId;
+      if (hookId) downloadHook(hookId, downloadBtn);
+    }
   });
 }
 
-export async function initHooksPage(): Promise<void> {
-  const list = document.getElementById('resource-list');
-  const clearFiltersBtn = document.getElementById('clear-filters');
-  const sortSelect = document.getElementById('sort-select') as HTMLSelectElement | null;
-
-  if (!modalReady) {
-    setupModal();
-    modalReady = true;
-  }
-
-  setupResourceListHandlers(list as HTMLElement | null);
-
+document.addEventListener('DOMContentLoaded', async () => {
+  setupHookActionHandlers();
   const data = await fetchData<HooksData>('hooks.json');
-  if (!data || !data.items) {
-    if (list) list.innerHTML = '<div class="empty-state"><h3>Failed to load data</h3></div>';
-    return;
+  if (data?.items) {
+    hookById = new Map(data.items.map((item) => [item.id, item]));
   }
+});
 
-  allItems = data.items;
-  hookById = new Map(allItems.map((item) => [item.id, item]));
-
-  tagSelectEl = document.getElementById('filter-tag') as HTMLSelectElement | null;
-  if (tagSelectEl) {
-    tagSelectEl.innerHTML = '';
-    data.filters.tags.forEach((tag) => {
-      const option = document.createElement('option');
-      option.value = tag;
-      option.textContent = tag;
-      tagSelectEl?.appendChild(option);
-    });
-  }
-
-  const initialTags = getQueryParamValues('tag').filter((tag) => data.filters.tags.includes(tag));
-  const initialSort = getQueryParam('sort');
-
-  if (initialTags.length > 0) {
-    currentFilters.tags = initialTags;
-    setSelectValues(tagSelectEl, initialTags);
-  }
-  if (initialSort === 'lastUpdated') {
-    currentSort = initialSort;
-    if (sortSelect) sortSelect.value = initialSort;
-  }
-
-  tagSelectEl?.addEventListener('change', () => {
-    currentFilters.tags = getSelectValues(tagSelectEl);
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  sortSelect?.addEventListener('change', () => {
-    currentSort = sortSelect.value as HookSortOption;
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  clearFiltersBtn?.addEventListener('click', () => {
-    currentFilters = { tags: [] };
-    currentSort = 'title';
-    clearSelectValues(tagSelectEl);
-    if (sortSelect) sortSelect.value = 'title';
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  applyFiltersAndRender();
-}
-
-// Auto-initialize when DOM is ready
-document.addEventListener('DOMContentLoaded', initHooksPage);
+initListingPage<Hook>({
+  dataFile: 'hooks.json',
+  keyOf: (item) => item.readmeFile,
+  search: hookSearchText,
+  facetValues: (item) => ({ event: hookEvents(item) }),
+  sort: (items, sort) => sortHooks(items, sort as HookSortOption),
+  render: renderHooksHtml,
+  noun: 'hook',
+  openModal: openHookDetailsModal,
+});

--- a/website/src/scripts/pages/instructions-render.ts
+++ b/website/src/scripts/pages/instructions-render.ts
@@ -5,7 +5,14 @@ import {
   getInstallDropdownHtml,
   getLastUpdatedHtml,
 } from '../utils';
-import { renderEmptyStateHtml, renderSharedCardHtml } from './card-render';
+import {
+  FACT_ICONS,
+  GITHUB_MARK,
+  TYPE_ICONS,
+  renderResourceGridHtml,
+  type RCardFact,
+  type RCardModel,
+} from './resource-card';
 
 export interface RenderableInstruction {
   title: string;
@@ -33,43 +40,81 @@ export function sortInstructions<T extends RenderableInstruction>(
   });
 }
 
-export function renderInstructionsHtml(
-  items: RenderableInstruction[]
-): string {
-  if (items.length === 0) {
-    return renderEmptyStateHtml('No instructions found', 'Try adjusting the selected filters.');
-  }
+/** Extension facet values for an instruction (["(none)"] when it targets none). */
+export function instructionExtensions(item: RenderableInstruction): string[] {
+  return item.extensions && item.extensions.length > 0
+    ? item.extensions
+    : ['(none)'];
+}
 
-  return items
-    .map((item) => {
-      const applyToText = Array.isArray(item.applyTo)
-        ? item.applyTo.join(', ')
-        : item.applyTo;
+export function instructionSearchText(item: RenderableInstruction): string {
+  const applyTo = Array.isArray(item.applyTo)
+    ? item.applyTo.join(' ')
+    : item.applyTo ?? '';
+  return [item.title, item.description ?? '', applyTo, (item.extensions ?? []).join(' ')].join(' ');
+}
 
-      const metaHtml = `
-        ${applyToText ? `<span class="resource-tag">applies to: ${escapeHtml(applyToText)}</span>` : ''}
-        ${item.extensions?.slice(0, 4).map((extension) => `<span class="resource-tag tag-extension">${escapeHtml(extension)}</span>`).join('') || ''}
-        ${item.extensions && item.extensions.length > 4 ? `<span class="resource-tag">+${item.extensions.length - 4} more</span>` : ''}
-        ${getLastUpdatedHtml(item.lastUpdated)}
-      `;
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
 
-      const actionsHtml = `
-        ${getInstallDropdownHtml('instructions', item.path, true)}
-        ${getActionButtonsHtml(item.path, true)}
-        <a href="${getGitHubUrl(item.path)}" class="btn btn-secondary btn-small" target="_blank" onclick="event.stopPropagation()" title="View on GitHub">
-          GitHub
-        </a>
-      `;
+/** Human-friendly "applies to" label; collapses catch-all globs to "All files". */
+function formatApplyTo(applyToText: string): string {
+  const normalized = applyToText.trim();
+  if (!normalized) return 'All files';
+  const catchAll = new Set(['*', '**', '**/*', '**/**', '*.*']);
+  if (catchAll.has(normalized)) return 'All files';
+  return truncate(normalized, 42);
+}
 
-      return renderSharedCardHtml({
-        title: item.title,
-        description: item.description || 'No description',
-        articleAttributes: {
-          'data-path': item.path,
-        },
-        metaHtml,
-        actionsHtml,
-      });
-    })
-    .join('');
+export function renderInstructionsHtml(items: RenderableInstruction[]): string {
+  const models: RCardModel[] = items.map((item) => {
+    const extensions = item.extensions ?? [];
+    const applyToText = Array.isArray(item.applyTo)
+      ? item.applyTo.join(', ')
+      : item.applyTo ?? '';
+
+    const badge = extensions.length
+      ? {
+          text: extensions[0],
+          title: extensions.join(', '),
+          moreCount: extensions.length - 1,
+          mono: true,
+        }
+      : null;
+
+    const facts: RCardFact[] = [
+      { icon: FACT_ICONS.applies, label: formatApplyTo(applyToText) },
+    ];
+
+    const actionsHtml = `
+      ${getInstallDropdownHtml('instructions', item.path, true)}
+      ${getActionButtonsHtml(item.path, true)}
+      <a href="${getGitHubUrl(
+        item.path
+      )}" class="btn btn-secondary btn-small action-github" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="View on GitHub" aria-label="View ${escapeHtml(
+        item.title
+      )} on GitHub">
+        ${GITHUB_MARK}
+      </a>
+    `;
+
+    return {
+      accent: 'docs',
+      icon: TYPE_ICONS.document,
+      title: item.title,
+      description: item.description || 'No description',
+      path: item.path,
+      badge,
+      facts,
+      lastUpdatedHtml: getLastUpdatedHtml(item.lastUpdated),
+      actionsHtml,
+    };
+  });
+
+  return renderResourceGridHtml(
+    models,
+    'No instructions match your filters',
+    'Try a different search term or clear the active filters.'
+  );
 }

--- a/website/src/scripts/pages/instructions.ts
+++ b/website/src/scripts/pages/instructions.ts
@@ -3,18 +3,14 @@
  */
 import {
   escapeHtml,
-  fetchData,
   formatRelativeTime,
-  getQueryParam,
-  getQueryParamValues,
   getVSCodeInstallUrl,
-  setupActionHandlers,
-  setupDropdownCloseHandlers,
-  updateQueryParams,
 } from '../utils';
-import { openCardDetailsModal, setupModal } from '../modal';
-import { clearSelectValues, getSelectValues, setSelectValues } from './select-utils';
+import { openCardDetailsModal } from '../modal';
+import { initListingPage } from './listing-controller';
 import {
+  instructionExtensions,
+  instructionSearchText,
   renderInstructionsHtml,
   sortInstructions,
   type InstructionSortOption,
@@ -28,64 +24,7 @@ interface Instruction extends RenderableInstruction {
   lastUpdated?: string | null;
 }
 
-interface InstructionsData {
-  items: Instruction[];
-  filters: {
-    extensions: string[];
-  };
-}
-
-let allItems: Instruction[] = [];
-let instructionByPath = new Map<string, Instruction>();
-let extensionSelectEl: HTMLSelectElement | null = null;
-let currentFilters = { extensions: [] as string[] };
-let currentSort: InstructionSortOption = 'title';
-let resourceListHandlersReady = false;
-let modalReady = false;
-
-function sortItems(items: Instruction[]): Instruction[] {
-  return sortInstructions(items, currentSort);
-}
-
-function applyFiltersAndRender(): void {
-  const countEl = document.getElementById('results-count');
-  let results = [...allItems];
-
-  if (currentFilters.extensions.length > 0) {
-    results = results.filter((item) => {
-      if (
-        currentFilters.extensions.includes('(none)') &&
-        (!item.extensions || item.extensions.length === 0)
-      ) {
-        return true;
-      }
-      return item.extensions?.some((ext) => currentFilters.extensions.includes(ext));
-    });
-  }
-
-  results = sortItems(results);
-
-  renderItems(results);
-  let countText = `${results.length} instruction${results.length === 1 ? '' : 's'}`;
-  if (currentFilters.extensions.length > 0) {
-    countText = `${results.length} of ${allItems.length} instructions (filtered by ${currentFilters.extensions.length} extension${currentFilters.extensions.length > 1 ? 's' : ''})`;
-  }
-  if (countEl) countEl.textContent = countText;
-}
-
-function renderItems(items: Instruction[]): void {
-  const list = document.getElementById('resource-list');
-  if (!list) return;
-
-  list.innerHTML = renderInstructionsHtml(items);
-}
-
-function openInstructionDetailsModal(path: string, trigger?: HTMLElement): void {
-  const item = instructionByPath.get(path);
-  if (!item) {
-    return;
-  }
-
+function openInstructionDetailsModal(item: Instruction, trigger?: HTMLElement): void {
   const metaParts: string[] = [];
   const applyToText = Array.isArray(item.applyTo) ? item.applyTo.join(', ') : item.applyTo;
   if (applyToText) {
@@ -102,8 +41,8 @@ function openInstructionDetailsModal(path: string, trigger?: HTMLElement): void 
     metaParts.push(`<span class="last-updated">Updated ${escapeHtml(formatRelativeTime(item.lastUpdated))}</span>`);
   }
 
-  const vscodeUrl = getVSCodeInstallUrl('instructions', path, false);
-  const insidersUrl = getVSCodeInstallUrl('instructions', path, true);
+  const vscodeUrl = getVSCodeInstallUrl('instructions', item.path, false);
+  const insidersUrl = getVSCodeInstallUrl('instructions', item.path, true);
   const actions = [
     vscodeUrl
       ? `<a class="btn btn-primary btn-small" href="${escapeHtml(vscodeUrl)}" target="_blank" rel="noopener noreferrer">Install (VS Code)</a>`
@@ -112,7 +51,7 @@ function openInstructionDetailsModal(path: string, trigger?: HTMLElement): void 
       ? `<a class="btn btn-secondary btn-small" href="${escapeHtml(insidersUrl)}" target="_blank" rel="noopener noreferrer">Install (Insiders)</a>`
       : '',
     `<button class="btn btn-secondary btn-small" type="button" data-open-file-path="${escapeHtml(
-      path
+      item.path
     )}" data-open-file-type="instruction">Source</button>`,
   ].filter(Boolean);
 
@@ -127,103 +66,13 @@ function openInstructionDetailsModal(path: string, trigger?: HTMLElement): void 
   });
 }
 
-function setupResourceListHandlers(list: HTMLElement | null): void {
-  if (!list || resourceListHandlersReady) return;
-
-  list.addEventListener('click', (event) => {
-    const target = event.target as HTMLElement;
-    if (target.closest('.resource-actions')) {
-      return;
-    }
-
-    const item = target.closest('.resource-item') as HTMLElement | null;
-    const button = item?.querySelector('.resource-preview') as HTMLElement | undefined;
-    const path = item?.dataset.path;
-    if (path) {
-      openInstructionDetailsModal(path, button);
-    }
-  });
-
-  resourceListHandlersReady = true;
-}
-
-function syncUrlState(): void {
-  updateQueryParams({
-    q: '',
-    extension: currentFilters.extensions,
-    sort: currentSort === 'title' ? '' : currentSort,
-  });
-}
-
-export async function initInstructionsPage(): Promise<void> {
-  const list = document.getElementById('resource-list');
-  const clearFiltersBtn = document.getElementById('clear-filters');
-  const sortSelect = document.getElementById('sort-select') as HTMLSelectElement | null;
-
-  if (!modalReady) {
-    setupModal();
-    modalReady = true;
-  }
-
-  setupResourceListHandlers(list as HTMLElement | null);
-
-  const data = await fetchData<InstructionsData>('instructions.json');
-  if (!data || !data.items) {
-    if (list) list.innerHTML = '<div class="empty-state"><h3>Failed to load data</h3></div>';
-    return;
-  }
-
-  allItems = data.items;
-  instructionByPath = new Map(allItems.map((item) => [item.path, item]));
-
-  extensionSelectEl = document.getElementById('filter-extension') as HTMLSelectElement | null;
-  if (extensionSelectEl) {
-    extensionSelectEl.innerHTML = '';
-    data.filters.extensions.forEach((ext) => {
-      const option = document.createElement('option');
-      option.value = ext;
-      option.textContent = ext;
-      extensionSelectEl?.appendChild(option);
-    });
-  }
-
-  const initialExtensions = getQueryParamValues('extension').filter((extension) => data.filters.extensions.includes(extension));
-  const initialSort = getQueryParam('sort');
-
-  if (initialExtensions.length > 0) {
-    currentFilters.extensions = initialExtensions;
-    setSelectValues(extensionSelectEl, initialExtensions);
-  }
-  if (initialSort === 'lastUpdated') {
-    currentSort = initialSort;
-    if (sortSelect) sortSelect.value = initialSort;
-  }
-
-  extensionSelectEl?.addEventListener('change', () => {
-    currentFilters.extensions = getSelectValues(extensionSelectEl);
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  sortSelect?.addEventListener('change', () => {
-    currentSort = sortSelect.value as InstructionSortOption;
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  clearFiltersBtn?.addEventListener('click', () => {
-    currentFilters = { extensions: [] };
-    currentSort = 'title';
-    clearSelectValues(extensionSelectEl);
-    if (sortSelect) sortSelect.value = 'title';
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  applyFiltersAndRender();
-  setupDropdownCloseHandlers();
-  setupActionHandlers();
-}
-
-// Auto-initialize when DOM is ready
-document.addEventListener('DOMContentLoaded', initInstructionsPage);
+initListingPage<Instruction>({
+  dataFile: 'instructions.json',
+  keyOf: (item) => item.path,
+  search: instructionSearchText,
+  facetValues: (item) => ({ extension: instructionExtensions(item) }),
+  sort: (items, sort) => sortInstructions(items, sort as InstructionSortOption),
+  render: renderInstructionsHtml,
+  noun: 'instruction',
+  openModal: openInstructionDetailsModal,
+});

--- a/website/src/scripts/pages/listing-controller.ts
+++ b/website/src/scripts/pages/listing-controller.ts
@@ -1,0 +1,245 @@
+/**
+ * Shared always-visible filter bar controller for listing pages.
+ *
+ * Reads the DOM produced by the `.filter-bar` markup:
+ *   #listing-search, .facet-chip[data-facet-group][data-facet-value],
+ *   #sort-select, #results-count, #clear-filters
+ *
+ * Filtering semantics: within a facet group values are OR'd; across groups the
+ * groups are AND'd; a free-text search AND's on top. Clicking a card (outside
+ * `.resource-actions`) opens the page's modal. Action buttons keep their own
+ * delegated handlers via setupActionHandlers.
+ */
+import {
+  fetchData,
+  getQueryParam,
+  setupActionHandlers,
+  setupDropdownCloseHandlers,
+  updateQueryParams,
+} from "../utils";
+import { setupModal } from "../modal";
+
+export interface ListingConfig<T> {
+  /** JSON file under /public/data, e.g. "hooks.json". */
+  dataFile: string;
+  /** Unique key per item, written to data-path and used for the modal map. */
+  keyOf: (item: T) => string;
+  /** Free-text haystack for the search box. */
+  search: (item: T) => string;
+  /** Values an item exposes for a facet group (group name -> values). */
+  facetValues?: (item: T) => Record<string, string[]>;
+  sort: (items: T[], sort: string) => T[];
+  render: (items: T[]) => string;
+  /** Singular noun for the results count, e.g. "hook". */
+  noun: string;
+  defaultSort?: string;
+  openModal?: (item: T, trigger?: HTMLElement) => void;
+  /** Run after each render (e.g. to (re)bind bespoke buttons). */
+  afterRender?: () => void;
+}
+
+export function initListingPage<T>(config: ListingConfig<T>): void {
+  const defaultSort = config.defaultSort ?? "title";
+
+  let allItems: T[] = [];
+  let byKey = new Map<string, T>();
+  let currentQuery = "";
+  let currentSort = defaultSort;
+  const activeFacets = new Map<string, Set<string>>();
+  let resourceListHandlersReady = false;
+  let modalReady = false;
+
+  function hasActiveFilters(): boolean {
+    if (currentQuery.trim() !== "") return true;
+    for (const set of activeFacets.values()) if (set.size > 0) return true;
+    return false;
+  }
+
+  function matchesFacets(item: T): boolean {
+    if (!config.facetValues || activeFacets.size === 0) return true;
+    const values = config.facetValues(item);
+    for (const [group, active] of activeFacets) {
+      if (active.size === 0) continue;
+      const itemValues = values[group] ?? [];
+      if (!itemValues.some((v) => active.has(v))) return false;
+    }
+    return true;
+  }
+
+  function filterItems(): T[] {
+    const query = currentQuery.trim().toLowerCase();
+    return allItems.filter((item) => {
+      if (!matchesFacets(item)) return false;
+      if (query && !config.search(item).toLowerCase().includes(query)) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  function renderItems(items: T[]): void {
+    const list = document.getElementById("resource-list");
+    if (!list) return;
+    list.innerHTML = config.render(items);
+    config.afterRender?.();
+  }
+
+  function applyFiltersAndRender(): void {
+    const results = config.sort(filterItems(), currentSort);
+    renderItems(results);
+
+    const countEl = document.getElementById("results-count");
+    if (countEl) {
+      countEl.textContent = `${results.length} ${config.noun}${
+        results.length === 1 ? "" : "s"
+      }`;
+    }
+    const clearBtn = document.getElementById("clear-filters");
+    if (clearBtn) (clearBtn as HTMLButtonElement).hidden = !hasActiveFilters();
+  }
+
+  function syncUrlState(): void {
+    const params: Record<string, string | string[]> = {
+      q: currentQuery.trim(),
+      sort: currentSort === defaultSort ? "" : currentSort,
+    };
+    for (const [group, set] of activeFacets) {
+      params[group] = [...set];
+    }
+    updateQueryParams(params);
+  }
+
+  function setupResourceListHandlers(): void {
+    const list = document.getElementById("resource-list");
+    if (!list || resourceListHandlersReady || !config.openModal) return;
+
+    list.addEventListener("click", (event) => {
+      const target = event.target as HTMLElement;
+      if (target.closest(".resource-actions")) return;
+
+      const item = target.closest(".resource-item") as HTMLElement | null;
+      const button = item?.querySelector(".resource-preview") as
+        | HTMLElement
+        | undefined;
+      const key = item?.dataset.path;
+      if (key) {
+        const record = byKey.get(key);
+        if (record) config.openModal?.(record, button);
+      }
+    });
+
+    resourceListHandlersReady = true;
+  }
+
+  function setupFilterBar(): void {
+    const searchInput = document.getElementById(
+      "listing-search"
+    ) as HTMLInputElement | null;
+    const sortSelect = document.getElementById(
+      "sort-select"
+    ) as HTMLSelectElement | null;
+    const chips = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".facet-chip")
+    );
+    const clearBtn = document.getElementById(
+      "clear-filters"
+    ) as HTMLButtonElement | null;
+
+    // Hydrate state from the URL so shared/bookmarked filters survive reloads.
+    const initialQuery = getQueryParam("q");
+    if (initialQuery && searchInput) {
+      currentQuery = initialQuery;
+      searchInput.value = initialQuery;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    for (const chip of chips) {
+      const group = chip.dataset.facetGroup;
+      if (group && !activeFacets.has(group)) {
+        activeFacets.set(group, new Set(params.getAll(group)));
+      }
+    }
+
+    const initialSort = getQueryParam("sort");
+    if (initialSort && sortSelect) {
+      currentSort = initialSort;
+      sortSelect.value = initialSort;
+    }
+
+    chips.forEach((chip) => {
+      const group = chip.dataset.facetGroup;
+      const value = chip.dataset.facetValue;
+      if (!group || value === undefined) return;
+      const active = activeFacets.get(group)!;
+      chip.setAttribute("aria-pressed", active.has(value) ? "true" : "false");
+
+      chip.addEventListener("click", () => {
+        const pressed = chip.getAttribute("aria-pressed") === "true";
+        const next = !pressed;
+        chip.setAttribute("aria-pressed", next ? "true" : "false");
+        if (next) active.add(value);
+        else active.delete(value);
+        applyFiltersAndRender();
+        syncUrlState();
+      });
+    });
+
+    let searchTimer: number | undefined;
+    searchInput?.addEventListener("input", () => {
+      window.clearTimeout(searchTimer);
+      searchTimer = window.setTimeout(() => {
+        currentQuery = searchInput.value;
+        applyFiltersAndRender();
+        syncUrlState();
+      }, 150);
+    });
+
+    sortSelect?.addEventListener("change", () => {
+      currentSort = sortSelect.value;
+      applyFiltersAndRender();
+      syncUrlState();
+    });
+
+    clearBtn?.addEventListener("click", () => {
+      currentQuery = "";
+      currentSort = defaultSort;
+      for (const set of activeFacets.values()) set.clear();
+      if (searchInput) searchInput.value = "";
+      if (sortSelect) sortSelect.value = defaultSort;
+      chips.forEach((chip) => chip.setAttribute("aria-pressed", "false"));
+      applyFiltersAndRender();
+      syncUrlState();
+      searchInput?.focus();
+    });
+  }
+
+  async function init(): Promise<void> {
+    const list = document.getElementById("resource-list");
+
+    if (config.openModal && !modalReady) {
+      setupModal();
+      modalReady = true;
+    }
+
+    setupResourceListHandlers();
+
+    const data = await fetchData<{ items: T[] }>(config.dataFile);
+    if (!data || !data.items) {
+      if (list) {
+        list.innerHTML =
+          '<div class="empty-state"><h3>Failed to load data</h3></div>';
+      }
+      return;
+    }
+
+    allItems = data.items;
+    byKey = new Map(allItems.map((item) => [config.keyOf(item), item]));
+
+    setupFilterBar();
+    applyFiltersAndRender();
+    setupDropdownCloseHandlers();
+    setupActionHandlers();
+  }
+
+  document.addEventListener("DOMContentLoaded", init);
+}

--- a/website/src/scripts/pages/plugins-render.ts
+++ b/website/src/scripts/pages/plugins-render.ts
@@ -3,7 +3,16 @@ import {
   getGitHubUrl,
   sanitizeUrl,
 } from '../utils';
-import { renderEmptyStateHtml, renderSharedCardHtml } from './card-render';
+import {
+  FACT_ICONS,
+  GITHUB_MARK,
+  TYPE_ICONS,
+  renderResourceGridHtml,
+  type RCardFact,
+  type RCardModel,
+} from './resource-card';
+
+const CLIPBOARD_SVG = `<svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M5.75 1a.75.75 0 0 0-.75.75V3h6V1.75a.75.75 0 0 0-.75-.75h-4.5ZM11 3v-.75A.75.75 0 0 1 11.75 1.5h.5A1.75 1.75 0 0 1 14 3.25v10A1.75 1.75 0 0 1 12.25 15h-8.5A1.75 1.75 0 0 1 2 13.25v-10A1.75 1.75 0 0 1 3.75 1.5h.5A.75.75 0 0 1 5 2.25V3H3.75a.25.25 0 0 0-.25.25v10c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-10a.25.25 0 0 0-.25-.25H11Z"/></svg>`;
 
 interface PluginAuthor {
   name: string;
@@ -47,54 +56,93 @@ export function sortPlugins<T extends RenderablePlugin>(
   });
 }
 
-function getExternalPluginUrl(plugin: RenderablePlugin): string {
+/** Source facet value: "external" for third-party plugins, else "local". */
+export function pluginSource(item: RenderablePlugin): string[] {
+  return [item.external === true ? 'external' : 'local'];
+}
+
+export function pluginSearchText(item: RenderablePlugin): string {
+  return [
+    item.name,
+    item.description ?? '',
+    item.author?.name ?? '',
+    (item.tags ?? []).join(' '),
+  ].join(' ');
+}
+
+export function getExternalPluginUrl(plugin: RenderablePlugin): string {
   if (plugin.source?.source === 'github' && plugin.source.repo) {
     const base = `https://github.com/${plugin.source.repo}`;
-    return plugin.source.path && plugin.source.path !== '/' ? `${base}/tree/main/${plugin.source.path}` : base;
+    return plugin.source.path && plugin.source.path !== '/'
+      ? `${base}/tree/main/${plugin.source.path}`
+      : base;
   }
 
   return sanitizeUrl(plugin.repository || plugin.homepage);
 }
 
 export function renderPluginsHtml(items: RenderablePlugin[]): string {
-  if (items.length === 0) {
-    return renderEmptyStateHtml('No plugins found', 'Try different tags or clear the current filters');
-  }
+  const models: RCardModel[] = items.map((item) => {
+    const isExternal = item.external === true;
+    const safeName = escapeHtml(item.name);
 
-  return items
-    .map((item) => {
-      const isExternal = item.external === true;
-      const metaTag = isExternal
-        ? '<span class="resource-tag resource-tag-external">🔗 External</span>'
-        : `<span class="resource-tag">${item.itemCount} items</span>`;
-      const authorTag =
-        isExternal && item.author?.name
-          ? `<span class="resource-tag">by ${escapeHtml(item.author.name)}</span>`
-          : '';
-      const githubHref = isExternal
-        ? escapeHtml(getExternalPluginUrl(item))
-        : getGitHubUrl(item.path);
-      const metaHtml = `
-        ${metaTag}
-        ${authorTag}
-        ${item.tags?.slice(0, 4).map((tag) => `<span class="resource-tag">${escapeHtml(tag)}</span>`).join('') || ''}
-        ${item.tags && item.tags.length > 4 ? `<span class="resource-tag">+${item.tags.length - 4} more</span>` : ''}
-      `;
+    const badge = isExternal
+      ? { text: 'External', title: 'Third-party plugin' }
+      : null;
 
-      const actionsHtml = `
-        <a href="${githubHref}" class="btn btn-secondary" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()" title="${isExternal ? 'View repository' : 'View on GitHub'}">${isExternal ? 'Repository' : 'GitHub'}</a>
-      `;
-
-      return renderSharedCardHtml({
-        title: item.name,
-        description: item.description || 'No description',
-        articleClassName: isExternal ? 'resource-item-external' : '',
-        articleAttributes: {
-          'data-path': item.path,
-        },
-        metaHtml,
-        actionsHtml,
+    const facts: RCardFact[] = [];
+    if (!isExternal) {
+      facts.push({
+        icon: FACT_ICONS.items,
+        label: `${item.itemCount} item${item.itemCount === 1 ? '' : 's'}`,
       });
-    })
-    .join('');
+    } else if (item.author?.name) {
+      facts.push({ icon: FACT_ICONS.author, label: `by ${item.author.name}` });
+    }
+
+    const tagCount = item.tags?.length ?? 0;
+    if (tagCount > 0) {
+      facts.push({
+        icon: FACT_ICONS.tag,
+        label: `${tagCount} tag${tagCount === 1 ? '' : 's'}`,
+      });
+    }
+
+    const actionsHtml = isExternal
+      ? `
+        <a href="${escapeHtml(
+          getExternalPluginUrl(item)
+        )}" class="btn btn-primary btn-small" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()" title="View repository" aria-label="View ${safeName} repository">
+          Repository
+        </a>
+      `
+      : `
+        <button type="button" class="btn btn-primary btn-small copy-plugin-install-btn" data-plugin-name="${safeName}" title="Copy install command" aria-label="Copy install command for ${safeName}">
+          ${CLIPBOARD_SVG}<span>Copy install</span>
+        </button>
+        <a href="${getGitHubUrl(
+          item.path
+        )}" class="btn btn-secondary btn-small action-github rcard-lead" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="View on GitHub" aria-label="View ${safeName} on GitHub">
+          ${GITHUB_MARK}
+        </a>
+      `;
+
+    return {
+      accent: 'extension',
+      icon: TYPE_ICONS.plug,
+      title: item.name,
+      description: item.description || 'No description',
+      path: item.path,
+      articleClassName: isExternal ? 'resource-item-external' : '',
+      badge,
+      facts,
+      actionsHtml,
+    };
+  });
+
+  return renderResourceGridHtml(
+    models,
+    'No plugins match your filters',
+    'Try a different search term or clear the active filters.'
+  );
 }

--- a/website/src/scripts/pages/plugins.ts
+++ b/website/src/scripts/pages/plugins.ts
@@ -4,33 +4,20 @@
 import {
   copyToClipboard,
   escapeHtml,
-  fetchData,
   formatRelativeTime,
-  getGitHubUrl,
-  getQueryParam,
-  getQueryParamValues,
   showToast,
-  updateQueryParams,
 } from '../utils';
-import { openCardDetailsModal, setupModal } from '../modal';
-import { clearSelectValues, getSelectValues, setSelectValues } from './select-utils';
+import { openCardDetailsModal } from '../modal';
+import { initListingPage } from './listing-controller';
 import {
+  getExternalPluginUrl,
+  pluginSearchText,
+  pluginSource,
   renderPluginsHtml,
   sortPlugins,
   type PluginSortOption,
   type RenderablePlugin,
 } from './plugins-render';
-
-interface PluginAuthor {
-  name: string;
-  url?: string;
-}
-
-interface PluginSource {
-  source: string;
-  repo?: string;
-  path?: string;
-}
 
 interface PluginItem {
   kind: string;
@@ -39,74 +26,8 @@ interface PluginItem {
 
 interface Plugin extends RenderablePlugin {
   id: string;
-  name: string;
-  path: string;
-  tags?: string[];
-  itemCount: number;
   items?: PluginItem[];
-  external?: boolean;
-  repository?: string | null;
-  homepage?: string | null;
-  author?: PluginAuthor | null;
   license?: string | null;
-  source?: PluginSource | null;
-}
-
-interface PluginsData {
-  items: Plugin[];
-  filters: {
-    tags: string[];
-  };
-}
-
-let allItems: Plugin[] = [];
-let pluginByPath = new Map<string, Plugin>();
-let tagSelectEl: HTMLSelectElement | null = null;
-let currentSort: PluginSortOption = 'title';
-let currentFilters = {
-  tags: [] as string[],
-};
-let resourceListHandlersReady = false;
-let modalReady = false;
-
-function sortItems(items: Plugin[]): Plugin[] {
-  return sortPlugins(items, currentSort);
-}
-
-function getCountText(resultsCount: number): string {
-  if (currentFilters.tags.length === 0) {
-    return `${resultsCount} plugin${resultsCount === 1 ? '' : 's'}`;
-  }
-
-  return `${resultsCount} of ${allItems.length} plugins (filtered by ${currentFilters.tags.length} tag${currentFilters.tags.length === 1 ? '' : 's'})`;
-}
-
-function applyFiltersAndRender(): void {
-  const countEl = document.getElementById('results-count');
-  let results = [...allItems];
-
-  if (currentFilters.tags.length > 0) {
-    results = results.filter((item) => item.tags?.some((tag) => currentFilters.tags.includes(tag)));
-  }
-
-  results = sortItems(results);
-
-  renderItems(results);
-  if (countEl) countEl.textContent = getCountText(results.length);
-}
-
-function renderItems(items: Plugin[]): void {
-  const list = document.getElementById('resource-list');
-  if (!list) return;
-
-  list.innerHTML = renderPluginsHtml(items);
-}
-
-function getPluginRepositoryUrl(item: Plugin): string {
-  if (item.external && item.repository) return item.repository;
-  if (item.homepage) return item.homepage;
-  if (item.repository) return item.repository;
-  return getGitHubUrl(item.path);
 }
 
 function getPluginItemLabel(item: PluginItem): string {
@@ -114,12 +35,16 @@ function getPluginItemLabel(item: PluginItem): string {
   return `${item.kind}: ${normalizedPath}`;
 }
 
-function openPluginDetailsModal(path: string, trigger?: HTMLElement): void {
-  const item = pluginByPath.get(path);
-  if (!item) {
-    return;
-  }
+async function copyPluginInstall(name: string): Promise<void> {
+  const command = `copilot plugin install ${name}@awesome-copilot`;
+  const success = await copyToClipboard(command);
+  showToast(
+    success ? 'Install command copied!' : 'Failed to copy',
+    success ? 'success' : 'error'
+  );
+}
 
+function openPluginDetailsModal(item: Plugin, trigger?: HTMLElement): void {
   const metaParts: string[] = [];
   metaParts.push(
     `<span class="resource-tag">${
@@ -128,7 +53,9 @@ function openPluginDetailsModal(path: string, trigger?: HTMLElement): void {
   );
 
   if (item.author?.name) {
-    metaParts.push(`<span class="resource-tag">by ${escapeHtml(item.author.name)}</span>`);
+    metaParts.push(
+      `<span class="resource-tag">by ${escapeHtml(item.author.name)}</span>`
+    );
   }
 
   if (item.lastUpdated) {
@@ -148,7 +75,9 @@ function openPluginDetailsModal(path: string, trigger?: HTMLElement): void {
     .slice(0, 24)
     .map(
       (pluginItem) =>
-        `<span class="resource-tag tag-plugin-item">${escapeHtml(getPluginItemLabel(pluginItem))}</span>`
+        `<span class="resource-tag tag-plugin-item">${escapeHtml(
+          getPluginItemLabel(pluginItem)
+        )}</span>`
     )
     .join('');
   const includedMoreHtml =
@@ -158,14 +87,14 @@ function openPluginDetailsModal(path: string, trigger?: HTMLElement): void {
 
   const actions = [
     item.external
-      ? ''
+      ? `<a class="btn btn-primary" href="${escapeHtml(
+          getExternalPluginUrl(item)
+        )}" target="_blank" rel="noopener noreferrer">Repository</a>`
       : `<button id="plugin-details-install" class="btn btn-primary" type="button" data-plugin-name="${escapeHtml(
           item.name
-        )}">Copy Install</button>`,
+        )}">Copy install</button>`,
     item.external
-      ? `<a class="btn btn-secondary" href="${escapeHtml(
-          getPluginRepositoryUrl(item)
-        )}" target="_blank" rel="noopener noreferrer">Repository</a>`
+      ? ''
       : `<button class="btn btn-secondary" type="button" data-open-file-path="${escapeHtml(
           item.path
         )}" data-open-file-type="plugin">Source</button>`,
@@ -177,121 +106,36 @@ function openPluginDetailsModal(path: string, trigger?: HTMLElement): void {
     previewIcon: '🔌',
     previewText: 'Plugin metadata and install options',
     metaHtml: metaParts.join(''),
-    tagsHtml: [tagHtml, includedItemHtml, includedMoreHtml].filter(Boolean).join(''),
+    tagsHtml: [tagHtml, includedItemHtml, includedMoreHtml]
+      .filter(Boolean)
+      .join(''),
     actionsHtml: actions.join(''),
     trigger,
   });
 }
 
-function setupResourceListHandlers(list: HTMLElement | null): void {
-  if (!list || resourceListHandlersReady) return;
-
-  list.addEventListener('click', (event) => {
-    const target = event.target as HTMLElement;
-    if (target.closest('.resource-actions')) {
-      return;
-    }
-
-    const item = target.closest('.resource-item') as HTMLElement | null;
-    const button = item?.querySelector('.resource-preview') as HTMLElement | undefined;
-    const path = item?.dataset.path;
-    if (path) {
-      openPluginDetailsModal(path, button);
-    }
-  });
-
-  document.addEventListener('click', async (event) => {
+function setupPluginActionHandlers(): void {
+  document.addEventListener('click', (event) => {
     const target = event.target as HTMLElement;
     const installButton = target.closest(
-      '#plugin-details-install'
+      '.copy-plugin-install-btn, #plugin-details-install'
     ) as HTMLButtonElement | null;
     if (!installButton) return;
+    event.stopPropagation();
     const pluginName = installButton.dataset.pluginName || '';
-    if (!pluginName) return;
-    const command = `copilot plugin install ${pluginName}@awesome-copilot`;
-    const success = await copyToClipboard(command);
-    showToast(success ? 'Install command copied!' : 'Failed to copy', success ? 'success' : 'error');
-  });
-
-  resourceListHandlersReady = true;
-}
-
-function syncUrlState(): void {
-  updateQueryParams({
-    q: '',
-    tag: currentFilters.tags,
-    sort: currentSort === 'title' ? '' : currentSort,
+    if (pluginName) copyPluginInstall(pluginName);
   });
 }
 
-export async function initPluginsPage(): Promise<void> {
-  const list = document.getElementById('resource-list');
-  const clearFiltersBtn = document.getElementById('clear-filters');
-  const sortSelect = document.getElementById('sort-select') as HTMLSelectElement | null;
+setupPluginActionHandlers();
 
-  if (!modalReady) {
-    setupModal();
-    modalReady = true;
-  }
-
-  setupResourceListHandlers(list as HTMLElement | null);
-
-  const data = await fetchData<PluginsData>('plugins.json');
-  if (!data || !data.items) {
-    if (list) list.innerHTML = '<div class="empty-state"><h3>Failed to load data</h3></div>';
-    return;
-  }
-
-  allItems = data.items;
-  pluginByPath = new Map(allItems.map((item) => [item.path, item]));
-
-  tagSelectEl = document.getElementById('filter-tag') as HTMLSelectElement | null;
-  if (tagSelectEl) {
-    tagSelectEl.innerHTML = '';
-    data.filters.tags.forEach((tag) => {
-      const option = document.createElement('option');
-      option.value = tag;
-      option.textContent = tag;
-      tagSelectEl?.appendChild(option);
-    });
-  }
-
-  const initialTags = getQueryParamValues('tag').filter((tag) => data.filters.tags.includes(tag));
-  const initialSort = getQueryParam('sort');
-
-  if (initialTags.length > 0) {
-    currentFilters.tags = initialTags;
-    setSelectValues(tagSelectEl, initialTags);
-  }
-
-  tagSelectEl?.addEventListener('change', () => {
-    currentFilters.tags = getSelectValues(tagSelectEl);
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  if (initialSort === 'lastUpdated') {
-    currentSort = initialSort;
-    if (sortSelect) sortSelect.value = initialSort;
-  }
-  sortSelect?.addEventListener('change', () => {
-    currentSort = sortSelect.value as PluginSortOption;
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  clearFiltersBtn?.addEventListener('click', () => {
-    currentFilters = { tags: [] };
-    currentSort = 'title';
-    clearSelectValues(tagSelectEl);
-    if (sortSelect) sortSelect.value = 'title';
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  applyFiltersAndRender();
-  syncUrlState();
-}
-
-// Auto-initialize when DOM is ready
-document.addEventListener('DOMContentLoaded', initPluginsPage);
+initListingPage<Plugin>({
+  dataFile: 'plugins.json',
+  keyOf: (item) => item.path,
+  search: pluginSearchText,
+  facetValues: (item) => ({ source: pluginSource(item) }),
+  sort: (items, sort) => sortPlugins(items, sort as PluginSortOption),
+  render: renderPluginsHtml,
+  noun: 'plugin',
+  openModal: openPluginDetailsModal,
+});

--- a/website/src/scripts/pages/resource-card.ts
+++ b/website/src/scripts/pages/resource-card.ts
@@ -1,0 +1,150 @@
+import { escapeHtml } from "../utils";
+import { renderEmptyStateHtml } from "./card-render";
+
+/**
+ * Shared "rcard" renderer used by every listing page. Each page builds a
+ * ResourceCardModel (type icon, accent, purpose-built facts, action row) and
+ * this module emits the exact markup + a11y hooks the listing CSS + client
+ * handlers expect:
+ *   - `.resource-item.rcard[data-path]` (role=listitem)
+ *   - `.resource-preview` is a <button> with NO nested interactive children
+ *   - `.resource-actions` are siblings OUTSIDE the button
+ */
+
+// --- Type glyphs (Primer where available; each carries its own viewBox) -----
+
+export const TYPE_ICONS: Record<string, string> = {
+  robot: `<svg viewBox="0 0 24 24" width="22" height="22" fill="currentColor" aria-hidden="true"><path d="M22.5 13.919v-.278a5.097 5.097 0 0 0-4.961-5.086.858.858 0 0 1-.754-.497l-.149-.327A6.414 6.414 0 0 0 10.81 4a6.133 6.133 0 0 0-6.13 6.32l.019.628a.863.863 0 0 1-.67.869A3.263 3.263 0 0 0 1.5 14.996v.108A3.397 3.397 0 0 0 4.896 18.5h1.577a.75.75 0 0 1 0 1.5H4.896A4.896 4.896 0 0 1 0 15.104v-.108a4.761 4.761 0 0 1 3.185-4.493l-.004-.137A7.633 7.633 0 0 1 10.81 2.5a7.911 7.911 0 0 1 7.176 4.58C21.36 7.377 24 10.207 24 13.641v.278a.75.75 0 0 1-1.5 0Z"/><path d="m12.306 11.77 3.374 3.375a.749.749 0 0 1 0 1.061l-3.375 3.375-.057.051a.751.751 0 0 1-1.004-.051.751.751 0 0 1-.051-1.004l.051-.057 2.845-2.845-2.844-2.844a.75.75 0 1 1 1.061-1.061ZM22.5 19.8H18a.75.75 0 0 1 0-1.5h4.5a.75.75 0 0 1 0 1.5Z"/></svg>`,
+  document: `<svg viewBox="0 0 24 24" width="21" height="21" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>`,
+  lightning: `<svg viewBox="0 0 24 24" width="21" height="21" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2 4.09 12.11a1.23 1.23 0 0 0 .13 1.72l.16.14a1.23 1.23 0 0 0 1.52 0L13 9.5V22l8.91-10.11a1.23 1.23 0 0 0-.13-1.72l-.16-.14a1.23 1.23 0 0 0-1.52 0L13 14.5V2Z"/></svg>`,
+  hook: `<svg viewBox="0 0 24 24" width="21" height="21" fill="currentColor" aria-hidden="true"><path d="M3.38 8A9.502 9.502 0 0 1 12 2.5a9.502 9.502 0 0 1 9.215 7.182.75.75 0 1 0 1.456-.364C21.473 4.539 17.15 1 12 1a10.995 10.995 0 0 0-9.5 5.452V4.75a.75.75 0 0 0-1.5 0V8.5a1 1 0 0 0 1 1h3.75a.75.75 0 0 0 0-1.5H3.38Zm-.595 6.318a.75.75 0 0 0-1.455.364C2.527 19.461 6.85 23 12 23c4.052 0 7.592-2.191 9.5-5.451v1.701a.75.75 0 0 0 1.5 0V15.5a1 1 0 0 0-1-1h-3.75a.75.75 0 0 0 0 1.5h2.37A9.502 9.502 0 0 1 12 21.5c-4.446 0-8.181-3.055-9.215-7.182Z"/></svg>`,
+  workflow: `<svg viewBox="0 0 24 24" width="21" height="21" fill="currentColor" aria-hidden="true"><path d="M1 3a2 2 0 0 1 2-2h6.5a2 2 0 0 1 2 2v6.5a2 2 0 0 1-2 2H7v4.063C7 16.355 7.644 17 8.438 17H12.5v-2.5a2 2 0 0 1 2-2H21a2 2 0 0 1 2 2V21a2 2 0 0 1-2 2h-6.5a2 2 0 0 1-2-2v-2.5H8.437A2.939 2.939 0 0 1 5.5 15.562V11.5H3a2 2 0 0 1-2-2Zm2-.5a.5.5 0 0 0-.5.5v6.5a.5.5 0 0 0 .5.5h6.5a.5.5 0 0 0 .5-.5V3a.5.5 0 0 0-.5-.5ZM14.5 14a.5.5 0 0 0-.5.5V21a.5.5 0 0 0 .5.5H21a.5.5 0 0 0 .5-.5v-6.5a.5.5 0 0 0-.5-.5Z"/></svg>`,
+  plug: `<svg viewBox="0 0 24 24" width="21" height="21" fill="currentColor" aria-hidden="true"><path d="M7 11.5H2.938c-.794 0-1.438.644-1.438 1.437v8.313a.75.75 0 0 1-1.5 0v-8.312A2.939 2.939 0 0 1 2.937 10H7V6.151c0-.897.678-1.648 1.57-1.74l6.055-.626 1.006-1.174A1.752 1.752 0 0 1 16.96 2h1.29c.966 0 1.75.784 1.75 1.75V6h3.25a.75.75 0 0 1 0 1.5H20V14h3.25a.75.75 0 0 1 0 1.5H20v2.25a1.75 1.75 0 0 1-1.75 1.75h-1.29a1.75 1.75 0 0 1-1.329-.611l-1.006-1.174-6.055-.627A1.749 1.749 0 0 1 7 15.348Zm9.77-7.913v.001l-1.201 1.4a.75.75 0 0 1-.492.258l-6.353.657a.25.25 0 0 0-.224.249v9.196a.25.25 0 0 0 .224.249l6.353.657c.191.02.368.112.493.258l1.2 1.401a.252.252 0 0 0 .19.087h1.29a.25.25 0 0 0 .25-.25v-14a.25.25 0 0 0-.25-.25h-1.29a.252.252 0 0 0-.19.087Z"/></svg>`,
+  wrench: `<svg viewBox="0 0 24 24" width="21" height="21" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76Z"/></svg>`,
+  browser: `<svg viewBox="0 0 24 24" width="21" height="21" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18M7 6.5h.01M10 6.5h.01"/></svg>`,
+};
+
+// --- Fact glyphs (small, stroke, tint to the card accent) -------------------
+
+export const FACT_ICONS = {
+  tools: `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76Z"/></svg>`,
+  handoffs: `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h11M11 3l4 4-4 4M20 17H9M13 13l-4 4 4 4"/></svg>`,
+  mcp: `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 2v6M15 2v6M6 8h12v3a6 6 0 0 1-12 0zM12 17v5"/></svg>`,
+  applies: `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="4.5"/><circle cx="12" cy="12" r="0.6" fill="currentColor"/></svg>`,
+  file: `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z"/><path d="M14 3v5h5"/></svg>`,
+  asset: `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><path d="M3.27 6.96 12 12l8.73-5.04M12 22V12"/></svg>`,
+  event: `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8Z"/></svg>`,
+  trigger: `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8Z"/></svg>`,
+  items: `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>`,
+  tag: `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20.59 13.41 13.42 20.6a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82Z"/><path d="M7 7h.01"/></svg>`,
+  category: `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 7l9-4 9 4-9 4-9-4Z"/><path d="M3 12l9 4 9-4M3 17l9 4 9-4"/></svg>`,
+  feature: `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>`,
+  author: `<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>`,
+  star: `<svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" aria-hidden="true"><path d="m12 2.5 2.9 5.88 6.49.94-4.7 4.58 1.11 6.46L12 17.82 6.2 20.86l1.11-6.46-4.7-4.58 6.49-.94Z"/></svg>`,
+};
+
+export const GITHUB_MARK = `<svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>`;
+
+export interface RCardFact {
+  icon: string;
+  label: string;
+}
+
+export interface RCardBadge {
+  text: string;
+  title?: string;
+  moreCount?: number;
+  mono?: boolean;
+}
+
+export interface RCardModel {
+  accent: string;
+  icon: string;
+  title: string;
+  description: string;
+  /** Value written to data-path; the modal + action handlers key off this. */
+  path: string;
+  badge?: RCardBadge | null;
+  facts?: RCardFact[];
+  lastUpdatedHtml?: string;
+  actionsHtml: string;
+  /** Extra attributes on the card element (e.g. data-hook-id, id). */
+  attributes?: Record<string, string>;
+  articleClassName?: string;
+  /** Optional media that replaces the icon tile (extensions thumbnails). */
+  mediaHtml?: string;
+}
+
+export function factHtml(icon: string, label: string): string {
+  return `<span class="rcard-fact">${icon}<span>${escapeHtml(label)}</span></span>`;
+}
+
+function badgeHtml(badge?: RCardBadge | null): string {
+  if (!badge) return "";
+  const cls = badge.mono ? "rcard-badge rcard-badge-mono" : "rcard-badge";
+  const more =
+    badge.moreCount && badge.moreCount > 0
+      ? `<span class="rcard-badge-more">+${badge.moreCount}</span>`
+      : "";
+  return `<span class="${cls}"${
+    badge.title ? ` title="${escapeHtml(badge.title)}"` : ""
+  }>${escapeHtml(badge.text)}${more}</span>`;
+}
+
+function attrsHtml(attributes?: Record<string, string>): string {
+  if (!attributes) return "";
+  return Object.entries(attributes)
+    .map(([key, value]) => ` ${key}="${escapeHtml(value)}"`)
+    .join("");
+}
+
+export function renderResourceCardHtml(model: RCardModel): string {
+  const factsHtml = model.facts && model.facts.length
+    ? `<span class="rcard-facts">${model.facts
+        .map((f) => factHtml(f.icon, f.label))
+        .join("")}</span>`
+    : "";
+
+  const media = model.mediaHtml
+    ? `<span class="rcard-media" aria-hidden="true">${model.mediaHtml}</span>`
+    : `<span class="rcard-icon" aria-hidden="true">${model.icon}</span>`;
+
+  const className = model.articleClassName
+    ? `resource-item rcard ${model.articleClassName}`
+    : "resource-item rcard";
+
+  return `
+    <div class="${className}" role="listitem" data-accent="${escapeHtml(
+      model.accent
+    )}" data-path="${escapeHtml(model.path)}"${attrsHtml(model.attributes)}>
+      <button type="button" class="resource-preview rcard-preview">
+        ${media}
+        <span class="rcard-body">
+          <span class="rcard-head">
+            <span class="resource-title rcard-title">${escapeHtml(model.title)}</span>
+            ${badgeHtml(model.badge)}
+          </span>
+          <span class="resource-description rcard-desc">${escapeHtml(
+            model.description || "No description"
+          )}</span>
+          ${factsHtml}
+          ${model.lastUpdatedHtml ? `<span class="rcard-updated">${model.lastUpdatedHtml}</span>` : ""}
+        </span>
+      </button>
+      <div class="resource-actions rcard-actions">
+        ${model.actionsHtml}
+      </div>
+    </div>
+  `;
+}
+
+export function renderResourceGridHtml(
+  models: RCardModel[],
+  emptyTitle: string,
+  emptyDescription: string
+): string {
+  if (models.length === 0) {
+    return renderEmptyStateHtml(emptyTitle, emptyDescription);
+  }
+  return models.map(renderResourceCardHtml).join("");
+}

--- a/website/src/scripts/pages/skills-render.ts
+++ b/website/src/scripts/pages/skills-render.ts
@@ -1,9 +1,12 @@
+import { escapeHtml, getGitHubUrl, getLastUpdatedHtml } from '../utils';
 import {
-  escapeHtml,
-  getGitHubUrl,
-  getLastUpdatedHtml,
-} from "../utils";
-import { renderEmptyStateHtml, renderSharedCardHtml } from "./card-render";
+  FACT_ICONS,
+  GITHUB_MARK,
+  TYPE_ICONS,
+  renderResourceGridHtml,
+  type RCardFact,
+  type RCardModel,
+} from './resource-card';
 
 export interface RenderableSkillFile {
   name: string;
@@ -40,61 +43,66 @@ export function sortSkills<T extends RenderableSkill>(
   });
 }
 
-export function renderSkillsHtml(items: RenderableSkill[]): string {
-  if (items.length === 0) {
-    return renderEmptyStateHtml("No skills found", "No skills are available right now.");
+/** Top-level bundled resource kinds (scripts, references, assets, …). */
+export function skillAssetKinds(item: RenderableSkill): string[] {
+  const kinds = new Set<string>();
+  for (const file of item.files ?? []) {
+    const name = file.name ?? '';
+    const slash = name.indexOf('/');
+    if (slash > 0) kinds.add(name.slice(0, slash).toLowerCase());
   }
+  return [...kinds];
+}
 
-  return items
-    .map((item) => {
-      const metaHtml = `
-        ${
-          item.hasAssets
-            ? `<span class="resource-tag tag-assets">${item.assetCount} asset${
-                item.assetCount === 1 ? "" : "s"
-              }</span>`
-            : ""
-        }
-        <span class="resource-tag">${item.files.length} file${
-          item.files.length === 1 ? "" : "s"
-        }</span>
-        ${getLastUpdatedHtml(item.lastUpdated)}
-      `;
+export function skillSearchText(item: RenderableSkill): string {
+  return [item.title, item.description ?? '', item.id, skillAssetKinds(item).join(' ')].join(' ');
+}
 
-      const actionsHtml = `
-        <button class="btn btn-secondary copy-install-btn" data-skill-id="${escapeHtml(
-          item.id
-        )}" title="Copy install command">
-          <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
-            <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"/>
-            <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/>
-          </svg>
-          Copy Install
-        </button>
-        <button class="btn btn-primary download-skill-btn" data-skill-id="${escapeHtml(
-          item.id
-        )}" title="Download as ZIP">
-          <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
-            <path d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z"/>
-            <path d="M7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06l1.97 1.969Z"/>
-          </svg>
-          Download
-        </button>
-        <a href="${getGitHubUrl(
-          item.path
-        )}" class="btn btn-secondary" target="_blank" onclick="event.stopPropagation()" title="View on GitHub">GitHub</a>
-      `;
+const CLIPBOARD_SVG = `<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"/><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>`;
+const DOWNLOAD_SVG = `<svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M7.47 10.78a.75.75 0 0 0 1.06 0l3.75-3.75a.75.75 0 0 0-1.06-1.06L8.75 8.44V1.75a.75.75 0 0 0-1.5 0v6.69L4.78 5.97a.75.75 0 0 0-1.06 1.06l3.75 3.75ZM3.75 13a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5h-8.5Z"/></svg>`;
 
-      return renderSharedCardHtml({
-        title: item.title,
-        description: item.description || "No description",
-        articleAttributes: {
-          "data-path": item.skillFile,
-          "data-skill-id": item.id,
-        },
-        metaHtml,
-        actionsHtml,
+export function renderSkillsHtml(items: RenderableSkill[]): string {
+  const models: RCardModel[] = items.map((item) => {
+    const facts: RCardFact[] = [
+      { icon: FACT_ICONS.file, label: `${item.files.length} file${item.files.length === 1 ? '' : 's'}` },
+    ];
+    if (item.hasAssets) {
+      facts.push({
+        icon: FACT_ICONS.asset,
+        label: `${item.assetCount} asset${item.assetCount === 1 ? '' : 's'}`,
       });
-    })
-    .join("");
+    }
+
+    const safeTitle = escapeHtml(item.title);
+    const skillId = escapeHtml(item.id);
+    const actionsHtml = `
+      <button type="button" class="btn btn-primary btn-small copy-install-btn" data-skill-id="${skillId}" title="Copy install command" aria-label="Copy install command for ${safeTitle}">
+        ${CLIPBOARD_SVG}<span>Copy install</span>
+      </button>
+      <button type="button" class="download-skill-btn rcard-icon-btn rcard-lead" data-skill-id="${skillId}" title="Download as ZIP" aria-label="Download ${safeTitle} as ZIP">
+        ${DOWNLOAD_SVG}
+      </button>
+      <a href="${getGitHubUrl(item.path)}" class="action-github" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="View on GitHub" aria-label="View ${safeTitle} on GitHub">
+        ${GITHUB_MARK}
+      </a>
+    `;
+
+    return {
+      accent: 'power',
+      icon: TYPE_ICONS.lightning,
+      title: item.title,
+      description: item.description || 'No description',
+      path: item.skillFile,
+      attributes: { 'data-skill-id': item.id },
+      facts,
+      lastUpdatedHtml: getLastUpdatedHtml(item.lastUpdated),
+      actionsHtml,
+    };
+  });
+
+  return renderResourceGridHtml(
+    models,
+    'No skills match your filters',
+    'Try a different search term or clear the active filters.'
+  );
 }

--- a/website/src/scripts/pages/skills.ts
+++ b/website/src/scripts/pages/skills.ts
@@ -5,16 +5,17 @@ import {
   escapeHtml,
   fetchData,
   formatRelativeTime,
-  getQueryParam,
   showToast,
   downloadZipBundle,
-  updateQueryParams,
   copyToClipboard,
   REPO_IDENTIFIER,
 } from '../utils';
-import { openCardDetailsModal, setupModal } from '../modal';
+import { openCardDetailsModal } from '../modal';
+import { initListingPage } from './listing-controller';
 import {
   renderSkillsHtml,
+  skillAssetKinds,
+  skillSearchText,
   sortSkills,
   type RenderableSkill,
   type SkillSortOption,
@@ -33,28 +34,14 @@ interface SkillsData {
   items: Skill[];
 }
 
-let allItems: Skill[] = [];
+const SPINNER_SVG =
+  '<svg class="spinner" viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M8 0a8 8 0 1 0 8 8h-1.5A6.5 6.5 0 1 1 8 1.5V0z"/></svg>';
+const CHECK_SVG =
+  '<svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z"/></svg>';
+const DOWNLOAD_SVG =
+  '<svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M7.47 10.78a.75.75 0 0 0 1.06 0l3.75-3.75a.75.75 0 0 0-1.06-1.06L8.75 8.44V1.75a.75.75 0 0 0-1.5 0v6.69L4.78 5.97a.75.75 0 0 0-1.06 1.06l3.75 3.75ZM3.75 13a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5h-8.5Z"/></svg>';
+
 let skillById = new Map<string, Skill>();
-let currentSort: SkillSortOption = 'title';
-let resourceListHandlersReady = false;
-let modalReady = false;
-
-function applyFiltersAndRender(): void {
-  const countEl = document.getElementById('results-count');
-  const results = sortSkills(allItems, currentSort);
-
-  renderItems(results);
-  if (countEl) {
-    countEl.textContent = `${results.length} skill${results.length === 1 ? '' : 's'}`;
-  }
-}
-
-function renderItems(items: Skill[]): void {
-  const list = document.getElementById('resource-list');
-  if (!list) return;
-
-  list.innerHTML = renderSkillsHtml(items);
-}
 
 async function copyInstallCommand(skillId: string, btn: HTMLButtonElement): Promise<void> {
   const command = `gh skills install ${REPO_IDENTIFIER} ${skillId}`;
@@ -62,36 +49,34 @@ async function copyInstallCommand(skillId: string, btn: HTMLButtonElement): Prom
   const success = await copyToClipboard(command);
   showToast(success ? 'Install command copied!' : 'Failed to copy', success ? 'success' : 'error');
   if (success) {
-    btn.innerHTML = '<svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z"/></svg> Copied!';
+    btn.innerHTML = `${CHECK_SVG}<span>Copied!</span>`;
     setTimeout(() => {
       btn.innerHTML = originalContent;
     }, 2000);
   }
 }
 
+/** Icon-only download button: swap only the glyph so the 32px tile keeps its shape. */
 async function downloadSkill(skillId: string, btn: HTMLButtonElement): Promise<void> {
-  const skill = allItems.find((item) => item.id === skillId);
+  const skill = skillById.get(skillId);
   if (!skill || !skill.files || skill.files.length === 0) {
     showToast('No files found for this skill.', 'error');
     return;
   }
 
+  const iconOnly = btn.classList.contains('rcard-icon-btn');
   const originalContent = btn.innerHTML;
   btn.disabled = true;
-  btn.innerHTML = '<svg class="spinner" viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M8 0a8 8 0 1 0 8 8h-1.5A6.5 6.5 0 1 1 8 1.5V0z"/></svg> Preparing...';
+  btn.innerHTML = iconOnly ? SPINNER_SVG : `${SPINNER_SVG}<span>Preparing…</span>`;
 
   try {
     await downloadZipBundle(skill.id, skill.files);
-
-    btn.innerHTML = '<svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z"/></svg> Downloaded!';
-    setTimeout(() => {
-      btn.disabled = false;
-      btn.innerHTML = originalContent;
-    }, 2000);
+    btn.innerHTML = iconOnly ? CHECK_SVG : `${CHECK_SVG}<span>Downloaded!</span>`;
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Download failed.';
     showToast(message, 'error');
-    btn.innerHTML = '<svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor"><path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.75.75 0 1 1 1.06 1.06L9.06 8l3.22 3.22a.75.75 0 0 1-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 0 1-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06z"/></svg> Failed';
+    btn.innerHTML = iconOnly ? DOWNLOAD_SVG : originalContent;
+  } finally {
     setTimeout(() => {
       btn.disabled = false;
       btn.innerHTML = originalContent;
@@ -99,12 +84,7 @@ async function downloadSkill(skillId: string, btn: HTMLButtonElement): Promise<v
   }
 }
 
-function openSkillDetailsModal(skillId: string, trigger?: HTMLElement): void {
-  const item = skillById.get(skillId);
-  if (!item) {
-    return;
-  }
-
+function openSkillDetailsModal(item: Skill, trigger?: HTMLElement): void {
   const metaParts: string[] = [];
   if (item.hasAssets) {
     metaParts.push(
@@ -159,102 +139,47 @@ function openSkillDetailsModal(skillId: string, trigger?: HTMLElement): void {
   });
 }
 
-function setupResourceListHandlers(list: HTMLElement | null): void {
-  if (!list || resourceListHandlersReady) return;
-
-  list.addEventListener('click', (event) => {
-    const target = event.target as HTMLElement;
-
-    const copyInstallButton = target.closest('.copy-install-btn') as HTMLButtonElement | null;
-    if (copyInstallButton) {
-      event.stopPropagation();
-      const skillId = copyInstallButton.dataset.skillId;
-      if (skillId) copyInstallCommand(skillId, copyInstallButton);
-      return;
-    }
-
-    const downloadButton = target.closest('.download-skill-btn') as HTMLButtonElement | null;
-    if (downloadButton) {
-      event.stopPropagation();
-      const skillId = downloadButton.dataset.skillId;
-      if (skillId) downloadSkill(skillId, downloadButton);
-      return;
-    }
-
-    if (target.closest('.resource-actions')) return;
-
-    const item = target.closest('.resource-item') as HTMLElement | null;
-    const button = item?.querySelector('.resource-preview') as HTMLElement | undefined;
-    const skillId = item?.dataset.skillId;
-    if (skillId) openSkillDetailsModal(skillId, button);
-  });
-
+/** Delegated handlers for the bespoke copy/download buttons (cards + modal). */
+function setupSkillActionHandlers(): void {
   document.addEventListener('click', (event) => {
     const target = event.target as HTMLElement;
-    const modalInstallButton = target.closest(
-      '#skill-details-install'
+
+    const copyBtn = target.closest(
+      '.copy-install-btn, #skill-details-install'
     ) as HTMLButtonElement | null;
-    if (modalInstallButton) {
-      const skillId = modalInstallButton.dataset.skillId;
-      if (skillId) copyInstallCommand(skillId, modalInstallButton);
+    if (copyBtn) {
+      event.stopPropagation();
+      const skillId = copyBtn.dataset.skillId;
+      if (skillId) copyInstallCommand(skillId, copyBtn);
       return;
     }
 
-    const modalDownloadButton = target.closest(
-      '#skill-details-download'
+    const downloadBtn = target.closest(
+      '.download-skill-btn, #skill-details-download'
     ) as HTMLButtonElement | null;
-    if (modalDownloadButton) {
-      const skillId = modalDownloadButton.dataset.skillId;
-      if (skillId) downloadSkill(skillId, modalDownloadButton);
+    if (downloadBtn) {
+      event.stopPropagation();
+      const skillId = downloadBtn.dataset.skillId;
+      if (skillId) downloadSkill(skillId, downloadBtn);
     }
   });
-
-  resourceListHandlersReady = true;
 }
 
-function syncUrlState(): void {
-  updateQueryParams({
-    q: '',
-    category: [],
-    hasAssets: false,
-    sort: currentSort === 'title' ? '' : currentSort,
-  });
-}
-
-export async function initSkillsPage(): Promise<void> {
-  const list = document.getElementById('resource-list');
-  const sortSelect = document.getElementById('sort-select') as HTMLSelectElement;
-
-  if (!modalReady) {
-    setupModal();
-    modalReady = true;
-  }
-
-  setupResourceListHandlers(list as HTMLElement | null);
-
+document.addEventListener('DOMContentLoaded', async () => {
+  setupSkillActionHandlers();
   const data = await fetchData<SkillsData>('skills.json');
-  if (!data || !data.items) {
-    if (list) list.innerHTML = '<div class="empty-state"><h3>Failed to load data</h3></div>';
-    return;
+  if (data?.items) {
+    skillById = new Map(data.items.map((item) => [item.id, item]));
   }
+});
 
-  allItems = data.items;
-  skillById = new Map(allItems.map((item) => [item.id, item]));
-
-  const initialSort = getQueryParam('sort');
-  if (initialSort === 'lastUpdated') {
-    currentSort = initialSort;
-    if (sortSelect) sortSelect.value = initialSort;
-  }
-
-  sortSelect?.addEventListener('change', () => {
-    currentSort = sortSelect.value as SkillSortOption;
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  applyFiltersAndRender();
-}
-
-// Auto-initialize when DOM is ready
-document.addEventListener('DOMContentLoaded', initSkillsPage);
+initListingPage<Skill>({
+  dataFile: 'skills.json',
+  keyOf: (item) => item.skillFile,
+  search: skillSearchText,
+  facetValues: (item) => ({ resource: skillAssetKinds(item) }),
+  sort: (items, sort) => sortSkills(items, sort as SkillSortOption),
+  render: renderSkillsHtml,
+  noun: 'skill',
+  openModal: openSkillDetailsModal,
+});

--- a/website/src/scripts/pages/tools-render.ts
+++ b/website/src/scripts/pages/tools-render.ts
@@ -1,9 +1,17 @@
 import { escapeHtml } from "../utils";
+import {
+  FACT_ICONS,
+  GITHUB_MARK,
+  TYPE_ICONS,
+  renderResourceGridHtml,
+  type RCardFact,
+  type RCardModel,
+} from "./resource-card";
 
 export interface RenderableTool {
   id: string;
   name: string;
-  title: string;
+  title?: string;
   description: string;
   category: string;
   featured: boolean;
@@ -39,15 +47,25 @@ export function sortTools<T extends RenderableTool>(
       if (!a.featured && b.featured) return 1;
     }
 
-    return a.title.localeCompare(b.title);
+    return a.name.localeCompare(b.name);
   });
 }
 
-function formatMultilineText(text: string): string {
-  return escapeHtml(text).replace(/\r?\n/g, "<br>");
+export function toolCategories(item: RenderableTool): string[] {
+  return item.category ? [item.category] : [];
 }
 
-function sanitizeToolUrl(url: string): string {
+export function toolSearchText(item: RenderableTool): string {
+  return [
+    item.name,
+    item.description ?? "",
+    item.category ?? "",
+    (item.tags ?? []).join(" "),
+    (item.features ?? []).join(" "),
+  ].join(" ");
+}
+
+export function sanitizeToolUrl(url: string): string {
   try {
     const protocol = new URL(url).protocol;
     if (
@@ -65,139 +83,92 @@ function sanitizeToolUrl(url: string): string {
   return "#";
 }
 
-function getToolActionLink(
-  href: string | undefined,
-  label: string,
-  className: string
-): string {
-  if (!href) return "";
-  return `<a href="${sanitizeToolUrl(
-    href
-  )}" class="${className}" target="_blank" rel="noopener">${label}</a>`;
+// Ordered by how we surface the primary card action + modal link buttons.
+const LINK_DEFS: { key: keyof RenderableTool["links"]; label: string }[] = [
+  { key: "vscode", label: "Install in VS Code" },
+  { key: "vscode-insiders", label: "VS Code Insiders" },
+  { key: "visual-studio", label: "Visual Studio" },
+  { key: "marketplace", label: "Marketplace" },
+  { key: "npm", label: "npm" },
+  { key: "pypi", label: "PyPI" },
+  { key: "documentation", label: "Docs" },
+  { key: "blog", label: "Blog" },
+  { key: "github", label: "GitHub" },
+];
+
+/** Best single call-to-action for the card, plus the key it consumed. */
+function primaryToolLink(
+  tool: RenderableTool
+): { key: string; label: string; href: string } | null {
+  for (const { key, label } of LINK_DEFS) {
+    const href = tool.links[key];
+    if (href) return { key, label, href };
+  }
+  return null;
 }
 
-export function renderToolsHtml(
-  tools: RenderableTool[]
-): string {
-  if (tools.length === 0) {
-    return `
-      <div class="empty-state">
-        <h3>No tools found</h3>
-        <p>Try a different category or clear the current filters</p>
-      </div>
-    `;
-  }
+/** All link buttons for the details modal. */
+export function renderToolModalLinks(tool: RenderableTool): string {
+  return LINK_DEFS.map(({ key, label }) => {
+    const href = tool.links[key];
+    if (!href) return "";
+    const primary = key === "vscode" ? "btn btn-primary" : "btn btn-secondary";
+    return `<a class="${primary}" href="${sanitizeToolUrl(
+      href
+    )}" target="_blank" rel="noopener">${label}</a>`;
+  })
+    .filter(Boolean)
+    .join("");
+}
 
-  return tools
-    .map((tool) => {
-      const badges: string[] = [];
-      if (tool.featured) {
-        badges.push('<span class="tool-badge featured">Featured</span>');
-      }
-      badges.push(
-        `<span class="tool-badge category">${escapeHtml(tool.category)}</span>`
-      );
+export function renderToolsHtml(tools: RenderableTool[]): string {
+  const models: RCardModel[] = tools.map((tool) => {
+    const safeName = escapeHtml(tool.name);
+    const facts: RCardFact[] = [];
+    if (tool.featured) {
+      facts.push({ icon: FACT_ICONS.star, label: "Featured" });
+    }
+    if (tool.features?.length) {
+      facts.push({
+        icon: FACT_ICONS.feature,
+        label: `${tool.features.length} feature${
+          tool.features.length === 1 ? "" : "s"
+        }`,
+      });
+    }
 
-      const features =
-        tool.features && tool.features.length > 0
-          ? `<div class="tool-section">
-          <h3>Features</h3>
-          <ul>${tool.features
-            .map((feature) => `<li>${escapeHtml(feature)}</li>`)
-            .join("")}</ul>
-        </div>`
-          : "";
+    const primary = primaryToolLink(tool);
+    const primaryHtml = primary
+      ? `<a href="${sanitizeToolUrl(
+          primary.href
+        )}" class="btn btn-primary btn-small" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="${escapeHtml(
+          primary.label
+        )}">${escapeHtml(primary.label)}</a>`
+      : "";
 
-      const requirements =
-        tool.requirements && tool.requirements.length > 0
-          ? `<div class="tool-section">
-          <h3>Requirements</h3>
-          <ul>${tool.requirements
-            .map((requirement) => `<li>${escapeHtml(requirement)}</li>`)
-            .join("")}</ul>
-        </div>`
-          : "";
-
-      const tags =
-        tool.tags && tool.tags.length > 0
-          ? `<div class="tool-tags">
-          ${tool.tags
-            .map((tag) => `<span class="tool-tag">${escapeHtml(tag)}</span>`)
-            .join("")}
-        </div>`
-          : "";
-
-      const config = tool.configuration
-        ? `<div class="tool-config">
-          <h3>Configuration</h3>
-          <div class="tool-config-wrapper">
-            <pre><code>${escapeHtml(tool.configuration.content)}</code></pre>
-          </div>
-          <button class="copy-config-btn" data-config="${encodeURIComponent(
-            tool.configuration.content
-          )}">
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-              <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"/>
-              <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/>
-            </svg>
-            Copy Configuration
-          </button>
-        </div>`
+    const githubHref = tool.links.github;
+    const githubHtml =
+      githubHref && primary?.key !== "github"
+        ? `<a href="${sanitizeToolUrl(
+            githubHref
+          )}" class="btn btn-secondary btn-small action-github rcard-lead" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="View on GitHub" aria-label="View ${safeName} on GitHub">${GITHUB_MARK}</a>`
         : "";
 
-      const actions = [
-        getToolActionLink(tool.links.blog, "📖 Blog", "btn btn-secondary"),
-        getToolActionLink(
-          tool.links.marketplace,
-          "🏪 Marketplace",
-          "btn btn-secondary"
-        ),
-        getToolActionLink(tool.links.npm, "📦 npm", "btn btn-secondary"),
-        getToolActionLink(tool.links.pypi, "🐍 PyPI", "btn btn-secondary"),
-        getToolActionLink(
-          tool.links.documentation,
-          "📚 Docs",
-          "btn btn-secondary"
-        ),
-        getToolActionLink(tool.links.github, "GitHub", "btn btn-secondary"),
-        getToolActionLink(
-          tool.links.vscode,
-          "Install in VS Code",
-          "btn btn-primary"
-        ),
-        getToolActionLink(
-          tool.links["vscode-insiders"],
-          "VS Code Insiders",
-          "btn btn-outline"
-        ),
-        getToolActionLink(
-          tool.links["visual-studio"],
-          "Visual Studio",
-          "btn btn-outline"
-        ),
-      ].filter(Boolean);
+    return {
+      accent: "dev",
+      icon: TYPE_ICONS.wrench,
+      title: tool.name,
+      description: tool.description || "No description",
+      path: tool.id,
+      badge: tool.category ? { text: tool.category } : null,
+      facts,
+      actionsHtml: `${primaryHtml}${githubHtml}`,
+    };
+  });
 
-      const actionsHtml =
-        actions.length > 0
-          ? `<div class="tool-actions">${actions.join("")}</div>`
-          : "";
-
-      return `
-      <div class="tool-card">
-        <div class="tool-header">
-          <h2>${escapeHtml(tool.name)}</h2>
-          <div class="tool-badges">
-            ${badges.join("")}
-          </div>
-        </div>
-        <p class="tool-description">${formatMultilineText(tool.description)}</p>
-        ${features}
-        ${requirements}
-        ${config}
-        ${tags}
-        ${actionsHtml}
-      </div>
-    `;
-    })
-    .join("");
+  return renderResourceGridHtml(
+    models,
+    "No tools match your filters",
+    "Try a different search term or clear the active filters."
+  );
 }

--- a/website/src/scripts/pages/tools.ts
+++ b/website/src/scripts/pages/tools.ts
@@ -1,105 +1,91 @@
 /**
  * Tools page functionality
  */
+import { escapeHtml } from "../utils";
+import { openCardDetailsModal } from "../modal";
+import { initListingPage } from "./listing-controller";
 import {
-  fetchData,
-  getQueryParam,
-  updateQueryParams,
-} from "../utils";
-import {
+  renderToolModalLinks,
   renderToolsHtml,
   sortTools,
+  toolCategories,
+  toolSearchText,
+  type RenderableTool,
   type ToolSortOption,
 } from "./tools-render";
 
-export interface Tool {
-  id: string;
-  name: string;
-  title: string;
-  description: string;
-  category: string;
-  featured: boolean;
-  requirements: string[];
-  features: string[];
-  links: {
-    blog?: string;
-    vscode?: string;
-    "vscode-insiders"?: string;
-    "visual-studio"?: string;
-    github?: string;
-    documentation?: string;
-    marketplace?: string;
-    npm?: string;
-    pypi?: string;
-  };
-  configuration?: {
-    type: string;
-    content: string;
-  };
-  tags: string[];
+interface Tool extends RenderableTool {}
+
+const COPY_SVG =
+  '<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"/><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>';
+
+function buildSection(heading: string, items: string[]): string {
+  if (!items.length) return "";
+  return `<div class="tool-section"><h3>${heading}</h3><ul>${items
+    .map((entry) => `<li>${escapeHtml(entry)}</li>`)
+    .join("")}</ul></div>`;
 }
 
-interface ToolsData {
-  items: Tool[];
-  filters: {
-    categories: string[];
-    tags: string[];
-  };
-}
-
-let allItems: Tool[] = [];
-let currentFilters = {
-  categories: [] as string[],
-};
-let currentSort: ToolSortOption = "featured";
-let copyHandlersReady = false;
-let initialized = false;
-
-function sortItems(items: Tool[]): Tool[] {
-  return sortTools(items, currentSort);
-}
-
-function getCountText(resultsCount: number): string {
-  if (currentFilters.categories.length === 0) {
-    return `${resultsCount} tool${resultsCount === 1 ? "" : "s"}`;
+function openToolDetailsModal(item: Tool, trigger?: HTMLElement): void {
+  const badges: string[] = [];
+  if (item.category) {
+    badges.push(`<span class="resource-tag">${escapeHtml(item.category)}</span>`);
+  }
+  if (item.featured) {
+    badges.push('<span class="resource-tag tag-featured">Featured</span>');
   }
 
-  return `${resultsCount} of ${allItems.length} tools (filtered by ${currentFilters.categories.length} categor${currentFilters.categories.length === 1 ? "y" : "ies"})`;
-}
+  const sections: string[] = [
+    buildSection("Features", item.features ?? []),
+    buildSection("Requirements", item.requirements ?? []),
+  ];
 
-function applyFiltersAndRender(): void {
-  const countEl = document.getElementById("results-count");
-  let results = [...allItems];
-
-  if (currentFilters.categories.length > 0) {
-    results = results.filter((item) =>
-      currentFilters.categories.includes(item.category)
+  if (item.configuration?.content) {
+    const encoded = encodeURIComponent(item.configuration.content);
+    sections.push(
+      `<div class="tool-config"><h3>Configuration</h3><div class="tool-config-wrapper"><pre><code>${escapeHtml(
+        item.configuration.content
+      )}</code></pre></div><button class="copy-config-btn" type="button" data-config="${encoded}">${COPY_SVG}<span>Copy configuration</span></button></div>`
     );
   }
 
-  results = sortItems(results);
+  const tagsHtml = item.tags?.length
+    ? `<div class="tool-tags">${item.tags
+        .map((tag) => `<span class="tool-tag">${escapeHtml(tag)}</span>`)
+        .join("")}</div>`
+    : "";
 
-  renderTools(results);
-  if (countEl) countEl.textContent = getCountText(results.length);
-}
+  const detailsHtml = `
+    <div class="resource-details-body modal-card-details-body tool-details-modal">
+      <div class="resource-details-content">
+        <p class="resource-details-description">${escapeHtml(
+          item.description || "No description"
+        )}</p>
+        ${
+          badges.length
+            ? `<div class="resource-meta resource-details-meta">${badges.join(
+                ""
+              )}</div>`
+            : ""
+        }
+        ${sections.filter(Boolean).join("")}
+        ${tagsHtml}
+        <div class="resource-actions resource-details-actions">${renderToolModalLinks(
+          item
+        )}</div>
+      </div>
+    </div>`;
 
-function renderTools(tools: Tool[]): void {
-  const container = document.getElementById("tools-list");
-  if (!container) return;
-  container.innerHTML = renderToolsHtml(tools);
-}
-
-function syncUrlState(): void {
-  updateQueryParams({
-    q: "",
-    category: currentFilters.categories,
-    sort: currentSort === "featured" ? "" : currentSort,
+  openCardDetailsModal({
+    title: item.name,
+    description: item.description || "No description",
+    detailsHtml,
+    trigger,
   });
 }
 
+/** Delegated handler for the bespoke copy-configuration button (modal only). */
 function setupCopyConfigHandlers(): void {
-  if (copyHandlersReady) return;
-
   document.addEventListener("click", async (event) => {
     const button = (event.target as HTMLElement).closest(
       ".copy-config-btn"
@@ -110,15 +96,10 @@ function setupCopyConfigHandlers(): void {
     const config = decodeURIComponent(button.dataset.config || "");
     try {
       await navigator.clipboard.writeText(config);
-      button.classList.add("copied");
       const originalHtml = button.innerHTML;
-      button.innerHTML = `
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-          <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"/>
-        </svg>
-        Copied!
-      `;
-      setTimeout(() => {
+      button.classList.add("copied");
+      button.innerHTML = `${COPY_SVG}<span>Copied!</span>`;
+      window.setTimeout(() => {
         button.classList.remove("copied");
         button.innerHTML = originalHtml;
       }, 2000);
@@ -126,86 +107,18 @@ function setupCopyConfigHandlers(): void {
       console.error("Failed to copy:", err);
     }
   });
-
-  copyHandlersReady = true;
 }
 
-export async function initToolsPage(): Promise<void> {
-  if (initialized) return;
-  initialized = true;
+setupCopyConfigHandlers();
 
-  const categoryFilter = document.getElementById(
-    "filter-category"
-  ) as HTMLSelectElement;
-  const clearFiltersBtn = document.getElementById("clear-filters");
-  const sortSelect = document.getElementById("sort-select") as HTMLSelectElement;
-
-  const data = await fetchData<ToolsData>("tools.json");
-  if (!data || !data.items) {
-    const container = document.getElementById("tools-list");
-    if (container)
-      container.innerHTML =
-        '<div class="empty-state"><h3>Failed to load tools</h3></div>';
-    return;
-  }
-
-  // Map items to include title for FuzzySearch
-  allItems = data.items.map((item) => ({
-    ...item,
-    title: item.name, // FuzzySearch uses title
-  }));
-
-  // Populate category filter
-  if (categoryFilter && data.filters.categories) {
-    categoryFilter.innerHTML =
-      '<option value="">All Categories</option>' +
-      data.filters.categories
-        .map(
-          (c) => `<option value="${c}">${c}</option>`
-        )
-        .join("");
-
-    const initialCategory = getQueryParam("category");
-    if (initialCategory && data.filters.categories.includes(initialCategory)) {
-      currentFilters.categories = [initialCategory];
-      categoryFilter.value = initialCategory;
-    }
-
-    categoryFilter.addEventListener("change", () => {
-      currentFilters.categories = categoryFilter.value
-        ? [categoryFilter.value]
-        : [];
-      applyFiltersAndRender();
-      syncUrlState();
-    });
-  }
-
-  const initialSort = getQueryParam("sort");
-  if (initialSort === "title") {
-    currentSort = initialSort;
-    if (sortSelect) sortSelect.value = initialSort;
-  }
-  sortSelect?.addEventListener("change", () => {
-    currentSort = sortSelect.value as ToolSortOption;
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  applyFiltersAndRender();
-  syncUrlState();
-
-  // Clear filters
-  clearFiltersBtn?.addEventListener("click", () => {
-    currentFilters = { categories: [] };
-    currentSort = "featured";
-    if (categoryFilter) categoryFilter.value = "";
-    if (sortSelect) sortSelect.value = "featured";
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  setupCopyConfigHandlers();
-}
-
-// Auto-initialize when DOM is ready
-document.addEventListener("DOMContentLoaded", initToolsPage);
+initListingPage<Tool>({
+  dataFile: "tools.json",
+  keyOf: (item) => item.id,
+  search: toolSearchText,
+  facetValues: (item) => ({ category: toolCategories(item) }),
+  sort: (items, sort) => sortTools(items, sort as ToolSortOption),
+  render: renderToolsHtml,
+  noun: "tool",
+  defaultSort: "featured",
+  openModal: openToolDetailsModal,
+});

--- a/website/src/scripts/pages/workflows-render.ts
+++ b/website/src/scripts/pages/workflows-render.ts
@@ -4,7 +4,12 @@ import {
   getGitHubUrl,
   getLastUpdatedHtml,
 } from '../utils';
-import { renderEmptyStateHtml, renderSharedCardHtml } from './card-render';
+import {
+  GITHUB_MARK,
+  TYPE_ICONS,
+  renderResourceGridHtml,
+  type RCardModel,
+} from './resource-card';
 
 export interface RenderableWorkflow {
   title: string;
@@ -15,6 +20,22 @@ export interface RenderableWorkflow {
 }
 
 export type WorkflowSortOption = 'title' | 'lastUpdated';
+
+const TRIGGER_LABELS: Record<string, string> = {
+  schedule: 'Scheduled',
+  workflow_dispatch: 'Manual',
+  issues: 'On issues',
+  slash_command: 'Slash command',
+  roles: 'Roles',
+};
+
+/** Human-friendly label for a raw trigger key. */
+export function humanizeTrigger(trigger: string): string {
+  return (
+    TRIGGER_LABELS[trigger] ??
+    trigger.replace(/_/g, ' ').replace(/^\w/, (c) => c.toUpperCase())
+  );
+}
 
 export function sortWorkflows<T extends RenderableWorkflow>(
   items: T[],
@@ -31,36 +52,56 @@ export function sortWorkflows<T extends RenderableWorkflow>(
   });
 }
 
-export function renderWorkflowsHtml(
-  items: RenderableWorkflow[]
-): string {
-  if (items.length === 0) {
-    return renderEmptyStateHtml('No workflows found', 'Try adjusting the selected filters.');
-  }
+export function workflowTriggers(item: RenderableWorkflow): string[] {
+  return item.triggers ?? [];
+}
 
-  return items
-    .map((item) => {
-      const metaHtml = `
-        ${item.triggers
-          .map((trigger) => `<span class="resource-tag tag-trigger">${escapeHtml(trigger)}</span>`)
-          .join('')}
-        ${getLastUpdatedHtml(item.lastUpdated)}
-      `;
+export function workflowSearchText(item: RenderableWorkflow): string {
+  return [
+    item.title,
+    item.description ?? '',
+    (item.triggers ?? []).map(humanizeTrigger).join(' '),
+    (item.triggers ?? []).join(' '),
+  ].join(' ');
+}
 
-      const actionsHtml = `
-        ${getActionButtonsHtml(item.path)}
-        <a href="${getGitHubUrl(item.path)}" class="btn btn-secondary" target="_blank" onclick="event.stopPropagation()" title="View on GitHub">GitHub</a>
-      `;
+export function renderWorkflowsHtml(items: RenderableWorkflow[]): string {
+  const models: RCardModel[] = items.map((item) => {
+    const triggers = item.triggers ?? [];
+    const badge = triggers.length
+      ? {
+          text: humanizeTrigger(triggers[0]),
+          title: triggers.map(humanizeTrigger).join(', '),
+          moreCount: triggers.length - 1,
+        }
+      : null;
 
-      return renderSharedCardHtml({
-        title: item.title,
-        description: item.description || 'No description',
-        articleAttributes: {
-          'data-path': item.path,
-        },
-        metaHtml,
-        actionsHtml,
-      });
-    })
-    .join('');
+    const actionsHtml = `
+      ${getActionButtonsHtml(item.path, true)}
+      <a href="${getGitHubUrl(
+        item.path
+      )}" class="btn btn-secondary btn-small action-github" target="_blank" rel="noopener" onclick="event.stopPropagation()" title="View on GitHub" aria-label="View ${escapeHtml(
+        item.title
+      )} on GitHub">
+        ${GITHUB_MARK}
+      </a>
+    `;
+
+    return {
+      accent: 'automation',
+      icon: TYPE_ICONS.workflow,
+      title: item.title,
+      description: item.description || 'No description',
+      path: item.path,
+      badge,
+      lastUpdatedHtml: getLastUpdatedHtml(item.lastUpdated),
+      actionsHtml,
+    };
+  });
+
+  return renderResourceGridHtml(
+    models,
+    'No workflows match your filters',
+    'Try a different search term or clear the active filters.'
+  );
 }

--- a/website/src/scripts/pages/workflows.ts
+++ b/website/src/scripts/pages/workflows.ts
@@ -4,82 +4,26 @@
 import {
   copyToClipboard,
   escapeHtml,
-  fetchData,
   formatRelativeTime,
-  getQueryParam,
-  getQueryParamValues,
   showToast,
-  setupActionHandlers,
-  updateQueryParams,
 } from '../utils';
-import { openCardDetailsModal, setupModal } from '../modal';
-import { clearSelectValues, getSelectValues, setSelectValues } from './select-utils';
+import { openCardDetailsModal } from '../modal';
+import { initListingPage } from './listing-controller';
 import {
+  humanizeTrigger,
   renderWorkflowsHtml,
   sortWorkflows,
+  workflowSearchText,
+  workflowTriggers,
   type RenderableWorkflow,
   type WorkflowSortOption,
 } from './workflows-render';
 
 interface Workflow extends RenderableWorkflow {
   id: string;
-  path: string;
-  triggers: string[];
-  lastUpdated?: string | null;
 }
 
-interface WorkflowsData {
-  items: Workflow[];
-  filters: {
-    triggers: string[];
-  };
-}
-
-let allItems: Workflow[] = [];
-let workflowByPath = new Map<string, Workflow>();
-let triggerSelectEl: HTMLSelectElement | null = null;
-let currentFilters = {
-  triggers: [] as string[],
-};
-let currentSort: WorkflowSortOption = 'title';
-let resourceListHandlersReady = false;
-let modalReady = false;
-
-function sortItems(items: Workflow[]): Workflow[] {
-  return sortWorkflows(items, currentSort);
-}
-
-function applyFiltersAndRender(): void {
-  const countEl = document.getElementById('results-count');
-  let results = [...allItems];
-
-  if (currentFilters.triggers.length > 0) {
-    results = results.filter((item) => item.triggers.some((trigger) => currentFilters.triggers.includes(trigger)));
-  }
-
-  results = sortItems(results);
-
-  renderItems(results);
-  let countText = `${results.length} workflow${results.length === 1 ? '' : 's'}`;
-  if (currentFilters.triggers.length > 0) {
-    countText = `${results.length} of ${allItems.length} workflows (filtered by ${currentFilters.triggers.length} trigger${currentFilters.triggers.length > 1 ? 's' : ''})`;
-  }
-  if (countEl) countEl.textContent = countText;
-}
-
-function renderItems(items: Workflow[]): void {
-  const list = document.getElementById('resource-list');
-  if (!list) return;
-
-  list.innerHTML = renderWorkflowsHtml(items);
-}
-
-function openWorkflowDetailsModal(path: string, trigger?: HTMLElement): void {
-  const item = workflowByPath.get(path);
-  if (!item) {
-    return;
-  }
-
+function openWorkflowDetailsModal(item: Workflow, trigger?: HTMLElement): void {
   const metaParts: string[] = [];
   if (item.lastUpdated) {
     metaParts.push(
@@ -90,12 +34,18 @@ function openWorkflowDetailsModal(path: string, trigger?: HTMLElement): void {
   }
 
   const triggerTags = item.triggers
-    .map((triggerName) => `<span class="resource-tag tag-trigger">${escapeHtml(triggerName)}</span>`)
+    .map(
+      (triggerName) =>
+        `<span class="resource-tag tag-trigger">${escapeHtml(
+          humanizeTrigger(triggerName)
+        )}</span>`
+    )
     .join('');
+
   const actionsHtml = `
-    <button id="workflow-details-copy-path" class="btn btn-secondary" type="button" data-workflow-path="${escapeHtml(
+    <button id="workflow-details-copy-path" class="btn btn-primary" type="button" data-workflow-path="${escapeHtml(
       item.path
-    )}">Copy Path</button>
+    )}">Copy path</button>
     <button class="btn btn-secondary" type="button" data-open-file-path="${escapeHtml(
       item.path
     )}" data-open-file-type="workflow">Source</button>
@@ -113,23 +63,7 @@ function openWorkflowDetailsModal(path: string, trigger?: HTMLElement): void {
   });
 }
 
-function setupResourceListHandlers(list: HTMLElement | null): void {
-  if (!list || resourceListHandlersReady) return;
-
-  list.addEventListener('click', (event) => {
-    const target = event.target as HTMLElement;
-    if (target.closest('.resource-actions')) {
-      return;
-    }
-
-    const item = target.closest('.resource-item') as HTMLElement | null;
-    const button = item?.querySelector('.resource-preview') as HTMLElement | undefined;
-    const path = item?.dataset.path;
-    if (path) {
-      openWorkflowDetailsModal(path, button);
-    }
-  });
-
+function setupWorkflowActionHandlers(): void {
   document.addEventListener('click', async (event) => {
     const target = event.target as HTMLElement;
     const copyPathButton = target.closest(
@@ -139,88 +73,22 @@ function setupResourceListHandlers(list: HTMLElement | null): void {
     const workflowPath = copyPathButton.dataset.workflowPath || '';
     if (!workflowPath) return;
     const success = await copyToClipboard(workflowPath);
-    showToast(success ? 'Path copied!' : 'Failed to copy path', success ? 'success' : 'error');
-  });
-
-  resourceListHandlersReady = true;
-}
-
-function syncUrlState(): void {
-  updateQueryParams({
-    q: '',
-    trigger: currentFilters.triggers,
-    sort: currentSort === 'title' ? '' : currentSort,
+    showToast(
+      success ? 'Path copied!' : 'Failed to copy path',
+      success ? 'success' : 'error'
+    );
   });
 }
 
-export async function initWorkflowsPage(): Promise<void> {
-  const list = document.getElementById('resource-list');
-  const clearFiltersBtn = document.getElementById('clear-filters');
-  const sortSelect = document.getElementById('sort-select') as HTMLSelectElement | null;
+setupWorkflowActionHandlers();
 
-  if (!modalReady) {
-    setupModal();
-    modalReady = true;
-  }
-
-  setupResourceListHandlers(list as HTMLElement | null);
-
-  const data = await fetchData<WorkflowsData>('workflows.json');
-  if (!data || !data.items) {
-    if (list) list.innerHTML = '<div class="empty-state"><h3>Failed to load data</h3></div>';
-    return;
-  }
-
-  allItems = data.items;
-  workflowByPath = new Map(allItems.map((item) => [item.path, item]));
-
-  triggerSelectEl = document.getElementById('filter-trigger') as HTMLSelectElement | null;
-  if (triggerSelectEl) {
-    triggerSelectEl.innerHTML = '';
-    data.filters.triggers.forEach((trigger) => {
-      const option = document.createElement('option');
-      option.value = trigger;
-      option.textContent = trigger;
-      triggerSelectEl?.appendChild(option);
-    });
-  }
-
-  const initialTriggers = getQueryParamValues('trigger').filter((trigger) => data.filters.triggers.includes(trigger));
-  const initialSort = getQueryParam('sort');
-
-  if (initialTriggers.length > 0) {
-    currentFilters.triggers = initialTriggers;
-    setSelectValues(triggerSelectEl, initialTriggers);
-  }
-  if (initialSort === 'lastUpdated') {
-    currentSort = initialSort;
-    if (sortSelect) sortSelect.value = initialSort;
-  }
-
-  triggerSelectEl?.addEventListener('change', () => {
-    currentFilters.triggers = getSelectValues(triggerSelectEl);
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  sortSelect?.addEventListener('change', () => {
-    currentSort = sortSelect.value as WorkflowSortOption;
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  clearFiltersBtn?.addEventListener('click', () => {
-    currentFilters = { triggers: [] };
-    currentSort = 'title';
-    clearSelectValues(triggerSelectEl);
-    if (sortSelect) sortSelect.value = 'title';
-    applyFiltersAndRender();
-    syncUrlState();
-  });
-
-  applyFiltersAndRender();
-  setupActionHandlers();
-}
-
-// Auto-initialize when DOM is ready
-document.addEventListener('DOMContentLoaded', initWorkflowsPage);
+initListingPage<Workflow>({
+  dataFile: 'workflows.json',
+  keyOf: (item) => item.path,
+  search: workflowSearchText,
+  facetValues: (item) => ({ trigger: workflowTriggers(item) }),
+  sort: (items, sort) => sortWorkflows(items, sort as WorkflowSortOption),
+  render: renderWorkflowsHtml,
+  noun: 'workflow',
+  openModal: openWorkflowDetailsModal,
+});

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -662,16 +662,16 @@ body:has(#main-content) {
 
 .btn-primary {
   background: var(--color-accent);
-  color: var(--sl-color-text-invert) !important;
+  color: #fff !important;
   border-color: transparent;
   font-weight: 600;
 }
 
 .btn-primary:hover {
-  background: var(--color-accent-hover);
+  background: #7326d6;
   transform: translateY(-1px);
   box-shadow: var(--shadow-glow);
-  color: white;
+  color: #fff;
 }
 
 .btn-secondary {

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -48,15 +48,24 @@
   --gradient-hero: radial-gradient(ellipse 80% 50% at 50% -20%, rgba(133, 52, 243, 0.25), transparent),
                    radial-gradient(ellipse 60% 40% at 80% 50%, rgba(254, 76, 37, 0.12), transparent),
                    radial-gradient(ellipse 60% 40% at 20% 50%, rgba(184, 112, 255, 0.12), transparent);
-  --border-radius: 8px;
+  /* Radius system (locked): controls 10px · cards/panels 16px · pills full */
+  --border-radius: 10px;
   --border-radius-lg: 16px;
   --border-radius-xl: 24px;
+  --radius-control: 10px;
+  --radius-card: 16px;
+  --radius-pill: 999px;
+  /* Hairline + elevated surface for cleaner depth */
+  --color-hairline: rgba(255, 255, 255, 0.06);
+  --color-border-strong: #3a3a4f;
+  --color-surface-elevated: #191922;
   --shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.2), 0 2px 4px -2px rgba(0, 0, 0, 0.2);
   --shadow-md: 0 12px 24px -10px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 20px 40px -12px rgba(0, 0, 0, 0.5);
   --shadow-glow: 0 0 40px -10px rgba(133, 52, 243, 0.5);
   --transition: 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   --transition-slow: 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
   --container-width: 1200px;
   --header-height: 72px;
   --font-mono: 'Monaspace Argon NF', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
@@ -68,6 +77,9 @@
   --color-bg-secondary: #ffffff;
   --color-bg-tertiary: #f5f5f7;
   --color-border: #e4e4e7;
+  --color-hairline: rgba(0, 0, 0, 0.05);
+  --color-border-strong: #d4d4d8;
+  --color-surface-elevated: #ffffff;
   --color-text: #3f3f46;
   --color-text-muted: #52525b;
   --color-text-emphasis: #18181b;
@@ -92,6 +104,9 @@
     --color-bg-secondary: #ffffff;
     --color-bg-tertiary: #f5f5f7;
     --color-border: #e4e4e7;
+    --color-hairline: rgba(0, 0, 0, 0.05);
+    --color-border-strong: #d4d4d8;
+    --color-surface-elevated: #ffffff;
     --color-text: #3f3f46;
     --color-text-muted: #52525b;
     --color-text-emphasis: #18181b;
@@ -230,20 +245,55 @@ body:has(#main-content) {
   font-size: clamp(36px, 8vw, 64px);
   font-weight: 800;
   letter-spacing: -0.03em;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
   position: relative;
   z-index: 1;
   line-height: 1.1;
+}
+
+.hero-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-bottom: 24px;
+  padding: 6px 14px 6px 12px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-elevated);
+  color: var(--color-text-muted);
+  font-size: 13px;
+  font-weight: 600;
+  position: relative;
+  z-index: 2;
+}
+
+.hero-chip svg {
+  color: var(--color-accent);
 }
 
 .hero-subtitle {
   font-size: clamp(16px, 3vw, 20px);
   color: var(--color-text-muted);
   max-width: 600px;
-  margin: 0 auto 48px;
+  margin: 0 auto 36px;
   line-height: 1.6;
   position: relative;
   z-index: 1;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  position: relative;
+  z-index: 2;
+}
+
+.hero-actions .btn {
+  padding: 12px 22px;
+  font-size: 15px;
 }
 
 .hero-search {
@@ -439,32 +489,46 @@ body:has(#main-content) {
 }
 
 .card {
-  background: var(--color-bg-secondary);
+  position: relative;
+  overflow: hidden;
+  background: var(--color-surface-elevated);
   border: 1px solid var(--color-border);
-  border-radius: var(--border-radius);
+  border-radius: var(--radius-card);
   padding: 24px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  transition: transform 0.25s var(--ease-out), box-shadow 0.25s var(--ease-out),
+    border-color 0.25s var(--ease-out);
   display: block;
   color: inherit;
   text-decoration: none;
   opacity: 0;
-  animation: card-enter 0.4s ease-out forwards;
+  animation: card-enter 0.5s var(--ease-out) forwards;
   animation-delay: var(--animation-delay, 0ms);
 }
 
+/* Category accent bar (top edge). Category classes recolor the gradient. */
+.card::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: var(--color-hairline);
+  opacity: 0.85;
+  transition: opacity var(--transition);
+}
+
 .card-with-count {
-  display: flex;
-  align-items: flex-start;
-  gap: 16px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: start;
+  column-gap: 16px;
+  row-gap: 4px;
 }
 
 .card-with-count .card-icon {
-  flex-shrink: 0;
   margin-bottom: 0;
 }
 
 .card-with-count .card-content {
-  flex: 1;
   min-width: 0;
 }
 
@@ -473,19 +537,34 @@ body:has(#main-content) {
 }
 
 .card-count {
-  flex-shrink: 0;
-  font-size: 28px;
+  justify-self: end;
+  align-self: start;
+  font-size: 13px;
   font-weight: 700;
-  color: var(--color-primary);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted);
   line-height: 1;
-  min-width: 40px;
-  text-align: right;
+  padding: 5px 11px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-tertiary);
+  transition: color var(--transition), border-color var(--transition),
+    background-color var(--transition);
 }
 
 .card:hover {
-  border-color: var(--color-accent);
-  transform: translateY(-2px);
+  border-color: var(--color-border-strong);
+  transform: translateY(-3px);
   box-shadow: var(--shadow-md);
+}
+
+.card:hover::before {
+  opacity: 1;
+}
+
+.card:hover .card-count {
+  color: var(--color-text-emphasis);
+  border-color: var(--color-accent);
 }
 
 @keyframes card-enter {
@@ -496,29 +575,32 @@ body:has(#main-content) {
 }
 
 .card-icon {
-  width: 48px;
-  height: 48px;
+  width: 44px;
+  height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;
   margin-bottom: 16px;
+  border-radius: 12px;
   color: var(--color-primary);
-  transition: transform var(--transition), color var(--transition);
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  transition: transform var(--transition), background-color var(--transition);
 }
 
 .card-icon svg {
-  width: 100%;
-  height: 100%;
+  width: 24px;
+  height: 24px;
 }
 
 .card:hover .card-icon {
-  transform: scale(1.1);
-  color: var(--color-accent-hover);
+  transform: scale(1.08);
+  background: color-mix(in srgb, currentColor 20%, transparent);
 }
 
 .card h3 {
-  font-size: 20px;
+  font-size: 19px;
   font-weight: 700;
+  letter-spacing: -0.01em;
   color: var(--color-text-emphasis);
   margin-bottom: 10px;
 }
@@ -2437,7 +2519,7 @@ body:has(#main-content) {
   }
 
   .card {
-    padding: 24px;
+    padding: 20px;
   }
 
   .card::after {
@@ -2445,23 +2527,13 @@ body:has(#main-content) {
   }
 
   .card-icon {
-    width: 36px;
-    height: 36px;
-  }
-
-  .card-with-count {
-    flex-wrap: wrap;
+    width: 40px;
+    height: 40px;
   }
 
   .card-with-count .card-icon {
-    width: 32px;
-    height: 32px;
-  }
-
-  .card-count {
-    position: absolute;
-    top: 20px;
-    right: 20px;
+    width: 40px;
+    height: 40px;
   }
 
   .container {
@@ -2984,6 +3056,49 @@ body:has(#main-content) {
   --category-dev-glow: rgba(96, 165, 250, 0.4);
   --category-learn: #F08A3A;
   --category-learn-glow: rgba(240, 138, 58, 0.4);
+
+  /* Accent TEXT tokens — readable on the dark surface (>= 4.5:1). Overridden
+     for light mode below. Used for accent-colored text (headings, links). */
+  --category-ai-text: #C89BFF;
+  --category-docs-text: #F4A876;
+  --category-power-text: #FF6E4E;
+  --category-automation-text: #C898FD;
+  --category-extension-text: #34D399;
+  --category-dev-text: #7CB3FF;
+  --category-learn-text: #F5A25A;
+
+  /* Accent STRONG tokens — fixed saturated fills that carry WHITE text at
+     >= 4.5:1 in BOTH themes (used for pressed filter chips). */
+  --category-ai-strong: #7C3AED;
+  --category-docs-strong: #B45309;
+  --category-power-strong: #C2410C;
+  --category-automation-strong: #7C3AED;
+  --category-extension-strong: #047857;
+  --category-dev-strong: #1D4ED8;
+  --category-learn-strong: #C2410C;
+}
+
+/* Light-mode accent TEXT tokens — darker so they stay >= 4.5:1 on white. */
+[data-theme="light"] {
+  --category-ai-text: #7C3AED;
+  --category-docs-text: #B45309;
+  --category-power-text: #C2410C;
+  --category-automation-text: #7C3AED;
+  --category-extension-text: #047857;
+  --category-dev-text: #1D4ED8;
+  --category-learn-text: #C2410C;
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {
+    --category-ai-text: #7C3AED;
+    --category-docs-text: #B45309;
+    --category-power-text: #C2410C;
+    --category-automation-text: #7C3AED;
+    --category-extension-text: #047857;
+    --category-dev-text: #1D4ED8;
+    --category-learn-text: #C2410C;
+  }
 }
 
 /* Gradient Text for Hero */
@@ -3063,8 +3178,7 @@ html {
 /* Loading state for counts */
 .card-count {
   position: relative;
-  min-width: 40px;
-  text-align: right;
+  text-align: center;
 }
 
 .card-count:empty::before,
@@ -3563,6 +3677,455 @@ header .theme-toggle-container {
 
 [data-theme="light"] .card:hover {
   border-color: rgba(133, 52, 243, 0.2);
+}
+
+/* ============================================
+   LISTING FILTER BAR + REDESIGNED CARDS (rcard)
+   Scoped to new markup; leaves legacy listing pages untouched
+   until the pattern is rolled out.
+   ============================================ */
+
+.filter-bar {
+  --accent-color: var(--color-accent);
+  --accent-text: var(--color-link);
+  --accent-strong: var(--color-accent);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-bottom: 28px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--color-glass-border);
+  position: relative;
+  z-index: 10;
+}
+
+.filter-bar[data-accent='ai'] { --accent-color: var(--category-ai); --accent-text: var(--category-ai-text); --accent-strong: var(--category-ai-strong); }
+.filter-bar[data-accent='docs'] { --accent-color: var(--category-docs); --accent-text: var(--category-docs-text); --accent-strong: var(--category-docs-strong); }
+.filter-bar[data-accent='power'] { --accent-color: var(--category-power); --accent-text: var(--category-power-text); --accent-strong: var(--category-power-strong); }
+.filter-bar[data-accent='automation'] { --accent-color: var(--category-automation); --accent-text: var(--category-automation-text); --accent-strong: var(--category-automation-strong); }
+.filter-bar[data-accent='extension'] { --accent-color: var(--category-extension); --accent-text: var(--category-extension-text); --accent-strong: var(--category-extension-strong); }
+.filter-bar[data-accent='dev'] { --accent-color: var(--category-dev); --accent-text: var(--category-dev-text); --accent-strong: var(--category-dev-strong); }
+.filter-bar[data-accent='learn'] { --accent-color: var(--category-learn); --accent-text: var(--category-learn-text); --accent-strong: var(--category-learn-strong); }
+
+.filter-bar-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.filter-bar-search-icon {
+  position: absolute;
+  left: 16px;
+  color: var(--color-text-muted);
+  pointer-events: none;
+}
+
+.filter-bar-input {
+  width: 100%;
+  padding: 13px 16px 13px 44px;
+  font-size: 15px;
+  font-family: inherit;
+  color: var(--color-text-emphasis);
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.filter-bar-input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.filter-bar-input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-color) 30%, transparent);
+}
+
+.filter-bar-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.facet-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.facet-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--color-text);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color var(--transition), background var(--transition), border-color var(--transition);
+}
+
+.facet-chip:hover {
+  color: var(--color-text-emphasis);
+  border-color: color-mix(in srgb, var(--accent-color) 55%, var(--color-border));
+  background: color-mix(in srgb, var(--accent-color) 8%, transparent);
+}
+
+.facet-chip[aria-pressed='true'] {
+  color: #ffffff;
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
+}
+
+.facet-chip:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.filter-bar-sort select {
+  padding: 8px 12px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--color-text-emphasis);
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.filter-bar-sort select:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.filter-bar-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.filter-bar .results-count {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+
+.filter-bar-clear {
+  padding: 4px 10px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--accent-text);
+  background: transparent;
+  border: 0;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  transition: background var(--transition);
+}
+
+.filter-bar-clear:hover {
+  background: color-mix(in srgb, var(--accent-color) 14%, transparent);
+}
+
+.filter-bar-clear:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+/* --- Redesigned card grid --- */
+.resource-list.rcard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+  align-items: stretch;
+}
+
+.rcard.resource-item {
+  --card-accent: var(--color-accent);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 13px;
+  padding: 20px;
+  height: 100%;
+  cursor: pointer;
+  overflow: hidden;
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--border-radius-lg);
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.rcard[data-accent='ai'] { --card-accent: var(--category-ai); }
+.rcard[data-accent='docs'] { --card-accent: var(--category-docs); }
+.rcard[data-accent='power'] { --card-accent: var(--category-power); }
+.rcard[data-accent='automation'] { --card-accent: var(--category-automation); }
+.rcard[data-accent='extension'] { --card-accent: var(--category-extension); }
+.rcard[data-accent='dev'] { --card-accent: var(--category-dev); }
+.rcard[data-accent='learn'] { --card-accent: var(--category-learn); }
+
+/* Top accent hairline (replaces inherited left bar). */
+.rcard.resource-item::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, var(--card-accent), transparent 70%);
+  opacity: 0.65;
+  transition: opacity var(--transition);
+}
+
+.rcard.resource-item:hover,
+.rcard.resource-item:focus-within {
+  transform: translateY(-4px);
+  border-color: color-mix(in srgb, var(--card-accent) 45%, var(--color-glass-border));
+  box-shadow: var(--shadow-lg), 0 0 42px -16px color-mix(in srgb, var(--card-accent) 70%, transparent);
+}
+
+.rcard.resource-item:hover::before,
+.rcard.resource-item:focus-within::before {
+  opacity: 1;
+}
+
+.rcard-preview {
+  display: flex;
+  align-items: flex-start;
+  gap: 13px;
+  flex: 0 0 auto;
+  width: 100%;
+  padding: 0;
+  background: none;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.rcard-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  flex: none;
+  border-radius: 11px;
+  color: var(--card-accent);
+  background: linear-gradient(140deg, color-mix(in srgb, var(--card-accent) 22%, transparent), color-mix(in srgb, var(--card-accent) 7%, transparent));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--card-accent) 30%, transparent);
+  transition: transform var(--transition);
+}
+
+.rcard.resource-item:hover .rcard-icon,
+.rcard.resource-item:focus-within .rcard-icon {
+  transform: scale(1.06);
+}
+
+/* Thumbnail media tile (extensions) — same footprint as the icon tile. */
+.rcard-media {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  flex: none;
+  border-radius: 11px;
+  overflow: hidden;
+  color: var(--card-accent);
+  background: linear-gradient(140deg, color-mix(in srgb, var(--card-accent) 22%, transparent), color-mix(in srgb, var(--card-accent) 7%, transparent));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--card-accent) 30%, transparent);
+  transition: transform var(--transition);
+}
+
+.rcard-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.rcard.resource-item:hover .rcard-media,
+.rcard.resource-item:focus-within .rcard-media {
+  transform: scale(1.06);
+}
+
+.rcard-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.rcard-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.rcard-title {
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: var(--color-text-emphasis);
+}
+
+.rcard-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1.65;
+  color: var(--color-text-emphasis);
+  background: color-mix(in srgb, var(--card-accent) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--card-accent) 28%, transparent);
+  border-radius: 6px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rcard-badge-mono {
+  font-size: 10.5px;
+  font-family: ui-monospace, "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", monospace;
+}
+
+.rcard-badge-more {
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.rcard-desc {
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--color-text-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.rcard-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  margin-top: 2px;
+}
+
+.rcard-fact {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+
+.rcard-fact svg {
+  color: var(--card-accent);
+  flex: none;
+}
+
+.rcard-updated {
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+}
+
+.rcard-updated .last-updated {
+  color: inherit;
+}
+
+.rcard-actions {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 7px;
+  margin-top: auto;
+  padding-top: 14px;
+  border-top: 1px solid var(--color-glass-border);
+}
+
+.rcard-actions .install-dropdown-small {
+  flex: 0 0 auto;
+}
+
+/* Secondary actions become quiet icon buttons, pushed to the right. */
+.rcard-actions .action-download,
+.rcard-actions .rcard-lead {
+  margin-left: auto;
+}
+
+.rcard-actions .action-download,
+.rcard-actions .action-share,
+.rcard-actions .action-github,
+.rcard-actions .rcard-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  min-width: 0;
+  padding: 0;
+  color: var(--color-text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  transition: color var(--transition), background var(--transition), border-color var(--transition);
+}
+
+.rcard-actions .action-download:hover,
+.rcard-actions .action-share:hover,
+.rcard-actions .action-github:hover,
+.rcard-actions .rcard-icon-btn:hover {
+  color: var(--card-accent);
+  background: color-mix(in srgb, var(--card-accent) 12%, transparent);
+  border-color: color-mix(in srgb, var(--card-accent) 28%, transparent);
+}
+
+@media (max-width: 768px) {
+  .resource-list.rcard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .filter-bar-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filter-bar-sort,
+  .filter-bar-sort select {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rcard.resource-item:hover,
+  .rcard.resource-item:focus-within {
+    transform: none;
+  }
+  .rcard.resource-item:hover .rcard-icon,
+  .rcard.resource-item:focus-within .rcard-icon {
+    transform: none;
+  }
 }
 
 /* Print styles */

--- a/website/src/styles/starlight-overrides.css
+++ b/website/src/styles/starlight-overrides.css
@@ -11,7 +11,7 @@
   --sl-color-white: #f0f0f5;
   --sl-color-gray-1: #d0d0da;
   --sl-color-gray-2: #9898a6;
-  --sl-color-gray-3: #60607a;
+  --sl-color-gray-3: #84849c;
   --sl-color-gray-4: #30304a;
   --sl-color-gray-5: #1a1a2e;
   --sl-color-gray-6: #0d0d12;

--- a/website/src/styles/starlight-overrides.css
+++ b/website/src/styles/starlight-overrides.css
@@ -88,17 +88,61 @@ header.header .header-actions {
   gap: 12px;
 }
 
-/* Hide social icons in header - GitHub link moved to hero */
+/* GitHub link — sits far-right in the header action cluster */
 header .social-icons {
+  display: flex !important;
+  align-items: center;
+  gap: 4px;
+}
+header .social-icons a {
+  color: var(--sl-color-gray-2);
+  padding: 8px;
+  border-radius: 999px;
+  line-height: 0;
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease;
+}
+header .social-icons a:hover {
+  color: var(--sl-color-white);
+  background: var(--sl-color-gray-5);
+}
+header .social-icons svg {
+  width: 20px;
+  height: 20px;
+}
+/* Starlight draws a divider after social icons to separate the theme
+   dropdown; that dropdown is hidden here, so drop the dangling line. */
+header .social-icons::after {
   display: none !important;
 }
 
-/* Move theme toggle inside header - align with header elements */
+/* Single-icon theme toggle rides in the header flow, left of GitHub */
 .theme-toggle-container {
-  position: fixed !important;
-  top: 12px !important;
-  right: 80px !important;
+  position: static !important;
+  display: flex !important;
+  align-items: center;
   z-index: 1001;
+}
+
+/* Keep the action cluster (theme toggle + GitHub) visible on every
+   viewport — Starlight hides it below `md` by default, but this site
+   surfaces those controls in the header on mobile too. */
+header .right-group {
+  display: flex !important;
+  align-items: center;
+  gap: 4px;
+}
+
+@media (max-width: 50rem) {
+  /* Free up room so the long site title isn't truncated on phones. */
+  .site-title {
+    font-size: var(--sl-text-lg) !important;
+  }
+  header.header .header,
+  header.header {
+    gap: 8px;
+  }
 }
 
 /* On custom splash pages, body already has the gradient bg.


### PR DESCRIPTION
## Summary

Redesigns the Awesome GitHub Copilot website UX with a modern, cohesive dark-tech language while preserving IA, routes, and copy voice.

> [!NOTE]
> This PR **stacks on #2180** (WCAG a11y remediation). Until #2180 merges into `main`, this PR's diff also shows those two a11y commits. Once #2180 lands, this collapses to the single UX commit. The UX work is built on top of the a11y base, so it merges cleanly.

## What changed

**Header & theme**
- Replaced the hero "View the Awesome Copilot repository on GitHub" text link with a far-right GitHub mark in the top nav.
- Converted the 3-state theme pill into a single cycling icon toggle; the a11y label reflects the active state.
- Fixed mobile nav cramping and title clipping.

**Landing**
- Recomposed the hero and category cards; fixed the mobile card-count overlap and added the missing category accent bar.

**Listing pages** (agents, instructions, skills, hooks, workflows, plugins, tools, extensions)
- Added a shared resource-card renderer (`resource-card.ts`) and a generic listing controller (`listing-controller.ts`) so every page uses one card system and one real, always-visible filter bar (search + sort + facet chips) in place of the broken `<details>` toggle.
- Gave each page a purpose-built identity: category accent, type icon, and per-type facts (model/tools for agents, author/keywords with icon thumbnails for extensions, features for tools, and so on).
- Headings now use the landing category accent colors.

## Verification
- `astro build` passes (38 pages).
- Accessibility audit (`npm run a11y`) passes: 12 routes x 2 themes, 0 critical/serious violations.
- Manually checked desktop + mobile, dark + light across all listing pages, landing, learning-hub, and contributors.

## Rev notes
- No route, slug, or nav-label changes. Social-card invariants and editLink untouched.
