### PR TITLE
fix: strip npm warn/notice lines from Vally PR comment output

### DIFF
--- a/.github/workflows/skill-check-comment.yml
+++ b/.github/workflows/skill-check-comment.yml
@@ -89,7 +89,12 @@ jobs:
             const rawOutput = fs.existsSync('vally-output.txt')
               ? fs.readFileSync('vally-output.txt', 'utf8')
               : '';
-            const output = rawOutput.replace(/\x1b\[[0-9;]*m/g, '').trim();
+            const output = rawOutput
+              .replace(/\x1b\[[0-9;]*m/g, '')
+              .split('\n')
+              .filter(line => !line.match(/^npm (warn|notice)/))
+              .join('\n')
+              .trim();
 
             const errorCount = (output.match(/❌/g) || []).length;
             const warningCount = (output.match(/⚠/g) || []).length;


### PR DESCRIPTION
## Problem

`npm warn` and `npm notice` messages from `npx`'s package installation were leaking into the Vally lint PR comment. They appeared in both the **Summary** findings table (labelled as `ℹ️` advisories) and in the full linter output block.

Example noise:
```
npm warn EBADENGINE Unsupported engine { package: 'commander@15.0.0', ... }
npm warn deprecated prebuild-install@7.1.3: No longer maintained.
```

Seen in: https://github.com/github/awesome-copilot/pull/2427#issuecomment-5075909989

## Fix

Filter out lines matching `^npm (warn|notice)` when processing the raw vally output in the comment script. This cleans up both the summary table and the `<details>` full output block without affecting any real vally findings.