### PR TITLE
Update upgrade-agent plugin to 1.1.441

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1547,7 +1547,7 @@
     {
       "name": "upgrade-agent",
       "description": "AI-powered upgrade assistant for upgrading and migrating applications. Helps modernize legacy code and upgrade .NET applications to current frameworks.",
-      "version": "1.1.404",
+      "version": "1.1.441",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -1566,8 +1566,8 @@
         "source": "github",
         "repo": "microsoft/upgrade-agent-plugins",
         "path": "plugins/upgrade-agent",
-        "ref": "v1.1.404",
-        "sha": "a4f718e90c39e7ab62a81ddd78be9b56b1a4c4bf"
+        "ref": "v1.1.441",
+        "sha": "f8abab778cfb5b57a3c745d540631b7aab15d5b3"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -1003,7 +1003,7 @@
   {
     "name": "upgrade-agent",
     "description": "AI-powered upgrade assistant for upgrading and migrating applications. Helps modernize legacy code and upgrade .NET applications to current frameworks.",
-    "version": "1.1.404",
+    "version": "1.1.441",
     "author": {
       "name": "Microsoft",
       "url": "https://www.microsoft.com"
@@ -1022,8 +1022,8 @@
       "source": "github",
       "repo": "microsoft/upgrade-agent-plugins",
       "path": "plugins/upgrade-agent",
-      "ref": "v1.1.404",
-      "sha": "a4f718e90c39e7ab62a81ddd78be9b56b1a4c4bf"
+      "ref": "v1.1.441",
+      "sha": "f8abab778cfb5b57a3c745d540631b7aab15d5b3"
     }
   },
   {


### PR DESCRIPTION
Automated version bump of the upgrade-agent external plugin entry from UpgradeAssistant build 2026-08-20-20260820.2 (version 1.1.441). Pinned to tag v1.1.441 / commit f8abab778cfb5b57a3c745d540631b7aab15d5b3 in microsoft/upgrade-agent-plugins.