### PR TITLE
fix: exclude auto-generated README files from PR risk scan

### DIFF
--- a/.github/workflows/pr-risk-scan.yml
+++ b/.github/workflows/pr-risk-scan.yml
@@ -26,7 +26,9 @@ jobs:
 
       - name: Collect changed files
         run: |
-          git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" > changed-files.txt
+          git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" \
+            | grep -v -E '^(README\.md|docs/README\.[^/]+\.md)$' \
+            > changed-files.txt
           echo "Changed files:"
           cat changed-files.txt || true
 

--- a/.github/workflows/pr-risk-scan.yml
+++ b/.github/workflows/pr-risk-scan.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Collect changed files
         run: |
           git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" \
-            | grep -v -E '^(README\.md|docs/README\.[^/]+\.md)$' \
+            | awk '!/^(README\.md|docs\/README\.[^/]+\.md)$/' \
             > changed-files.txt
           echo "Changed files:"
           cat changed-files.txt || true


### PR DESCRIPTION
The PR risk scanner was scanning `README.md` and `docs/README.*.md` files, which are auto-generated by `npm run build` whenever skills, agents, plugins, or other resources change. This produced noisy or misleading findings unrelated to the actual code being reviewed.

The fix pipes the `git diff` output through a `grep -v` filter before writing `changed-files.txt`, excluding the root `README.md` and any `docs/README.*.md` file from the scan.