### PR TITLE
Reduce risk scan false positives for version checks

### DIFF
--- a/eng/pr-risk-scan.mjs
+++ b/eng/pr-risk-scan.mjs
@@ -57,9 +57,18 @@ function hasUnpinnedVersionIndicator(line) {
     return true;
   }
 
-  // pyproject/requirements style entries with broad lower-bound only specs.
+  // Python package install commands with broad lower-bound only specs.
   if (
-    /\b[A-Za-z0-9_.-]+\s*(>=|>|~=)\s*\d+(?:\.\d+){0,2}\b(?!\s*,\s*<)/.test(
+    /\b(?:pip|pip3|uv|uvx|poetry|pdm)\s+install\b[^\n#]*\b[a-z0-9][a-z0-9_.-]*(?:\[[A-Za-z0-9_,.-]+\])?\s*(>=|>|~=)\s*\d+(?:\.\d+){0,2}\b(?!\s*,\s*<)/i.test(
+      trimmed
+    )
+  ) {
+    return true;
+  }
+
+  // requirements/constraints style entries that contain only a dependency spec.
+  if (
+    /^\s*(?:-\s*)?(?:["'])?[a-z0-9][a-z0-9_.-]*(?:\[[A-Za-z0-9_,.-]+\])?(?:["'])?\s*(>=|>|~=)\s*\d+(?:\.\d+){0,2}\b(?!\s*,\s*<)(?:\s*(?:#.*)?)?$/.test(
       trimmed
     )
   ) {


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `main` branch for this pull request.

---

## Description

The PR risk scan was reporting `unpinned-version-indicator` findings for ordinary comparisons and prose, such as `if (errors.length > 0)` and `>50 lines`. This change narrows that matcher so it still scans whole files, but only flags dependency-shaped version specs instead of any `name > number` pattern.

The updated logic keeps the existing JavaScript/package range detection, and limits the Python-style checks to dependency-only requirement entries and explicit install command contexts like `pip install requests>2`.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

## Additional Notes

Validated with `npm run build`, `npm run plugin:validate`, `npm run skill:validate`, and `bash eng/fix-line-endings.sh` after updating the matcher.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.