### PR TITLE
Add UIZZE Copilot MCP handoff

### DIFF
--- a/plugins/uizze/README.md
+++ b/plugins/uizze/README.md
@@ -27,6 +27,8 @@ The skill remains usable when catalogue browsing is unavailable: it can work fro
 
 - No account, credential, token, or external server is required.
 - No MCP server is bundled with this plugin.
+
+For direct catalogue search, visual audits, and screenshot critique inside your agent, connect the full [UIZZE MCP](https://uizze.com/github-copilot).
 - The skill is MIT licensed and useful on its own.
 
 UIZZE maintains the public catalogue referenced by the skill.


### PR DESCRIPTION
## What changed

Adds one optional full-MCP handoff to the already-merged UIZZE Copilot plugin README.

The free public-catalogue skill remains accountless and useful on its own. The new link is only for developers who need direct catalogue search, visual audits, and screenshot critique inside their agent.

## Why

The official plugin is live. This gives its high-intent users a clean UIZZE path for the optional in-agent workflow without adding credentials, tracking parameters, or pricing copy.