### PR TITLE
Update upgrade-agent plugin to 1.1.404

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1547,7 +1547,7 @@
     {
       "name": "upgrade-agent",
       "description": "AI-powered upgrade assistant for upgrading and migrating applications. Helps modernize legacy code and upgrade .NET applications to current frameworks.",
-      "version": "1.1.290",
+      "version": "1.1.404",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -1566,7 +1566,8 @@
         "source": "github",
         "repo": "microsoft/upgrade-agent-plugins",
         "path": "plugins/upgrade-agent",
-        "sha": "559f6fea2deea78fb5adf2cfacba2a5151a5fa7f"
+        "ref": "v1.1.404",
+        "sha": "a4f718e90c39e7ab62a81ddd78be9b56b1a4c4bf"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -1003,7 +1003,7 @@
   {
     "name": "upgrade-agent",
     "description": "AI-powered upgrade assistant for upgrading and migrating applications. Helps modernize legacy code and upgrade .NET applications to current frameworks.",
-    "version": "1.1.290",
+    "version": "1.1.404",
     "author": {
       "name": "Microsoft",
       "url": "https://www.microsoft.com"
@@ -1022,7 +1022,8 @@
       "source": "github",
       "repo": "microsoft/upgrade-agent-plugins",
       "path": "plugins/upgrade-agent",
-      "sha": "559f6fea2deea78fb5adf2cfacba2a5151a5fa7f"
+      "ref": "v1.1.404",
+      "sha": "a4f718e90c39e7ab62a81ddd78be9b56b1a4c4bf"
     }
   },
   {


### PR DESCRIPTION
Updates the `upgrade-agent` external plugin entry to **1.1.404**.

The plugin content lives in [microsoft/upgrade-agent-plugins](https://github.com/microsoft/upgrade-agent-plugins); this PR only updates the registry pointer.

**Changes**
- `plugins/external.json` — bumped `version` to `1.1.404`, repinned `source.sha`, and added an explicit `source.ref`
- `.github/plugin/marketplace.json` — regenerated mirror of the same entry

**Pin**
- Tag: `v1.1.404`
- Commit: `a4f718e90c39e7ab62a81ddd78be9b56b1a4c4bf`
- Upstream PR: microsoft/upgrade-agent-plugins#31

The pinned commit is immutable and tagged, and `plugins/upgrade-agent/plugin.json` reports `1.1.404` at that SHA.
