### PR TITLE
fix: prevent invalid contributor footer markup

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -12,7 +12,7 @@
   "commit": false,
   "commitConvention": "none",
   "contributorsPerLine": 7,
-  "linkToUsage": true,
+  "linkToUsage": false,
   "commitType": "docs",
   "types": {
     "instructions": {

--- a/README.md
+++ b/README.md
@@ -546,21 +546,14 @@ Thanks goes to these wonderful people ([emoji key](./CONTRIBUTING.md#contributor
       <td align="center" valign="top" width="14.28%"><a href="https://surenk.com"><img src="https://avatars.githubusercontent.com/u/902972?v=4" width="100px;" alt=""/><br /><sub><b>Suren K</b></sub></a></td>
     </tr>
   </tbody>
-  <tfoot>
-    <tr>
-      <td align="center" size="13px" colspan="7">
-        <img src="https://raw.githubusercontent.com/all-contributors/all-contributors-cli/1b8533af435da9854653492b1327a23a4dbd0a10/assets/logo-small.svg">
-          <a href="https://all-contributors.js.org/docs/en/bot/usage">Add your contributions</a>
-        </img>
-      </td>
-    </tr>
-  </tfoot>
 </table>
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+
+<p><a href="https://all-contributors.js.org/docs/en/bot/usage">Add your contributions</a></p>
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 

--- a/website/src/pages/contributors.astro
+++ b/website/src/pages/contributors.astro
@@ -499,20 +499,16 @@ import PageHeader from '../components/PageHeader.astro';
       <td align="center" valign="top" width="14.28%"><a href="https://surenk.com"><img src="https://avatars.githubusercontent.com/u/902972?v=4" width="100px;" alt=""/><br /><sub><b>Suren K</b></sub></a></td>
     </tr>
   </tbody>
-  <tfoot>
-    <tr>
-      <td align="center" size="13px" colspan="7">
-        <img src="https://raw.githubusercontent.com/all-contributors/all-contributors-cli/1b8533af435da9854653492b1327a23a4dbd0a10/assets/logo-small.svg">
-          <a href="https://all-contributors.js.org/docs/en/bot/usage">Add your contributions</a>
-      </td>
-    </tr>
-  </tfoot>
 </table>
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+          <p>
+            <img src="https://raw.githubusercontent.com/all-contributors/all-contributors-cli/1b8533af435da9854653492b1327a23a4dbd0a10/assets/logo-small.svg" alt="" />
+            <a href="https://all-contributors.js.org/docs/en/bot/usage">Add your contributions</a>
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Contributor PRs currently regenerate an invalid `</img>` tag in the website contributor page, causing Astro builds to fail. The pinned `all-contributors-cli` version hardcodes this tag in its usage footer.

This change disables that generated footer and keeps the contribution link outside the generated contributor block, so future contributor updates cannot reintroduce invalid Astro markup. The README and website page are updated consistently.

The full website build could not be run locally because dependency installation is blocked by an unavailable internal `@github/copilot@1.0.78` package.