### PR TITLE
Add Trends MCP — trend data API + MCP server (25+ sources)

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 - [VS Code Copilot Customization Documentation](https://code.visualstudio.com/docs/copilot/copilot-customization) - Official Microsoft documentation
 - [GitHub Copilot Chat Documentation](https://code.visualstudio.com/docs/copilot/chat/copilot-chat) - Complete chat feature guide
 - [VS Code Settings](https://code.visualstudio.com/docs/getstarted/settings) - General VS Code configuration guide
+- [Trends MCP](https://github.com/trendsmcp-ai/Trends-MCP) - Live trend data across 25+ platforms (Google, YouTube, TikTok, Reddit, Amazon, news sentiment, app downloads, more). MCP server + REST API. [Free tier](https://trendsmcp.ai) (100 req/mo).
 
 ## ™️ Trademarks
 


### PR DESCRIPTION
## Summary
Adds [Trends MCP](https://github.com/trendsmcp-ai/Trends-MCP) — free-tier trend data API + MCP server across 25+ platforms.

- Site: https://trendsmcp.ai
- Docs: https://trendsmcp.ai/docs
- Free tier: 100 req/mo, no card

Insertion: `inserted_in:resources`
