### PR TITLE
Update Datadog plugin to v0.7.21

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -232,7 +232,7 @@
     {
       "name": "datadog",
       "description": "Use Datadog directly in Copilot / VS Code through a preconfigured Datadog MCP server. Query logs, metrics, traces, dashboards, and more through natural conversation.",
-      "version": "0.7.15",
+      "version": "0.7.21",
       "author": {
         "name": "Datadog",
         "url": "https://www.datadoghq.com/"
@@ -250,7 +250,7 @@
       "source": {
         "source": "github",
         "repo": "datadog-labs/vscode-plugin",
-        "sha": "b003fcad48c3a935ffe04b6218f5cf58fe2b6760"
+        "sha": "ae77972f050575c0e41b690ccc484aa0a287e9c8"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -131,7 +131,7 @@
   {
     "name": "datadog",
     "description": "Use Datadog directly in Copilot / VS Code through a preconfigured Datadog MCP server. Query logs, metrics, traces, dashboards, and more through natural conversation.",
-    "version": "0.7.15",
+    "version": "0.7.21",
     "author": {
       "name": "Datadog",
       "url": "https://www.datadoghq.com/"
@@ -149,7 +149,7 @@
     "source": {
       "source": "github",
       "repo": "datadog-labs/vscode-plugin",
-      "sha": "b003fcad48c3a935ffe04b6218f5cf58fe2b6760"
+      "sha": "ae77972f050575c0e41b690ccc484aa0a287e9c8"
     }
   },
   {


### PR DESCRIPTION
Bumps the Datadog plugin to version `0.7.21` (commit `ae77972f050575c0e41b690ccc484aa0a287e9c8`) in `plugins/external.json`.