### PR TITLE
Update modernize-dotnet plugin to 1.0.1161-preview1

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -638,7 +638,7 @@
     {
       "name": "modernize-dotnet",
       "description": "AI-powered .NET modernization and upgrade assistant. Helps upgrade .NET Framework and .NET applications to the latest versions of .NET.",
-      "version": "1.0.1157-preview1",
+      "version": "1.0.1161-preview1",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -655,7 +655,8 @@
       "source": {
         "source": "github",
         "repo": "dotnet/modernize-dotnet",
-        "path": "plugins/modernize-dotnet"
+        "path": "plugins/modernize-dotnet",
+        "sha": "ce4ec09678498da38099ca9169c1624c59c2a89a"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -447,7 +447,7 @@
   {
     "name": "modernize-dotnet",
     "description": "AI-powered .NET modernization and upgrade assistant. Helps upgrade .NET Framework and .NET applications to the latest versions of .NET.",
-    "version": "1.0.1157-preview1",
+    "version": "1.0.1161-preview1",
     "author": {
       "name": "Microsoft",
       "url": "https://www.microsoft.com"
@@ -464,7 +464,8 @@
     "source": {
       "source": "github",
       "repo": "dotnet/modernize-dotnet",
-      "path": "plugins/modernize-dotnet"
+      "path": "plugins/modernize-dotnet",
+      "sha": "ce4ec09678498da38099ca9169c1624c59c2a89a"
     }
   },
   {


### PR DESCRIPTION
Automated update of modernize-dotnet plugin registry entry from UpgradeAssistant build main-20260715.2 (14667856) (version 1.0.1161-preview1).

The plugin source is pinned to the merge commit of dotnet/modernize-dotnet#1723 (`ce4ec09678498da38099ca9169c1624c59c2a89a`).

<sub><em><img src="https://raw.githubusercontent.com/tlmii/tlmii/main/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;">&nbsp;&nbsp;Generated via Copilot (Claude Opus 4.8) on behalf of @tlmii</em></sub>