### PR TITLE
dotnet-mcp-builder: pin sample dependency versions

### DIFF
--- a/skills/dotnet-mcp-builder/references/client.md
+++ b/skills/dotnet-mcp-builder/references/client.md
@@ -7,9 +7,9 @@ For just *running* a server, ignore this file.
 ## Packages
 
 ```bash
-dotnet add package ModelContextProtocol.Core   # minimal: just client + transports
+dotnet add package ModelContextProtocol.Core --version 2.2.0   # minimal: just client + transports
 # or
-dotnet add package ModelContextProtocol         # adds DI/hosting helpers
+dotnet add package ModelContextProtocol --version 2.2.0         # adds DI/hosting helpers
 ```
 
 ## Connecting via STDIO (launching a server process)

--- a/skills/dotnet-mcp-builder/references/mcp-apps.md
+++ b/skills/dotnet-mcp-builder/references/mcp-apps.md
@@ -147,7 +147,7 @@ A minimum viable bundle: vanilla JS using `@modelcontextprotocol/ext-apps`. The 
   <body>
     <div id="root">Loading…</div>
     <script type="module">
-      import { App } from "https://esm.sh/@modelcontextprotocol/ext-apps@1";
+      import { App } from "https://esm.sh/@modelcontextprotocol/ext-apps@1.7.5";
 
       const app = new App();
       await app.connect();

--- a/skills/dotnet-mcp-builder/references/packages.md
+++ b/skills/dotnet-mcp-builder/references/packages.md
@@ -19,7 +19,7 @@ All packages live under the [`ModelContextProtocol` NuGet profile](https://www.n
 
 ## Versions
 
-As of mid-2026, the stable line is **2.x** (`2.0.0` is current at time of writing), aligned with the MCP 2026-07-28 spec. The `0.x` line was preview and has breaking differences — if you find docs or blog posts referencing `0.4`/`0.6`, treat them as out of date. The `1.x` line still compiles and interoperates, but predates the v2 changes (stateless-by-default HTTP, discovery-first negotiation, roots/sampling/logging deprecations, the Tasks/Apps extension packages) — prefer 2.x for new projects.
+As of mid-2026, the stable line is **2.x** (`2.2.0` is current at time of writing), aligned with the MCP 2026-07-28 spec. The `0.x` line was preview and has breaking differences — if you find docs or blog posts referencing `0.4`/`0.6`, treat them as out of date. The `1.x` line still compiles and interoperates, but predates the v2 changes (stateless-by-default HTTP, discovery-first negotiation, roots/sampling/logging deprecations, the Tasks/Apps extension packages) — prefer 2.x for new projects.
 
 **Upgrading 1.x → 2.0 (highlights, not exhaustive):** stable v1.x APIs keep working; the deprecated capabilities (roots, sampling, logging) are now `[Obsolete]` with `MCP9005` warnings, experimental APIs moved (the 1.4.x Tasks surface → `ModelContextProtocol.Extensions.Tasks`), and several behaviors flipped (`HttpServerTransportOptions.Stateless` now defaults to `true`; non-object tool results emit raw `structuredContent` values; `Tool.inputSchema` is required on deserialization). OAuth also changed at runtime — `AuthorizationRedirectDelegate` → `ClientOAuthOptions.AuthorizationCallbackHandler`, RFC 9207 issuer validation, mandatory PKCE S256 in metadata, `application_type` in dynamic registration — and SSE transport failures now propagate the underlying `HttpRequestException`/`TimeoutException`. Before upgrading, read the full [v2.0.0 release notes](https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v2.0.0).
 
@@ -46,8 +46,8 @@ For HTTP servers you specifically need a TFM that supports ASP.NET Core (so .NET
 ```bash
 dotnet new console -n MyMcpServer -f net10.0
 cd MyMcpServer
-dotnet add package ModelContextProtocol
-dotnet add package Microsoft.Extensions.Hosting
+dotnet add package ModelContextProtocol --version 2.2.0
+dotnet add package Microsoft.Extensions.Hosting --version 10.0.11
 ```
 
 ### HTTP (Streamable) server
@@ -55,7 +55,7 @@ dotnet add package Microsoft.Extensions.Hosting
 ```bash
 dotnet new web -n MyMcpServer -f net10.0
 cd MyMcpServer
-dotnet add package ModelContextProtocol.AspNetCore
+dotnet add package ModelContextProtocol.AspNetCore --version 2.2.0
 ```
 
 (`dotnet new web` gives you a minimal ASP.NET Core project — exactly what `MapMcp` needs.)
@@ -65,7 +65,7 @@ dotnet add package ModelContextProtocol.AspNetCore
 ```bash
 dotnet new console -n MyMcpClient -f net10.0
 cd MyMcpClient
-dotnet add package ModelContextProtocol.Core
+dotnet add package ModelContextProtocol.Core --version 2.2.0
 ```
 
 ## Optional but commonly useful

--- a/skills/dotnet-mcp-builder/references/transport-http.md
+++ b/skills/dotnet-mcp-builder/references/transport-http.md
@@ -18,7 +18,7 @@ For local single-user scenarios, [STDIO](./transport-stdio.md) is simpler.
 ```bash
 dotnet new web -n MyHttpServer -f net10.0
 cd MyHttpServer
-dotnet add package ModelContextProtocol.AspNetCore
+dotnet add package ModelContextProtocol.AspNetCore --version 2.2.0
 ```
 
 ```csharp

--- a/skills/dotnet-mcp-builder/references/transport-stdio.md
+++ b/skills/dotnet-mcp-builder/references/transport-stdio.md
@@ -16,8 +16,8 @@ If the user wants a remote/multi-tenant server, use [HTTP Streamable](./transpor
 ```bash
 dotnet new console -n MyStdioServer -f net10.0
 cd MyStdioServer
-dotnet add package ModelContextProtocol
-dotnet add package Microsoft.Extensions.Hosting
+dotnet add package ModelContextProtocol --version 2.2.0
+dotnet add package Microsoft.Extensions.Hosting --version 10.0.11
 ```
 
 ```csharp


### PR DESCRIPTION
## Summary
- The MCP Apps sample HTML bundle imported `@modelcontextprotocol/ext-apps` from esm.sh using an unpinned major-version tag (`@1`). Snyk flags this as a medium-risk unverifiable external dependency / third-party content exposure (indirect prompt-injection surface, since the imported module can call `app.updateModelContext` and `app.callServerTool`). Pinned to the current release, `1.7.5`.
- Pinned the sample `dotnet add package` commands for `ModelContextProtocol`, `ModelContextProtocol.AspNetCore`, `ModelContextProtocol.Core`, and `Microsoft.Extensions.Hosting` to their current exact versions (`2.2.0` / `10.0.11`) across `packages.md`, `transport-stdio.md`, `transport-http.md`, and `client.md`.
- Corrected a stale "`2.0.0` is current" note in `packages.md` to `2.2.0`.

## Test plan
- [ ] Docs-only change — no build required.