### PR TITLE
Fix external plugin quality gate paths and diagnostics

### DIFF
--- a/.github/workflows/external-plugin-pr-quality-gates.yml
+++ b/.github/workflows/external-plugin-pr-quality-gates.yml
@@ -200,6 +200,18 @@ jobs:
               : qualityResult.overall_status === 'pass' || !shouldRun
                 ? '## ✅ External plugin PR checks passed'
                 : '## ⚠️ External plugin PR checks need maintainer follow-up';
+            const formatGateOutput = (pluginName, gateName, gateStatus, rawOutput) => {
+              const output = String(rawOutput || '').trim() || '_No output captured._';
+              return [
+                '<details>',
+                `<summary>${pluginName} — ${gateName} (${gateStatus || 'not_run'})</summary>`,
+                '',
+                '```text',
+                output,
+                '```',
+                '</details>',
+              ].join('\n');
+            };
 
             const rows = checkedPlugins.length > 0
               ? checkedPlugins.map((entry) => {
@@ -211,6 +223,21 @@ jobs:
                   return `| ${name} | ${quality.vally_lint_status || 'not_run'} | ${quality.smoke_status || 'not_run'} | ${quality.overall_status || 'not_run'} | ${sourceCell} |`;
                 })
               : ['| _none_ | not_run | not_run | not_run | _n/a_ |'];
+            const failureDetails = checkedPlugins.flatMap((entry) => {
+              const name = String(entry?.name || 'unknown');
+              const quality = entry?.quality || {};
+              const shouldShowVally = quality.vally_lint_status === 'fail' || quality.vally_lint_status === 'infra_error' || String(quality.vally_lint_output || '').trim().length > 0;
+              const shouldShowSmoke = quality.smoke_status === 'fail' || quality.smoke_status === 'infra_error' || String(quality.smoke_output || '').trim().length > 0;
+
+              const details = [];
+              if (shouldShowVally) {
+                details.push(formatGateOutput(name, 'vally lint', quality.vally_lint_status, quality.vally_lint_output));
+              }
+              if (shouldShowSmoke) {
+                details.push(formatGateOutput(name, 'install smoke test', quality.smoke_status, quality.smoke_output));
+              }
+              return details;
+            });
 
             const body = [
               marker,
@@ -225,6 +252,14 @@ jobs:
               '|---|---|---|---|---|',
               ...rows,
               '',
+              ...(failureDetails.length > 0
+                ? [
+                    '### Gate output details',
+                    '',
+                    ...failureDetails,
+                    '',
+                  ]
+                : []),
               String(qualityResult.summary || '').trim() || '_No summary provided._',
             ].join('\n');
 

--- a/eng/external-plugin-quality-gates.mjs
+++ b/eng/external-plugin-quality-gates.mjs
@@ -140,7 +140,7 @@ function cloneSubmissionRepository(workDir, plugin) {
 // NOTE: Keep in sync with EXTERNAL_PLUGIN_ROOT_MANIFEST_PATHS in external-plugin-validation.mjs
 const PLUGIN_JSON_CANDIDATES = [
   [".github", "plugin", "plugin.json"],
-  [".plugins", "plugin.json"],
+  [".plugin", "plugin.json"],
   ["plugin.json"],
 ];
 

--- a/eng/external-plugin-validation.mjs
+++ b/eng/external-plugin-validation.mjs
@@ -27,7 +27,7 @@ export const EXTERNAL_PLUGIN_POLICIES = Object.freeze({
 const EXTERNAL_PLUGIN_ROOT_MANIFEST_PATHS = Object.freeze([
   "plugin.json",
   ".github/plugin/plugin.json",
-  ".plugins/plugin.json",
+  ".plugin/plugin.json",
 ]);
 
 function resolvePolicy(policy) {


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `main` branch for this pull request.

---

## Description

PR #2260 exposed two gaps in external plugin quality gates: plugin manifest resolution accepted an incorrect `.plugins/plugin.json` path and PR comments did not surface failure output clearly. This change fixes both so vercel-plugin style submissions resolve the plugin root manifest correctly and reviewers can immediately see vally and smoke failure details.

The quality gate manifest candidates are now aligned across `eng/external-plugin-quality-gates.mjs` and `eng/external-plugin-validation.mjs` using `.plugin/plugin.json` (singular). The PR quality workflow comment renderer now appends a `Gate output details` section with collapsible `<details>` blocks per plugin/gate, includes vally and smoke output when present, and shows `_No output captured._` for empty output.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

## Additional Notes

Validated with:
- `npm run build`
- `npm run plugin:validate`
- `npm run skill:validate`
- targeted execution of `runExternalPluginPrQualityGates` to confirm payload/comment include gate outputs

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.