### PR TITLE
Update assertion-map.md for Should-Not-Throw syntax

### DIFF
--- a/skills/pester-should-migration/references/assertion-map.md
+++ b/skills/pester-should-migration/references/assertion-map.md
@@ -124,7 +124,7 @@ New combinator assertions have no v5 equivalent but are handy in migrations:
 | `{ ... } \| Should -Throw 'msg'` | `{ ... } \| Should-Throw -ExceptionMessage 'msg'` | Param **renamed** from `-ExpectedMessage`. `-like` wildcards supported. |
 | `{ ... } \| Should -Throw -ErrorId 'X'` | `{ ... } \| Should-Throw -FullyQualifiedErrorId 'X'` | Param **renamed**. |
 | `{ ... } \| Should -Throw -ExceptionType ([T])` | `{ ... } \| Should-Throw -ExceptionType ([T])` | Same. |
-| `{ ... } \| Should -Not -Throw` | `{ ... }; <no throw assertion needed>` | There is no `Should-NotThrow`; a script block that must not throw simply runs. Assert on its result instead, or keep the classic `Should -Not -Throw`. |
+| `{ ... } \| Should -Not -Throw` | `& { ... }; <no throw assertion needed>` | There is no `Should-NotThrow`; a script block that must not throw simply runs. Assert on its result instead, or keep the classic `Should -Not -Throw`. |
 
 `Should-Throw` adds `-AllowNonTerminatingError` and returns the error record for
 further assertions: `$err = { throw 'boom' } | Should-Throw; $err.Exception.Message | Should-BeString '*boom*'`.


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `main` branch for this pull request.

---

## Description

<!-- Briefly describe your contribution and its purpose. Include any relevant context or usage notes. -->
Fixing the invocation of the code when `Should -Not -Throw` is replaced with just scriptblock, to make sure the replacement scriptblock executes rather then just outputs its content.
---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
