### PR TITLE
Update keep-the-why plugin to 0.9.2

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -861,7 +861,7 @@
     {
       "name": "keep-the-why",
       "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-      "version": "0.5.2",
+      "version": "0.9.2",
       "author": {
         "name": "Oliver Zehentleitner",
         "url": "https://github.com/oliver-zehentleitner"
@@ -880,7 +880,7 @@
       "source": {
         "source": "github",
         "repo": "oliver-zehentleitner/keep-the-why",
-        "ref": "v0.5.2"
+        "ref": "v0.9.2"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -587,7 +587,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.5.2",
+    "version": "0.9.2",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"
@@ -606,7 +606,7 @@
     "source": {
       "source": "github",
       "repo": "oliver-zehentleitner/keep-the-why",
-      "ref": "v0.5.2"
+      "ref": "v0.9.2"
     }
   },
   {


### PR DESCRIPTION
Version bump for the previously approved external plugin listing (#2470 / #2776).

- `plugins/external.json`: `version` 0.5.2 → 0.9.2, `source.ref` v0.5.2 → v0.9.2
- `.github/plugin/marketplace.json` regenerated via `npm run plugin:generate-marketplace`

Release notes: https://github.com/oliver-zehentleitner/keep-the-why/releases/tag/v0.9.2