### PR TITLE
fix(excalidraw-diagram-generator): correct template file extensions 🤖🤖🤖

### DIFF
--- a/skills/excalidraw-diagram-generator/SKILL.md
+++ b/skills/excalidraw-diagram-generator/SKILL.md
@@ -589,9 +589,16 @@ python scripts/add-arrow.py my-aws-diagram.excalidraw 565 330 650 350 --label "S
 See bundled references for:
 - `references/excalidraw-schema.md` - Complete Excalidraw JSON schema
 - `references/element-types.md` - Detailed element type specifications
-- `templates/flowchart-template.json` - Basic flowchart starter
-- `templates/relationship-template.json` - Relationship diagram starter
-- `templates/mindmap-template.json` - Mind map starter
+- `templates/flowchart-template.excalidraw` - Basic flowchart starter
+- `templates/relationship-template.excalidraw` - Relationship diagram starter
+- `templates/mindmap-template.excalidraw` - Mind map starter
+- `templates/business-flow-swimlane-template.excalidraw` - Business flow swimlane starter
+- `templates/class-diagram-template.excalidraw` - Class diagram starter
+- `templates/data-flow-diagram-template.excalidraw` - Data flow diagram starter
+- `templates/er-diagram-template.excalidraw` - Entity-relationship diagram starter
+- `templates/sequence-diagram-template.excalidraw` - Sequence diagram starter
+- `scripts/add-icon-to-diagram.py` - Add icons from Excalidraw libraries to diagrams
+- `scripts/add-arrow.py` - Add arrows (connections) between elements in diagrams
 - `scripts/split-excalidraw-library.py` - Tool to split `.excalidrawlib` files
 - `scripts/README.md` - Documentation for library tools
 - `scripts/.gitignore` - Prevents local Python artifacts from being committed


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `main` branch for this pull request.

> Two boxes are left unchecked deliberately: this adds no new file (it corrects an existing one), and it is a documentation-only fix with no prompt behaviour to exercise against Copilot.

---

## Description

The References section of `skills/excalidraw-diagram-generator/SKILL.md` documents three bundled templates with a `.json` extension, but every template shipped in `templates/` uses `.excalidraw`:

```console
$ ls skills/excalidraw-diagram-generator/templates/
business-flow-swimlane-template.excalidraw  flowchart-template.excalidraw
class-diagram-template.excalidraw           mindmap-template.excalidraw
data-flow-diagram-template.excalidraw       relationship-template.excalidraw
er-diagram-template.excalidraw              sequence-diagram-template.excalidraw
```

So all three documented paths — `templates/flowchart-template.json`, `templates/relationship-template.json` and `templates/mindmap-template.json` — resolve to nothing. Anyone following the References section to open a starter template, agent or human, hits a missing file.

While correcting the extensions I also completed the list, which had drifted from what the skill actually bundles:

- five of the eight templates were undocumented (`business-flow-swimlane`, `class-diagram`, `data-flow-diagram`, `er-diagram`, `sequence-diagram`)
- `scripts/add-icon-to-diagram.py` and `scripts/add-arrow.py` were absent from the list, even though the skill body documents both at length (lines 388-441 and 524-534)

Documentation only — no behaviour change, and nothing outside the References section is touched. Happy to trim this to the extension fix alone if reviewers would rather keep the diff to the three broken paths.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

## Additional Notes

Verification:

- every path listed in the References section now resolves to a real file in the skill folder
- the list matches `find skills/excalidraw-diagram-generator -type f` exactly, minus `SKILL.md` itself
- `npm start` reports no changes: the generated asset column is derived from disk, not from this prose list, so no generated file moves

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
