### PR TITLE
Harden external plugin gate comment output safety

### DIFF
--- a/.github/workflows/external-plugin-pr-quality-gates.yml
+++ b/.github/workflows/external-plugin-pr-quality-gates.yml
@@ -200,15 +200,36 @@ jobs:
               : qualityResult.overall_status === 'pass' || !shouldRun
                 ? '## ✅ External plugin PR checks passed'
                 : '## ⚠️ External plugin PR checks need maintainer follow-up';
+            const MAX_GATE_OUTPUT_CHARS = 2000;
+            const escapeHtml = (value) =>
+              String(value || '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+            const truncateGateOutput = (rawOutput) => {
+              const normalized = String(rawOutput || '').trim();
+              if (!normalized) {
+                return '_No output captured._';
+              }
+              if (normalized.length <= MAX_GATE_OUTPUT_CHARS) {
+                return normalized;
+              }
+              return `${normalized.slice(0, MAX_GATE_OUTPUT_CHARS)}\n...output truncated...`;
+            };
             const formatGateOutput = (pluginName, gateName, gateStatus, rawOutput) => {
-              const output = String(rawOutput || '').trim() || '_No output captured._';
+              const summaryPluginName = escapeHtml(String(pluginName || 'unknown'));
+              const summaryGateName = escapeHtml(String(gateName || 'gate'));
+              const summaryGateStatus = escapeHtml(String(gateStatus || 'not_run'));
+              const output = escapeHtml(truncateGateOutput(rawOutput));
               return [
                 '<details>',
-                `<summary>${pluginName} — ${gateName} (${gateStatus || 'not_run'})</summary>`,
+                `<summary>${summaryPluginName} - ${summaryGateName} (${summaryGateStatus})</summary>`,
                 '',
-                '```text',
+                '<pre><code>',
                 output,
-                '```',
+                '</code></pre>',
                 '</details>',
               ].join('\n');
             };

--- a/.github/workflows/external-plugin-pr-quality-gates.yml
+++ b/.github/workflows/external-plugin-pr-quality-gates.yml
@@ -208,21 +208,22 @@ jobs:
                 .replace(/>/g, '&gt;')
                 .replace(/"/g, '&quot;')
                 .replace(/'/g, '&#39;');
+            const TRUNCATED_OUTPUT_MARKER = '\n...output truncated...';
             const truncateGateOutput = (rawOutput) => {
-              const normalized = String(rawOutput || '').trim();
+              const normalized = escapeHtml(String(rawOutput || '').trim());
               if (!normalized) {
                 return '_No output captured._';
               }
               if (normalized.length <= MAX_GATE_OUTPUT_CHARS) {
                 return normalized;
               }
-              return `${normalized.slice(0, MAX_GATE_OUTPUT_CHARS)}\n...output truncated...`;
+              return `${normalized.slice(0, Math.max(0, MAX_GATE_OUTPUT_CHARS - TRUNCATED_OUTPUT_MARKER.length))}${TRUNCATED_OUTPUT_MARKER}`;
             };
             const formatGateOutput = (pluginName, gateName, gateStatus, rawOutput) => {
               const summaryPluginName = escapeHtml(String(pluginName || 'unknown'));
               const summaryGateName = escapeHtml(String(gateName || 'gate'));
               const summaryGateStatus = escapeHtml(String(gateStatus || 'not_run'));
-              const output = escapeHtml(truncateGateOutput(rawOutput));
+              const output = truncateGateOutput(rawOutput);
               return [
                 '<details>',
                 `<summary>${summaryPluginName} - ${summaryGateName} (${summaryGateStatus})</summary>`,


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `main` branch for this pull request.

---

## Description

This follow-up hardens external plugin PR quality comment rendering to avoid malformed comments and oversized payload failures when plugin names or gate output contain unsafe characters or very large content.

The workflow now escapes HTML for summary and output content, renders gate details with `<pre><code>` blocks instead of fenced backticks, and truncates gate output to a bounded length with an explicit truncation marker.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

## Additional Notes

Scope is intentionally narrow: only `.github/workflows/external-plugin-pr-quality-gates.yml` was updated.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.