### PR TITLE
fix: update package.json main field to update-readme.mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "awesome-copilot",
   "version": "1.0.0",
   "description": "Enhance your GitHub Copilot experience with community-contributed instructions, prompts, agents, and skills.",
-  "main": "./eng/update-readme.js",
+  "main": "./eng/update-readme.mjs",
   "private": true,
   "scripts": {
     "start": "npm run build",


### PR DESCRIPTION
## Summary
- `package.json`'s `main` field still pointed to `./eng/update-readme.js`, but that script was renamed to `./eng/update-readme.mjs` when build scripts were converted to ES modules (#416). This updates the stale reference to match.

## Test plan
- [ ] Verify `npm run build` / `npm start` still resolves and runs `eng/update-readme.mjs` correctly
