### PR TITLE
Fix Node.js setup action version in skill quality report workflow

### DIFF
--- a/.github/workflows/skill-quality-report.yml
+++ b/.github/workflows/skill-quality-report.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0 # full history for git-log author fallback
 
       - name: Setup Node.js
-        uses: actions/setup-node@3235b876344febd2b5f2414c5edc3a01b7f10a06 # v4.2.0
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 20
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [x] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory. **N/A**
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `main` branch for this pull request.

---

## Description

The nightly quality scan appears to have been failing since July 30th due to an incorrect pinned version sha.  This PR swaps that sha out for the correct `setup-node` action for v4.2.0
---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

## Additional Notes

Very small change

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
