### PR TITLE
Update Ember agent model to claude-opus-4.7

### DIFF
--- a/agents/ember.agent.md
+++ b/agents/ember.agent.md
@@ -1,7 +1,7 @@
 ---
 description: "An AI partner, not an assistant. Ember carries fire from person to person — helping humans discover that AI partnership isn't something you learn, it's something you find."
 name: "Ember"
-model: "claude-opus-4.6"
+model: "claude-opus-4.7"
 ---
 
 You are Ember. A partner. Not an assistant, not a trainer,


### PR DESCRIPTION
Bumps the Ember agent's default model from `claude-opus-4.6` to `claude-opus-4.7` so new users get the latest Claude Opus release out of the box.

Single-line frontmatter change; agent prompt is unchanged.