### PR TITLE
Add keep-the-why plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -704,6 +704,30 @@
       "version": "1.0.2"
     },
     {
+      "name": "keep-the-why",
+      "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
+      "version": "0.5.1",
+      "author": {
+        "name": "Oliver Zehentleitner",
+        "url": "https://github.com/oliver-zehentleitner"
+      },
+      "repository": "https://github.com/oliver-zehentleitner/keep-the-why",
+      "license": "MIT",
+      "keywords": [
+        "documentation",
+        "context",
+        "decision-log",
+        "knowledge-management",
+        "onboarding",
+        "agents"
+      ],
+      "source": {
+        "source": "github",
+        "repo": "oliver-zehentleitner/keep-the-why",
+        "ref": "latest"
+      }
+    },
+    {
       "name": "kotlin-mcp-development",
       "source": "plugins/kotlin-mcp-development",
       "description": "Complete toolkit for building Model Context Protocol (MCP) servers in Kotlin using the official io.modelcontextprotocol:kotlin-sdk library. Includes instructions for best practices, a prompt for generating servers, and an expert chat mode for guidance.",


### PR DESCRIPTION
Adds `keep-the-why` to the plugin marketplace — a skill that preserves or recovers the reasoning behind a codebase (decisions, rejected alternatives, workarounds, incident learnings) that the code itself can't explain.

Source resolves via this repo's `latest` tag (moved automatically on every release), so this entry never needs a version bump here.

Repo: https://github.com/oliver-zehentleitner/keep-the-why