### PR TITLE
docs: clarify how the repo's resource types differ in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ New here? The quickest way to tell these apart is *when* each one reaches Copilo
 
 | Resource | Description | When it loads | Browse |
 |----------|-------------|---------------|--------|
-| 🤖 [Agents](docs/README.agents.md) | A specialist persona: system prompt + allowed tools/MCP servers + an optional pinned model | When **you** pick it for a conversation | [All agents →](https://awesome-copilot.github.com/agents) |
+| 🤖 [Agents](docs/README.agents.md) | A specialist persona: system prompt + allowed tools/MCP servers + an optional pinned model | When you select or assign it, or another agent delegates work to it | [All agents →](https://awesome-copilot.github.com/agents) |
 | 📋 [Instructions](docs/README.instructions.md) | Coding standards and repo conventions — prose only, no tools | **Automatically**, when a file matches its `applyTo` pattern | [All instructions →](https://awesome-copilot.github.com/instructions) |
 | 🎯 [Skills](docs/README.skills.md) | Task procedures plus bundled scripts, templates, and reference data | **In two stages** — only the frontmatter `description` sits in context; the body and assets load when the agent opens the file | [All skills →](https://awesome-copilot.github.com/skills) |
 | 🪝 [Hooks](docs/README.hooks.md) | Shell commands wired to coding-agent lifecycle events like `sessionStart` or `preToolUse` | Never — hooks *run*, they don't enter the context window | [Browse hooks →](hooks/) |

--- a/README.md
+++ b/README.md
@@ -16,13 +16,17 @@ New to GitHub Copilot customization? The **[Learning Hub](https://awesome-copilo
 
 ## What's in this repo
 
-| Resource | Description | Browse |
-|----------|-------------|--------|
-| 🤖 [Agents](docs/README.agents.md) | Specialized Copilot agents that integrate with MCP servers | [All agents →](https://awesome-copilot.github.com/agents) |
-| 📋 [Instructions](docs/README.instructions.md) | Coding standards applied automatically by file pattern | [All instructions →](https://awesome-copilot.github.com/instructions) |
-| 🎯 [Skills](docs/README.skills.md) | Self-contained folders with instructions and bundled assets | [All skills →](https://awesome-copilot.github.com/skills) |
-| 🔌 [Plugins](docs/README.plugins.md) | Curated bundles of agents and skills for specific workflows | [All plugins →](https://awesome-copilot.github.com/plugins) |
-| 🍳 [Cookbook](cookbook/README.md) | Copy-paste-ready recipes for working with Copilot APIs | — |
+New here? The quickest way to tell these apart is *when* each one reaches Copilot.
+
+| Resource | Description | When it loads | Browse |
+|----------|-------------|---------------|--------|
+| 🤖 [Agents](docs/README.agents.md) | A specialist persona: system prompt + allowed tools/MCP servers + an optional pinned model | When **you** pick it for a conversation | [All agents →](https://awesome-copilot.github.com/agents) |
+| 📋 [Instructions](docs/README.instructions.md) | Coding standards and repo conventions — prose only, no tools | **Automatically**, when a file matches its `applyTo` pattern | [All instructions →](https://awesome-copilot.github.com/instructions) |
+| 🎯 [Skills](docs/README.skills.md) | Task procedures plus bundled scripts, templates, and reference data | **In two stages** — only the frontmatter `description` sits in context; the body and assets load when the agent opens the file | [All skills →](https://awesome-copilot.github.com/skills) |
+| 🪝 [Hooks](docs/README.hooks.md) | Shell commands wired to coding-agent lifecycle events like `sessionStart` or `preToolUse` | Never — hooks *run*, they don't enter the context window | [Browse hooks →](hooks/) |
+| ⚙️ [Workflows](docs/README.workflows.md) | Agentic workflows that run Copilot in GitHub Actions on a schedule or repo event | Not in your editor — these execute in CI | [Browse workflows →](workflows/) |
+| 🔌 [Plugins](docs/README.plugins.md) | Installable bundles of related agents and skills — packaging, not a new capability | **At install time only** — the bundled agents and skills then load by their own rules above | [All plugins →](https://awesome-copilot.github.com/plugins) |
+| 🍳 [Cookbook](cookbook/README.md) | Copy-paste-ready recipes for building *with* the Copilot SDK | Never — these are docs for you, not for Copilot | — |
 
 ## Install a Plugin
 


### PR DESCRIPTION
## Why

The **What's in this repo** table is the first thing a newcomer reads, but it described all five listed resource types as interchangeable-sounding bits of configuration. Nothing in it answered the question people actually arrive with: *which of these do I want, and why?*

Two concrete gaps:

1. **No distinguishing axis.** "Custom agents", "coding standards", "task procedures" are all just descriptions of content. They don't explain that these things behave completely differently at runtime.
2. **The tagline promises six resource types** — agents, instructions, skills, hooks, workflows, and plugins — but the table listed four of them, plus the cookbook, which the tagline never mentions. Hooks and workflows were introduced and then never shown.

## What changed

**Added a "When it loads" column.** Load timing turns out to be the axis that genuinely separates these, and once it's visible the categories fall out on their own:

- agents / instructions / skills → become **context**
- hooks / workflows → **execute**, and never enter the context window
- plugins → **packaging** for the above

That grouping was implicit before. It's now readable straight off the table.

**Added the missing hooks and workflows rows**, closing the gap with the tagline.

**Fixed three accuracy problems in the existing rows:**

- *Skills* previously implied the whole file is loaded on demand. It isn't — only the frontmatter `description` stays resident, and the body and bundled assets load when the agent opens the file. This matters practically: the `description` is doing all the routing work, which is why `AGENTS.md` requires it to be 10–1024 characters.
- *Agents* said "pinned model." `model` is optional per `AGENTS.md` (strongly recommended, not required), and many agents in the collection omit it.
- *Plugins* said "Once, at install time," which conflated the package arriving with its contents reaching the model. The row now defers to the rules above it.

## Notes

- The Browse links for hooks and workflows point at the repo directories rather than the website. I couldn't find `awesome-copilot.github.com/hooks` or `/workflows` pages referenced anywhere in the repo or under `website/`, so I didn't want to invent URLs. Happy to swap them in if those pages exist.
- This section of `README.md` is hand-authored. `eng/update-readme.mjs` only splices between the `## 🌟 Featured Plugins` and `## MCP Server` markers, neither of which is present here — so the build doesn't manage this table.
- Ran `npm run build`; it produced no changes beyond this edit.
- `eng/fix-line-endings.sh` errors on macOS (`sed: invalid command code`) because it uses GNU `sed -i` syntax. It made no changes. Verified `README.md` is LF-only independently. Flagging as a possible separate issue.
