### PR TITLE
Document the optional UIZZE preview endpoint

### DIFF
--- a/plugins/uizze/README.md
+++ b/plugins/uizze/README.md
@@ -31,6 +31,8 @@ The skill remains usable when catalogue browsing is unavailable: it can work fro
 
 UIZZE maintains the public catalogue referenced by the skill.
 
+For an optional, separate anonymous source check outside this plugin, use the [free UI slop preview](https://uizze.com/mcp/preview). It exposes exactly one deterministic `check_ui_slop` tool, requires no account or token, and is not required by this plugin.
+
 ## Source
 
 This plugin is part of [Awesome Copilot](https://github.com/github/awesome-copilot).


### PR DESCRIPTION
## What changed

The UIZZE plugin is already listed and works without an MCP server. This adds one factual sentence documenting the separate optional free preview endpoint for users who want a deterministic source check outside the Copilot plugin.

- Preview: https://uizze.com/mcp/preview
- Exposes exactly one `check_ui_slop` tool
- Anonymous; no account or token
- Not required by this plugin and does not change its local-only behavior

This corrects the handoff by describing the endpoint itself, rather than linking to plugin installation instructions.