### PR TITLE
Add SaaSCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 - [VS Code Copilot Customization Documentation](https://code.visualstudio.com/docs/copilot/copilot-customization) - Official Microsoft documentation
 - [GitHub Copilot Chat Documentation](https://code.visualstudio.com/docs/copilot/chat/copilot-chat) - Complete chat feature guide
 - [VS Code Settings](https://code.visualstudio.com/docs/getstarted/settings) - General VS Code configuration guide
+- [SaaSCity](https://saascity.io) - Directory for launching SaaS and AI developer tools
 
 ## ™️ Trademarks
 


### PR DESCRIPTION
Adds **SaaSCity** to Additional Resources.

- Site: https://saascity.io
- Submit: https://saascity.io/submit
- Gamified SaaS directory where every listing becomes a building on a live isometric city map.
- Domain Rating 46 (Ahrefs), free listing, dofollow, every submission manually reviewed inside 24h.

Happy to adjust the wording or move it if it belongs somewhere else.
