### PR TITLE
Fix label line-height in image-annotations skill (getbbox bottom-top)

### DIFF
--- a/skills/image-annotations/SKILL.md
+++ b/skills/image-annotations/SKILL.md
@@ -416,7 +416,8 @@ def annotate_image(image_path, annotations, *,
         cyan = (eb[0] - em_pad, eb[1] - em_pad, eb[2] + em_pad, eb[3] + em_pad)
         lines = spec['label'].split('\n')
         tw = max(font.getbbox(line)[2] - font.getbbox(line)[0] for line in lines)
-        line_h = font.getbbox('Ay')[3] - font.getbbox('Ay')[0]
+        bbox = font.getbbox('Ay')
+        line_h = bbox[3] - bbox[1]
         th = line_h * len(lines) + 4 * (len(lines) - 1)
         pw, ph = tw + 2 * TEXT_PAD, th + 2 * TEXT_PAD
         cands = _find_candidates(pixels, W, H, cyan, pw, ph, font)


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968). (N/A — no paid services.)
- [x] My contribution updates an existing skill file.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my change (see Validation below).
- [x] I have run and verified `README.md` is up to date. (No README change — this is a code-logic fix inside an existing skill; no frontmatter/titles changed.)
- [x] I am targeting the `main` branch for this pull request.

---

## Description

Fixes a small line-height bug in the `annotate.py` module embedded in `skills/image-annotations/SKILL.md`.

`ImageFont.getbbox()` returns `(left, top, right, bottom)`. Text **height** must therefore be `bottom - top` = `bbox[3] - bbox[1]`. The automatic label-placement code computed it as `bbox[3] - bbox[0]` (`bottom - left`), which mixes an **x**-coordinate into a **height**:

```python
# Before
line_h = font.getbbox('Ay')[3] - font.getbbox('Ay')[0]

# After
bbox = font.getbbox('Ay')
line_h = bbox[3] - bbox[1]
```

**Why it matters:** `line_h` feeds the label-box height (`th`), so the black label background is sized slightly wrong. The error equals the glyph's top bearing — empirically **0–4px** depending on font (≈4px Consolas, ≈2px Pillow default, ≈1px Ink Free @32). It's most visible on multi-line labels where the error accumulates per line.

The debug heatmap labeling a few lines down in the **same module** already uses the correct `bbox[3] - bbox[1]`, so this simply brings label placement in line with the rest of the file.

Found while vendoring this skill into another repo.

---

## Type of Contribution

- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.

---

## Additional Notes

**Validation:**
- Extracted the module code block and confirmed it compiles (`python -m py_compile`).
- Ran `annotate_image()` end-to-end on a 2326×1486 screenshot with both single-line and multi-line labels — output renders correctly with correctly-sized label backgrounds.
- Diff is 1 line changed (2 insertions, 1 deletion).
