### PR TITLE
docs: update codebase-memory-mcp skill for v0.9.1-rc.1 🤖🤖🤖

### DIFF
--- a/skills/codebase-memory-mcp/SKILL.md
+++ b/skills/codebase-memory-mcp/SKILL.md
@@ -25,7 +25,7 @@ Use the configured Codebase Memory graph as a discovery accelerator, not as the 
 
 - Use `moderate` by default for normal indexing: it filters files while retaining similarity and semantic edges.
 - Use `fast` only for an explicitly requested smoke index, or when `moderate` is blocked and a degraded fallback is useful. Disclose that similarity and semantic edges are absent.
-- Use `full` when excluded files or maximum coverage justify the additional indexing cost.
+- Use `full` when moderate-only discovery filters omit relevant supported files and the additional indexing cost is justified. Full still honors `.gitignore`, `.cbmignore`, and always-skip rules.
 
 ## Safety and Fallbacks
 

--- a/skills/codebase-memory-mcp/SKILL.md
+++ b/skills/codebase-memory-mcp/SKILL.md
@@ -11,14 +11,21 @@ Use the configured Codebase Memory graph as a discovery accelerator, not as the 
 
 1. Discover the Codebase Memory tools exposed by the current MCP client; clients may prefix or rename tool namespaces.
 2. Call `list_projects` when available and use the exact indexed project name. If the repository is not indexed, continue with local exploration or ask before calling `index_repository` when graph access is important.
-3. Before branch-sensitive or edit-sensitive conclusions, use `index_status` or `detect_changes` when available. After a branch switch, assume the index may be stale until checked. If freshness cannot be established, disclose that limitation and verify locally.
-4. Use `get_architecture` once for orientation in an unfamiliar repository or subsystem. Do not repeat it for narrow follow-up questions.
-5. Use `search_graph` for definitions, implementations, routes, classes, interfaces, callers, and related symbols. Prefer a natural-language query for discovery and a name or qualified-name pattern for known symbols. Narrow by label or path, set a result limit, and paginate or reduce scope when the response reports more results.
+3. Before branch-sensitive or edit-sensitive conclusions, use `index_status` and verify the actual version-control state. Use `detect_changes` only when its Git base and head are valid for the checkout. If it unexpectedly reports zero changes, or the checkout uses another VCS, inspect that VCS's status or diff before claiming no impact.
+4. Use `get_architecture` once for unfamiliar structure. Request `clusters` to discover de-facto module seams. Treat `cycles` as an opt-in whole-call-graph scan: `path` does not scope cycle detection, so verify relevant cycles before making module-local claims.
+5. Use `search_graph` for definitions, implementations, routes, classes, interfaces, and related symbols. Prefer a natural-language query for discovery and a name or qualified-name pattern for known symbols. Narrow by label or path and set a result limit. For exhaustive claims, increase `offset` by `limit` while `has_more` is true.
 6. Use `search_code` or normal repository search for literal strings, configuration keys, test identifiers, error messages, and non-code files. Do not turn a precise text lookup into a broad graph query.
 7. After graph search, use `get_code_snippet` with the returned qualified name. If source snippets are unavailable, open the local file before relying on the result.
-8. Use `trace_path` for callers, callees, dependency paths, data flow, cross-service paths, and impact analysis. Include tests only when test coverage is part of the question.
-9. Use `get_graph_schema` before `query_graph`. Reserve custom queries for multi-hop or aggregate questions that simpler tools cannot answer, and apply `LIMIT` or the tool's row limit.
-10. When graph and checked-out source disagree, treat source as current and report likely index drift.
+8. Use `trace_path` for callers, callees, dependency paths, data flow, cross-service paths, and impact analysis. Include tests when the claim covers them. While `truncated` is true, pass `next` back as `cursor` with every other argument unchanged.
+9. After identifying candidate files, call `check_index_coverage` for every cited path. Before negative or exhaustive claims, also check the relevant `scopes`; advance `scope_offset` to each `next_offset` while `has_more` is true. This metadata is best-effort, not proof of completeness. Inspect local source for partial, skipped, excluded, stale, or otherwise uncovered paths.
+10. Use `get_graph_schema` before custom `query_graph` calls. Reserve them for bounded multi-hop or aggregate questions, apply `LIMIT` or `max_rows`, and use `graph="missed"` to audit files the main graph did not fully index.
+11. Complete every relevant result stream before an exhaustive claim. For bounded discovery, stopping early is acceptable when the result states its limit or truncation. When graph and checked-out source disagree, treat source as current and report likely index drift.
+
+## Indexing Modes
+
+- Use `moderate` by default for normal indexing: it filters files while retaining similarity and semantic edges.
+- Use `fast` only for an explicitly requested smoke index, or when `moderate` is blocked and a degraded fallback is useful. Disclose that similarity and semantic edges are absent.
+- Use `full` when excluded files or maximum coverage justify the additional indexing cost.
 
 ## Safety and Fallbacks
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the `CONTRIBUTING.md` guidelines.
- [x] The existing skill remains in the correct directory and follows the required naming and frontmatter conventions.
- [x] I tested the updated skill with RED/GREEN agent scenarios.
- [x] I ran `npm start` and verified that generated files are up to date.
- [x] This pull request targets `main`.

## Description

Update the existing Codebase Memory MCP skill for the `v0.9.1-rc.1` tool surface.

The skill now:

- uses the exact pagination contracts for `search_graph`, `trace_path`, and `check_index_coverage`;
- checks file and scope coverage before negative or exhaustive claims;
- documents the missed graph, architecture clusters and project-wide cycle detection;
- verifies real VCS state before trusting `detect_changes`;
- prefers `moderate` indexing for normal use while keeping `fast` and `full` explicit;
- preserves the existing explicit-approval gate for graph mutations.

This is intentionally client-neutral: it does not include local binary paths, sandbox settings, or server aliases.

## Validation

- `npm ci`
- `npm run skill:validate` — 395/395 skills valid
- `python3 .../quick_validate.py skills/codebase-memory-mcp`
- `npx --yes @microsoft/vally-cli lint skills/codebase-memory-mcp` — 2/2 checks passed
- `npm start` — generated files already up to date
- `git diff --check`
- all Markdown files verified LF-only

RED reproduced incorrect continuation arguments from the previous skill (`search_graph.cursor` and coverage `offset`). GREEN produced the documented `search_graph.offset`, `trace_path.cursor`, and `check_index_coverage.scope_offset` continuations. Bounded-search and mutation-safety controls also passed.

## Additional Notes

`bash eng/fix-line-endings.sh` was invoked as required, but its BSD `sed` invocation emits `invalid command code .` on macOS while exiting zero. An independent repository-wide CRLF scan confirmed all Markdown files are LF-only.
