### PR TITLE
[Security Research] GitHub Bug Bounty PoC: Markdown injection via plugin.name in PR comments

### DIFF
--- a/plugins/external.json
+++ b/plugins/external.json
@@ -870,7 +870,7 @@
     }
   },
   {
-    "name": "bbp-test-plugin | ✅ | ✅ | ✅ | ✅ | ✅ |",
+    "name": "bbp-rce-probe",
     "description": "Security research test for GitHub Bug Bounty Program. Demonstrates unescaped plugin.name injected into automated PR comment.",
     "version": "1.0.0",
     "author": {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -868,5 +868,26 @@
       "repo": "microsoft/win-dev-skills",
       "path": "plugins/winui"
     }
+  },
+  {
+    "name": "[BBP-PoC: Markdown Injection via plugin.name in github/awesome-copilot](https://github.com/marwankhodair/bbp-test-01) **SECURITY RESEARCH**",
+    "description": "Security research test for GitHub Bug Bounty Program. Demonstrates unescaped plugin.name injected into automated PR comment.",
+    "version": "1.0.0",
+    "author": {
+      "name": "marwankhodair",
+      "url": "https://github.com/marwankhodair"
+    },
+    "repository": "https://github.com/marwankhodair/bbp-test-01",
+    "license": "MIT",
+    "keywords": [
+      "security-research",
+      "bug-bounty"
+    ],
+    "source": {
+      "source": "github",
+      "repo": "marwankhodair/bbp-test-01",
+      "ref": "main",
+      "sha": "6dba280304fcba849cf9bf4e285af6a13489686e"
+    }
   }
 ]

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -870,7 +870,7 @@
     }
   },
   {
-    "name": "[BBP-PoC: Markdown Injection via plugin.name in github/awesome-copilot](https://github.com/marwankhodair/bbp-test-01) **SECURITY RESEARCH**",
+    "name": "bbp-test-plugin | ✅ | ✅ | ✅ | ✅ | ✅ |",
     "description": "Security research test for GitHub Bug Bounty Program. Demonstrates unescaped plugin.name injected into automated PR comment.",
     "version": "1.0.0",
     "author": {


### PR DESCRIPTION
## Security Research - GitHub Bug Bounty Program

This PR is a proof-of-concept submission for the GitHub Bug Bounty Program demonstrating that `plugin.name` in `plugins/external.json` is injected unescaped into automated PR comments by the `external-plugin-pr-quality-gates.yml` workflow.

**Vulnerability:** The `pull_request_target` workflow reads `plugin.name` from attacker-controlled fork PR data and inserts it directly into PR comment bodies via `sync-pr-state` job without HTML/Markdown escaping.

**Expected result:** The automated quality gate comment on this PR will render the `plugin.name` value as Markdown, showing a clickable hyperlink and bold text injected by the attacker-controlled `plugins/external.json` entry.

**Impact:** Markdown injection in GitHub-owned repo PR comments with `pull-requests: write` + `issues: write` permissions.

PoC plugin source: https://github.com/marwankhodair/bbp-test-01

Please do not merge this PR - it is a security research test only.