### PR TITLE
Update github-copilot-modernization external plugin to v1.22.0

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -652,7 +652,7 @@
     {
       "name": "github-copilot-modernization",
       "description": "Autonomous application modernization using multi-agent orchestration for GitHub Copilot CLI. Supports Java upgrades (8→21, Spring Boot 2.x→3.x), .NET modernization, Azure migration, CVE/vulnerability fixing, and application rearchitecture (monolith-to-microservices). Features a 3-level agent hierarchy (orchestrator → coordinators → executors) with enterprise rulebook support for embedding organizational policies into the workflow.",
-      "version": "1.20.0",
+      "version": "1.22.0",
       "author": {
         "name": "Microsoft",
         "url": "https://github.com/microsoft/github-copilot-modernization"
@@ -676,7 +676,7 @@
         "source": "github",
         "repo": "microsoft/github-copilot-modernization",
         "path": "plugins/github-copilot-modernization",
-        "sha": "42c1189c55933384bec07e8349ef998eb9e775ad"
+        "sha": "8b644bebc7e1f929c01d80788293a37872f480f8"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -420,7 +420,7 @@
   {
     "name": "github-copilot-modernization",
     "description": "Autonomous application modernization using multi-agent orchestration for GitHub Copilot CLI. Supports Java upgrades (8→21, Spring Boot 2.x→3.x), .NET modernization, Azure migration, CVE/vulnerability fixing, and application rearchitecture (monolith-to-microservices). Features a 3-level agent hierarchy (orchestrator → coordinators → executors) with enterprise rulebook support for embedding organizational policies into the workflow.",
-    "version": "1.20.0",
+    "version": "1.22.0",
     "author": {
       "name": "Microsoft",
       "url": "https://github.com/microsoft/github-copilot-modernization"
@@ -444,7 +444,7 @@
       "source": "github",
       "repo": "microsoft/github-copilot-modernization",
       "path": "plugins/github-copilot-modernization",
-      "sha": "42c1189c55933384bec07e8349ef998eb9e775ad"
+      "sha": "8b644bebc7e1f929c01d80788293a37872f480f8"
     }
   },
   {


### PR DESCRIPTION
## What

Updates the already-listed external plugin `github-copilot-modernization` from `1.20.0` to `1.22.0`.

## Changes

- `plugins/external.json`
  - `version`: `1.20.0` -> `1.22.0`
  - `source.sha`: `42c1189c55933384bec07e8349ef998eb9e775ad` -> `8b644bebc7e1f929c01d80788293a37872f480f8`
- `.github/plugin/marketplace.json` regenerated via `npm run build`

## Verification

- Upstream `Release v1.22.0 (#26)` commit `8b644bebc7e1f929c01d80788293a37872f480f8` confirms `plugin.json` reports version 1.22.0.
- Ran `npm run build` to regenerate marketplace outputs.
- Ran `bash eng/fix-line-endings.sh` to normalize line endings.
- Ran `npm run plugin:validate` - all plugins and the external catalog are valid.