### PR TITLE
Update Vercel plugin to 0.48.1

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1657,7 +1657,7 @@
     {
       "name": "vercel-plugin",
       "description": "Build and deploy web apps and agents. Comprehensive Vercel ecosystem plugin — relational knowledge graph, skills for every major product, specialized agents, and Vercel conventions. Turns any AI agent into a Vercel expert.",
-      "version": "0.43.0",
+      "version": "0.48.1",
       "author": {
         "name": "Vercel",
         "url": "https://github.com/vercel"
@@ -1680,7 +1680,7 @@
       "source": {
         "source": "github",
         "repo": "vercel/vercel-plugin",
-        "sha": "6e51924cb249e2941de005d59f1ac6f768477b98"
+        "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -1101,7 +1101,7 @@
   {
     "name": "vercel-plugin",
     "description": "Build and deploy web apps and agents. Comprehensive Vercel ecosystem plugin — relational knowledge graph, skills for every major product, specialized agents, and Vercel conventions. Turns any AI agent into a Vercel expert.",
-    "version": "0.43.0",
+    "version": "0.48.1",
     "author": {
       "name": "Vercel",
       "url": "https://github.com/vercel"
@@ -1124,7 +1124,7 @@
     "source": {
       "source": "github",
       "repo": "vercel/vercel-plugin",
-      "sha": "6e51924cb249e2941de005d59f1ac6f768477b98"
+      "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6"
     }
   },
   {


### PR DESCRIPTION
## Summary

- update the external Vercel plugin from `0.43.0` to `0.48.1`
- pin the source to immutable commit `c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6`
- regenerate the Awesome Copilot marketplace catalog

Upstream manifest and `package.json` both report version `0.48.1` at the pinned commit:
https://github.com/vercel/vercel-plugin/tree/c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6

## Validation

- `npm run plugin:validate` — passed
- `npm run build` — passed
- `git diff --check` — passed
- external plugin install smoke test — passed
- external plugin version match — passed

## Existing quality-gate findings

The current Vally checks report upstream skill-format findings on the proposed snapshot. The currently listed `0.43.0` snapshot also fails the same current quality gate, so these findings are not introduced by this catalog update. The proposed `0.48.1` snapshot installs successfully and its manifest version matches the catalog entry.
