### PR TITLE
Fix PRT writer permissions for fork PRs

### DIFF
--- a/.github/workflows/contributor-check-writer.yml
+++ b/.github/workflows/contributor-check-writer.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   actions: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: ccw-${{ github.event.workflow_run.head_repository.id || 'unknown-repo' }}-${{ github.event.workflow_run.head_branch || 'unknown-branch' }}

--- a/.github/workflows/external-plugin-pr-quality-gates-writer.yml
+++ b/.github/workflows/external-plugin-pr-quality-gates-writer.yml
@@ -9,7 +9,7 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: epqw-${{ github.event.workflow_run.head_repository.id || 'unknown-repo' }}-${{ github.event.workflow_run.head_branch || 'unknown-branch' }}

--- a/.github/workflows/label-pr-intent-writer.yml
+++ b/.github/workflows/label-pr-intent-writer.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   actions: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: lpiw-${{ github.event.workflow_run.head_repository.id || 'unknown-repo' }}-${{ github.event.workflow_run.head_branch || 'unknown-branch' }}

--- a/.github/workflows/pr-duplicate-check-writer.yml
+++ b/.github/workflows/pr-duplicate-check-writer.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   actions: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: pdcw-${{ github.event.workflow_run.head_repository.id || 'unknown-repo' }}-${{ github.event.workflow_run.head_branch || 'unknown-branch' }}


### PR DESCRIPTION
## Summary

- Restore label and comment synchronization for fork PRs after the PRT migration.
- Grant `pull-requests: write` to the four downstream writer workflows while retaining `issues: write` for label, comment, and repository-label management.

## Trust model

The downstream writers retain strict artifact, workflow run, repository, branch, and head-SHA validation before applying synchronized results.

## Validation

- `actionlint` on all four affected writer workflows
- Targeted assertions for the required writer permissions
