### PR TITLE
fix(ci): grant contributor check issue read access 🤖🤖🤖

### DIFF
--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -270,6 +270,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      issues: read
     steps:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0


### PR DESCRIPTION
## Description

Grant the `pr-check` job read-only access to issues so AGT's issue search evaluates the intended issue corpus instead of receiving pull requests under the restricted workflow token.

Fixes #2692.

PR #2649 is the concrete example used for reproduction: its contributor check reports `HIGH` after authored pull requests are treated as issue activity.

## Scope

- Adds only `issues: read` to the existing job-level permissions.
- Does not add write access or change the check implementation.
- Leaves AGT's defensive result-type validation and date-window behavior for separate upstream work.

## Validation

- `npm start` — passed; generated files remained unchanged.
- Parsed `.github/workflows/contributor-check.yml` with the repository's `js-yaml` dependency and asserted `jobs.pr-check.permissions.issues === "read"`.
- `git diff --check` — passed.
- [Control Actions run](https://github.com/astandrik/awesome-copilot/actions/runs/32021818822) with only this permission added changed the search corpus from 844 to 473 and the AGT result from `HIGH` to `MEDIUM`.

The specific risk level is not the acceptance criterion; the relevant result is that AGT receives actual issue results.

## Pull Request Checklist

- [x] I have read and followed the `CONTRIBUTING.md` guidelines.
- [x] I ran `npm start` and verified generated files are up to date.
- [x] I am targeting the `main` branch.
- [x] Other: CI workflow permission fix; resource-file naming and paid-service guidance are not applicable.
