### PR TITLE
Update modernize-java to 1.23.0

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1013,7 +1013,7 @@
     {
       "name": "modernize-java",
       "description": "GitHub Copilot modernization – Java Upgrade CLI Plugin helps you upgrade Java applications from the command line. It brings intelligent modernization capabilities to your terminal and CI/CD pipelines: analyze your project and generate an upgrade plan, automatically transform your codebase, fix build issues, validate against known CVEs, and output a detailed summary of file changes and updated dependencies.",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "author": {
         "name": "microsoft",
         "url": "https://github.com/microsoft/modernize-java"
@@ -1031,8 +1031,8 @@
         "source": "github",
         "repo": "microsoft/modernize-java",
         "path": "plugins/modernize-java",
-        "ref": "1.22.0",
-        "sha": "ef5367b446566bdc90960deeb40def63f9e7024e"
+        "ref": "1.23.0",
+        "sha": "5ccc2ad4011314602e1b80f0b818c95bcf198f67"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -739,7 +739,7 @@
   {
     "name": "modernize-java",
     "description": "GitHub Copilot modernization – Java Upgrade CLI Plugin helps you upgrade Java applications from the command line. It brings intelligent modernization capabilities to your terminal and CI/CD pipelines: analyze your project and generate an upgrade plan, automatically transform your codebase, fix build issues, validate against known CVEs, and output a detailed summary of file changes and updated dependencies.",
-    "version": "1.22.0",
+    "version": "1.23.0",
     "author": {
       "name": "microsoft",
       "url": "https://github.com/microsoft/modernize-java"
@@ -757,8 +757,8 @@
       "source": "github",
       "repo": "microsoft/modernize-java",
       "path": "plugins/modernize-java",
-      "ref": "1.22.0",
-      "sha": "ef5367b446566bdc90960deeb40def63f9e7024e"
+      "ref": "1.23.0",
+      "sha": "5ccc2ad4011314602e1b80f0b818c95bcf198f67"
     }
   },
   {


### PR DESCRIPTION
## Summary

- update the external `modernize-java` plugin from 1.22.0 to 1.23.0
- pin the release tag to commit `5ccc2ad4011314602e1b80f0b818c95bcf198f67`
- regenerate the plugin marketplace

## Validation

- `npm run plugin:validate`
- `npm run build`
- `git diff --check`