### PR TITLE
fix: add @astrojs/markdown-remark dep and fix build-website CI paths

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -4,14 +4,16 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - website
-      - agents
-      - skills
-      - plugins
-      - instructions
-      - hooks
-      - workflows
-      - extensions
+      - "website/**"
+      - "agents/**"
+      - "skills/**"
+      - "plugins/**"
+      - "instructions/**"
+      - "hooks/**"
+      - "workflows/**"
+      - "extensions/**"
+      - "package.json"
+      - "package-lock.json"
 
 permissions:
   contents: read

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -12,6 +12,9 @@ on:
       - "hooks/**"
       - "workflows/**"
       - "extensions/**"
+      - "cookbook/**"
+      - "eng/**"
+      - ".all-contributorsrc"
       - "package.json"
       - "package-lock.json"
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,3 +1,4 @@
+import { unified } from "@astrojs/markdown-remark";
 import sitemap from "@astrojs/sitemap";
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
@@ -34,9 +35,16 @@ export default defineConfig({
   base: "/",
   output: "static",
   markdown: {
-    remarkPlugins: [
-      [remarkGithubAdmonitionsToDirectives, { mapping: githubAdmonitionMapping }],
-    ],
+    // Astro 7.1+ uses Sätteri as the default Markdown processor, but its plugin
+    // API is incompatible with remark/rehype plugins. We explicitly opt into the
+    // unified() (remark/rehype) processor so we can keep using
+    // remark-github-admonitions-to-directives, which rewrites > [!NOTE] callouts
+    // from Learning Hub course content into Starlight aside directives.
+    processor: unified({
+      remarkPlugins: [
+        [remarkGithubAdmonitionsToDirectives, { mapping: githubAdmonitionMapping }],
+      ],
+    }),
   },
   integrations: [
     starlight({

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@astrojs/markdown-remark": "^7.2.0",
         "@astrojs/sitemap": "^3.7.2",
         "@astrojs/starlight": "^0.41.1",
         "astro": "^7.1.3",
@@ -135,9 +136,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -153,9 +151,6 @@
       "integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -173,9 +168,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -191,9 +183,6 @@
       "integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -268,6 +257,47 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
       "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark": {
+      "version": "7.2.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/markdown-remark/-/markdown-remark-7.2.1.tgz",
+      "integrity": "sha1-aqr0TwtErS/QUYN+btMULs0y5Mg=",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.1",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
+      "integrity": "sha1-P5a2TPc9ORmbGnCQneSIoAXFB3Y=",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.4",
@@ -1427,9 +1457,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1445,9 +1472,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1465,9 +1489,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1483,9 +1504,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1503,9 +1521,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1521,9 +1536,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1541,9 +1553,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1560,9 +1569,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1578,9 +1584,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1604,9 +1607,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1628,9 +1628,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1654,9 +1651,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1678,9 +1672,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1704,9 +1695,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1729,9 +1717,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1753,9 +1738,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/website/package.json
+++ b/website/package.json
@@ -19,6 +19,7 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
+    "@astrojs/markdown-remark": "^7.2.0",
     "@astrojs/sitemap": "^3.7.2",
     "@astrojs/starlight": "^0.41.1",
     "astro": "^7.1.3",


### PR DESCRIPTION
## Problem

Astro 7.1.x (bumped by dependabot in #2409) introduced "Sätteri" as the default Markdown processor and no longer bundles `@astrojs/markdown-remark` by default. The website's `astro.config.mjs` uses `markdown.remarkPlugins`, which requires this package to be installed explicitly — causing the [Deploy Website to GitHub Pages](https://github.com/github/awesome-copilot/actions/runs/30031106183) workflow to fail.

## Why not migrate to Sätteri?

Sätteri's own docs state: *"Sätteri's plugin API isn't compatible. Existing remark/rehype plugins won't run unmodified."* The site uses `remark-github-admonitions-to-directives` to convert `> [!NOTE]` callouts from Learning Hub course content into Starlight's aside directives. There is no Sätteri-native equivalent, so migrating would require writing a custom `defineMdastPlugin`. Staying on `unified()` is the officially supported Astro path for continuing to use remark/rehype plugins.

## Changes

### `website/package.json` — add `@astrojs/markdown-remark`
Added `@astrojs/markdown-remark@^7.2.0` as an explicit dependency. Required when using the `unified()` processor in Astro 7.1+.

### `website/astro.config.mjs` — use explicit `unified()` processor API
Updated from the deprecated `markdown.remarkPlugins` shorthand to the new `markdown.processor: unified({...})` API. This is the correct, explicit way to opt into the remark/rehype pipeline in Astro 7.1+.

### `.github/workflows/build-website.yml` — fix CI path triggers
The `paths` filter was using bare directory names without `/**` wildcards, which may not reliably match files inside those subdirectories. Updated to explicit globs (`website/**`, `agents/**`, etc.) and added root `package.json`/`package-lock.json` so future dependabot bumps that break the website build will be caught on the PR before merge.