### PR TITLE
Restructure Learning Hub navigation and add video landing pages

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -114,6 +114,7 @@ export default defineConfig({
       sidebar: [
         {
           label: "Fundamentals",
+          collapsed: true,
           items: [
             "learning-hub/github-copilot-app",
             "learning-hub/working-with-canvas-extensions",
@@ -135,9 +136,11 @@ export default defineConfig({
         },
         {
           label: "Courses",
+          collapsed: true,
           items: [
             {
               label: "CLI for Beginners",
+              collapsed: true,
               items: [
                 {
                   label: "Overview",
@@ -163,6 +166,7 @@ export default defineConfig({
         },
         {
           label: "Workshops",
+          collapsed: true,
           items: [
             {
               label: "Overview",
@@ -170,6 +174,7 @@ export default defineConfig({
             },
             {
               label: "VS Code",
+              collapsed: true,
               items: [
                 {
                   label: "Overview",
@@ -186,6 +191,7 @@ export default defineConfig({
             },
             {
               label: "Copilot CLI",
+              collapsed: true,
               items: [
                 {
                   label: "Overview",
@@ -204,6 +210,7 @@ export default defineConfig({
             },
             {
               label: "Copilot App",
+              collapsed: true,
               items: [
                 {
                   label: "Overview",
@@ -222,6 +229,7 @@ export default defineConfig({
             },
             {
               label: "Copilot Cloud Agent",
+              collapsed: true,
               items: [
                 {
                   label: "Overview",
@@ -239,10 +247,15 @@ export default defineConfig({
         },
         {
           label: "Video content",
-          items: ["learning-hub/videos/cli-for-beginners"],
+          collapsed: true,
+          items: [
+            "learning-hub/videos/cli-for-beginners",
+            "learning-hub/videos/copilot-app",
+          ],
         },
         {
           label: "Additional resources",
+          collapsed: true,
           items: [
             {
               label: "Cookbook",

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -134,28 +134,35 @@ export default defineConfig({
           ],
         },
         {
-          label: "Reference",
-          items: ["learning-hub/github-copilot-terminology-glossary"],
-        },
-        {
-          label: "Copilot CLI for Beginners",
+          label: "Courses",
           items: [
             {
-              label: "Overview",
-              link: "/learning-hub/cli-for-beginners/",
+              label: "CLI for Beginners",
+              items: [
+                {
+                  label: "Overview",
+                  link: "/learning-hub/cli-for-beginners/",
+                },
+                "learning-hub/cli-for-beginners/00-quick-start",
+                "learning-hub/cli-for-beginners/01-setup-and-first-steps",
+                "learning-hub/cli-for-beginners/02-context-and-conversations",
+                "learning-hub/cli-for-beginners/03-development-workflows",
+                "learning-hub/cli-for-beginners/04-agents-and-custom-instructions",
+                "learning-hub/cli-for-beginners/05-skills",
+                "learning-hub/cli-for-beginners/06-mcp-servers",
+                "learning-hub/cli-for-beginners/07-putting-it-all-together",
+              ],
             },
-            "learning-hub/cli-for-beginners/00-quick-start",
-            "learning-hub/cli-for-beginners/01-setup-and-first-steps",
-            "learning-hub/cli-for-beginners/02-context-and-conversations",
-            "learning-hub/cli-for-beginners/03-development-workflows",
-            "learning-hub/cli-for-beginners/04-agents-and-custom-instructions",
-            "learning-hub/cli-for-beginners/05-skills",
-            "learning-hub/cli-for-beginners/06-mcp-servers",
-            "learning-hub/cli-for-beginners/07-putting-it-all-together",
+            // Additional courses slot in here as their content lands:
+            //   Advanced CLI (github/awesome-copilot PR 2800) and
+            //   Copilot App for Beginners (upcoming). Each is a nested
+            //   sub-group like "CLI for Beginners" above. Do not add a
+            //   sidebar entry until the referenced markdown files exist —
+            //   an unresolved slug fails the build.
           ],
         },
         {
-          label: "Copilot Workshops",
+          label: "Workshops",
           items: [
             {
               label: "Overview",
@@ -231,17 +238,17 @@ export default defineConfig({
           ],
         },
         {
-          label: "Hands-on",
+          label: "Video content",
+          items: ["learning-hub/videos/cli-for-beginners"],
+        },
+        {
+          label: "Additional resources",
           items: [
             {
               label: "Cookbook",
               link: "/learning-hub/cookbook/",
             },
-          ],
-        },
-        {
-          label: "Browse Resources",
-          items: [
+            "learning-hub/github-copilot-terminology-glossary",
             { label: "Home", link: "/" },
             { label: "Agents", link: "/agents/" },
             { label: "Instructions", link: "/instructions/" },

--- a/website/src/components/Head.astro
+++ b/website/src/components/Head.astro
@@ -38,6 +38,7 @@ const contentSecurityPolicy = [
   "default-src 'self'",
   "base-uri 'self'",
   "object-src 'none'",
+  "frame-src https://www.youtube-nocookie.com https://www.youtube.com",
   "form-action 'none'",
   "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://analytics.githubassets.com",
   "style-src 'self' 'unsafe-inline'",

--- a/website/src/content/docs/learning-hub/index.md
+++ b/website/src/content/docs/learning-hub/index.md
@@ -4,35 +4,24 @@ description: "Curated articles, walkthroughs, and reference material to help you
 tableOfContents: false
 ---
 
-## Getting Started
-
-New to GitHub Copilot? Start here to understand the tools available to you.
-
-**Desktop App**: Explore the [GitHub Copilot app](github-copilot-app/) — a control center for directing multiple agents in parallel. Perfect for agent-native development and parallel work with isolated worktrees.
-
-**Automations**: Start with [Using Automations in the GitHub Copilot app](using-automations-in-copilot-app/) for templates, setup guidance, and real examples.
-
-**Canvases**: Learn [Working with Canvas Extensions](working-with-canvas-extensions/) to create and evolve interactive canvases with `/create-canvas`.
-
-**Terminal**: Looking for a guided path into GitHub Copilot from the terminal? Explore the [Copilot CLI for Beginners](cli-for-beginners/) with a text-based experience or the [YouTube video series](https://www.youtube.com/watch?v=BDxRhhs36ns&list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl).
-
-**Workshop**: Prefer to learn by building? Work through [Hands-on with GitHub Copilot's agents](copilot-workshops/) — a hands-on workshop with four harnesses (VS Code, Copilot CLI, Copilot app, and cloud agent) built around a shared Tailspin Toys backlog.
+Welcome to the GitHub Copilot Learning Hub. Whether you want to understand the concepts, work through a course, get hands-on in a workshop, watch along, or look something up, the sections below (and the sidebar) map to how you like to learn.
 
 ## Fundamentals
 
-Essential concepts to tailor GitHub Copilot beyond its default experience. Start with
-[What are Agents, Skills, and Instructions](what-are-agents-skills-instructions/)
-and work through the full track to master every customization primitive. For delegation
-and orchestration patterns, continue with [Agents and Subagents](agents-and-subagents/).
+New to GitHub Copilot? Start here to understand the tools and concepts you'll build on. Explore the [GitHub Copilot app](github-copilot-app/) — a control center for directing multiple agents in parallel — then learn [What are Agents, Skills, and Instructions](what-are-agents-skills-instructions/) and how to extend them with [Agents and Subagents](agents-and-subagents/), [custom instructions](defining-custom-instructions/), [skills](creating-effective-skills/), [MCP servers](understanding-mcp-servers/), [automations](using-automations-in-copilot-app/), and [canvas extensions](working-with-canvas-extensions/).
 
-## Reference
+## Courses
 
-Quick-lookup resources to keep handy while you work. Browse the
-[GitHub Copilot Terminology Glossary](github-copilot-terminology-glossary/)
-for definitions of common terms and concepts.
+Prefer a guided, self-paced path? Work through a full course end to end. Start with [CLI for Beginners](cli-for-beginners/) — a beginner-friendly path into GitHub Copilot from the terminal. More courses are on the way.
 
-## Hands-on
+## Workshops
 
-Interactive samples and recipes to learn by doing. Jump into the
-[Cookbook](cookbook/) for code samples, recipes,
-and examples you can use right away.
+Prefer to learn by building? Work through [Hands-on with GitHub Copilot's agents](copilot-workshops/) — a workshop with four harnesses (VS Code, Copilot CLI, Copilot app, and cloud agent) built around a shared Tailspin Toys backlog.
+
+## Video content
+
+Rather watch than read? Follow along with the [CLI for Beginners video series](videos/cli-for-beginners/) on YouTube — the same course, in video form.
+
+## Additional resources
+
+Keep these handy while you work. Jump into the [Cookbook](cookbook/) for code samples, recipes, and examples you can use right away, or browse the [GitHub Copilot Terminology Glossary](github-copilot-terminology-glossary/) for definitions of common terms and concepts.

--- a/website/src/content/docs/learning-hub/index.md
+++ b/website/src/content/docs/learning-hub/index.md
@@ -20,7 +20,7 @@ Prefer to learn by building? Work through [Hands-on with GitHub Copilot's agents
 
 ## Video content
 
-Rather watch than read? Explore the [CLI for Beginners video series](videos/cli-for-beginners/) on YouTube.
+Rather watch than read? Explore the [GitHub Copilot CLI for beginners](videos/cli-for-beginners/) and [GitHub Copilot app for beginners](videos/copilot-app/) video series on YouTube.
 
 ## Additional resources
 

--- a/website/src/content/docs/learning-hub/index.md
+++ b/website/src/content/docs/learning-hub/index.md
@@ -12,7 +12,7 @@ New to GitHub Copilot? Start here to understand the tools and concepts you'll bu
 
 ## Courses
 
-Prefer a guided, self-paced path? Work through a full course end to end. Start with [CLI for Beginners](cli-for-beginners/) — a beginner-friendly path into GitHub Copilot from the terminal. More courses are on the way.
+Prefer a guided, self-paced path? Work through a full course end to end. Start with [CLI for Beginners](cli-for-beginners/) — a beginner-friendly path into GitHub Copilot from the terminal.
 
 ## Workshops
 
@@ -20,7 +20,7 @@ Prefer to learn by building? Work through [Hands-on with GitHub Copilot's agents
 
 ## Video content
 
-Rather watch than read? Follow along with the [CLI for Beginners video series](videos/cli-for-beginners/) on YouTube — the same course, in video form.
+Rather watch than read? Explore the [CLI for Beginners video series](videos/cli-for-beginners/) on YouTube.
 
 ## Additional resources
 

--- a/website/src/content/docs/learning-hub/videos/cli-for-beginners.md
+++ b/website/src/content/docs/learning-hub/videos/cli-for-beginners.md
@@ -7,6 +7,8 @@ sidebar:
 
 Learn GitHub Copilot CLI by watching. This beginner-friendly series walks you through using AI assistance directly in your terminal — from install and first prompts to slash commands, delegation, MCP, and customization. Play an episode below, or [watch the full playlist on YouTube](https://www.youtube.com/watch?v=BDxRhhs36ns&list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl).
 
+New here? [Install GitHub Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli) to follow along.
+
 ### 1. Getting started with GitHub Copilot CLI
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/BDxRhhs36ns?list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl" title="Getting started with GitHub Copilot CLI" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>

--- a/website/src/content/docs/learning-hub/videos/cli-for-beginners.md
+++ b/website/src/content/docs/learning-hub/videos/cli-for-beginners.md
@@ -1,12 +1,46 @@
 ---
-title: "CLI for Beginners (Video Series)"
-description: "Watch the GitHub Copilot CLI for Beginners course as a guided YouTube video series."
+title: "GitHub Copilot CLI for beginners"
+description: "Watch the beginner-friendly GitHub Copilot CLI video series — a guided tour of AI assistance in your terminal, one episode at a time."
+sidebar:
+  label: GitHub Copilot CLI for beginners
 ---
 
-Prefer to learn by watching? The **GitHub Copilot CLI for Beginners** course is also available as a YouTube video series — the same beginner-friendly path through the CLI, in video form.
+Learn GitHub Copilot CLI by watching. This beginner-friendly series walks you through using AI assistance directly in your terminal — from install and first prompts to slash commands, delegation, MCP, and customization. Play an episode below, or [watch the full playlist on YouTube](https://www.youtube.com/watch?v=BDxRhhs36ns&list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl).
 
-[![Watch the GitHub Copilot CLI for Beginners video series on YouTube](https://img.youtube.com/vi/BDxRhhs36ns/hqdefault.jpg)](https://www.youtube.com/watch?v=BDxRhhs36ns&list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl)
+### 1. Getting started with GitHub Copilot CLI
 
-▶️ **[Watch the full playlist on YouTube](https://www.youtube.com/watch?v=BDxRhhs36ns&list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl)**
+<div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/BDxRhhs36ns?list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl" title="Getting started with GitHub Copilot CLI" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 
-Want the text-based version instead? Head to the [CLI for Beginners course](/learning-hub/cli-for-beginners/).
+Install the CLI with npm, authenticate with your GitHub account, and run your first prompts in the terminal.
+
+### 2. Interactive vs non-interactive modes
+
+<div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/bdIJkGr2NV0?list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl" title="Interactive vs non-interactive modes" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+
+Learn the two ways to run Copilot CLI — interactive sessions versus one-off non-interactive commands — and when to reach for each.
+
+### 3. A beginner's guide to slash commands
+
+<div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/-Yavis20B4Q?list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl" title="A beginner's guide to Copilot CLI slash commands" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+
+Use slash commands to steer the agent — switch models with `/model`, check status, and manage your session.
+
+### 4. Plan, delegate, and review
+
+<div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/v8dr7QcIiLU?list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl" title="Copilot CLI for beginners: Plan, delegate, and review" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+
+Have Copilot plan work and delegate it to the background, opening a draft pull request while you keep working on other tasks.
+
+### 5. How to use MCP servers
+
+<div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/DtQjVIRRszM?list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl" title="How to use MCP servers with GitHub Copilot CLI" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+
+Connect the Model Context Protocol (MCP) to give your agent access to external documentation, databases, and testing tools.
+
+### 6. Using agents, skills, and instructions
+
+<div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/-yKALFS5ewY?list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl" title="How to use agents, skills, and instructions in Copilot CLI" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+
+Customize the CLI with instructions, skills, and custom agents so it works the way your project needs.
+
+Looking for a text-based path instead? See the [CLI for Beginners course](/learning-hub/cli-for-beginners/).

--- a/website/src/content/docs/learning-hub/videos/cli-for-beginners.md
+++ b/website/src/content/docs/learning-hub/videos/cli-for-beginners.md
@@ -1,0 +1,12 @@
+---
+title: "CLI for Beginners (Video Series)"
+description: "Watch the GitHub Copilot CLI for Beginners course as a guided YouTube video series."
+---
+
+Prefer to learn by watching? The **GitHub Copilot CLI for Beginners** course is also available as a YouTube video series — the same beginner-friendly path through the CLI, in video form.
+
+[![Watch the GitHub Copilot CLI for Beginners video series on YouTube](https://img.youtube.com/vi/BDxRhhs36ns/hqdefault.jpg)](https://www.youtube.com/watch?v=BDxRhhs36ns&list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl)
+
+▶️ **[Watch the full playlist on YouTube](https://www.youtube.com/watch?v=BDxRhhs36ns&list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl)**
+
+Want the text-based version instead? Head to the [CLI for Beginners course](/learning-hub/cli-for-beginners/).

--- a/website/src/content/docs/learning-hub/videos/cli-for-beginners.md
+++ b/website/src/content/docs/learning-hub/videos/cli-for-beginners.md
@@ -9,37 +9,37 @@ Learn GitHub Copilot CLI by watching. This beginner-friendly series walks you th
 
 New here? [Install GitHub Copilot CLI](https://docs.github.com/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli) to follow along.
 
-### 1. Getting started with GitHub Copilot CLI
+## 1. Getting started with GitHub Copilot CLI
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/BDxRhhs36ns?list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl" title="Getting started with GitHub Copilot CLI" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 
 Install the CLI with npm, authenticate with your GitHub account, and run your first prompts in the terminal.
 
-### 2. Interactive vs non-interactive modes
+## 2. Interactive vs non-interactive modes
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/bdIJkGr2NV0?list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl" title="Interactive vs non-interactive modes" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 
 Learn the two ways to run Copilot CLI — interactive sessions versus one-off non-interactive commands — and when to reach for each.
 
-### 3. A beginner's guide to slash commands
+## 3. A beginner's guide to slash commands
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/-Yavis20B4Q?list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl" title="A beginner's guide to Copilot CLI slash commands" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 
 Use slash commands to steer the agent — switch models with `/model`, check status, and manage your session.
 
-### 4. Plan, delegate, and review
+## 4. Plan, delegate, and review
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/v8dr7QcIiLU?list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl" title="Copilot CLI for beginners: Plan, delegate, and review" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 
 Have Copilot plan work and delegate it to the background, opening a draft pull request while you keep working on other tasks.
 
-### 5. How to use MCP servers
+## 5. How to use MCP servers
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/DtQjVIRRszM?list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl" title="How to use MCP servers with GitHub Copilot CLI" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 
 Connect the Model Context Protocol (MCP) to give your agent access to external documentation, databases, and testing tools.
 
-### 6. Using agents, skills, and instructions
+## 6. Using agents, skills, and instructions
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/-yKALFS5ewY?list=PL0lo9MOBetEHvO-spzKBAITkkTqv4RvNl" title="How to use agents, skills, and instructions in Copilot CLI" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 

--- a/website/src/content/docs/learning-hub/videos/copilot-app.md
+++ b/website/src/content/docs/learning-hub/videos/copilot-app.md
@@ -7,6 +7,8 @@ sidebar:
 
 Meet the GitHub Copilot app — your agent-native desktop home for working on GitHub. This beginner-friendly series covers writing your first prompt, tracking work, automations, running agents in parallel, and reviewing changes in-app. Play an episode below, or [watch the full playlist on YouTube](https://www.youtube.com/watch?v=LsA4vIX_3UY&list=PLNBWjViYXaIY).
 
+New here? [Install the GitHub Copilot app](https://gh.io/app) to follow along.
+
 ### 1. Meet the GitHub Copilot app
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/LsA4vIX_3UY?list=PLNBWjViYXaIY" title="Meet the GitHub Copilot app" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>

--- a/website/src/content/docs/learning-hub/videos/copilot-app.md
+++ b/website/src/content/docs/learning-hub/videos/copilot-app.md
@@ -1,0 +1,46 @@
+---
+title: "GitHub Copilot app for beginners"
+description: "Watch the beginner-friendly GitHub Copilot app video series — a guided tour of your AI desktop assistant, one episode at a time."
+sidebar:
+  label: GitHub Copilot app for beginners
+---
+
+Meet the GitHub Copilot app — your agent-native desktop home for working on GitHub. This beginner-friendly series covers writing your first prompt, tracking work, automations, running agents in parallel, and reviewing changes in-app. Play an episode below, or [watch the full playlist on YouTube](https://www.youtube.com/watch?v=LsA4vIX_3UY&list=PLNBWjViYXaIY).
+
+### 1. Meet the GitHub Copilot app
+
+<div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/LsA4vIX_3UY?list=PLNBWjViYXaIY" title="Meet the GitHub Copilot app" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+
+Meet the agent-native desktop home for your GitHub work, and see how it differs from linear, isolated AI coding.
+
+### 2. Write your first prompt
+
+<div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/WrMt6T8yu18?list=PLNBWjViYXaIY" title="Write your first prompt in the GitHub Copilot app" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+
+Start your first session, write your first prompt, and add project context in the Copilot app.
+
+### 3. The My work tab: your mission control
+
+<div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/h9g4umRfgn0?list=PLNBWjViYXaIY" title="The My work tab: your mission control in the GitHub Copilot app" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+
+Use the My work tab as mission control to track tasks across repositories from one centralized place.
+
+### 4. Automate recurring developer tasks
+
+<div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/k73_z4Hv3Ls?list=PLNBWjViYXaIY" title="Automate recurring developer tasks with the GitHub Copilot app" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+
+Set up automations to handle recurring chores like dependency updates and pull request triage.
+
+### 5. Run parallel AI agents
+
+<div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/F1UwPa7lemA?list=PLNBWjViYXaIY" title="How to run parallel AI agents in the GitHub Copilot app" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+
+Run multiple agents on the same project at once, using isolated git worktrees to keep their work conflict-free.
+
+### 6. Using the diff, terminal, and browser
+
+<div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/IyWlcES85Zw?list=PLNBWjViYXaIY" title="GitHub Copilot app for beginners: using the diff, terminal, and browser" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+
+Review agent changes without leaving the app using the built-in diff, terminal, and browser panels.
+
+Want to read more about the app? Start with [The GitHub Copilot app](/learning-hub/github-copilot-app/).

--- a/website/src/content/docs/learning-hub/videos/copilot-app.md
+++ b/website/src/content/docs/learning-hub/videos/copilot-app.md
@@ -9,37 +9,37 @@ Meet the GitHub Copilot app — your agent-native desktop home for working on Gi
 
 New here? [Install the GitHub Copilot app](https://gh.io/app) to follow along.
 
-### 1. Meet the GitHub Copilot app
+## 1. Meet the GitHub Copilot app
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/LsA4vIX_3UY?list=PLNBWjViYXaIY" title="Meet the GitHub Copilot app" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 
 Meet the agent-native desktop home for your GitHub work, and see how it differs from linear, isolated AI coding.
 
-### 2. Write your first prompt
+## 2. Write your first prompt
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/WrMt6T8yu18?list=PLNBWjViYXaIY" title="Write your first prompt in the GitHub Copilot app" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 
 Start your first session, write your first prompt, and add project context in the Copilot app.
 
-### 3. The My work tab: your mission control
+## 3. The My work tab: your mission control
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/h9g4umRfgn0?list=PLNBWjViYXaIY" title="The My work tab: your mission control in the GitHub Copilot app" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 
 Use the My work tab as mission control to track tasks across repositories from one centralized place.
 
-### 4. Automate recurring developer tasks
+## 4. Automate recurring developer tasks
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/k73_z4Hv3Ls?list=PLNBWjViYXaIY" title="Automate recurring developer tasks with the GitHub Copilot app" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 
 Set up automations to handle recurring chores like dependency updates and pull request triage.
 
-### 5. Run parallel AI agents
+## 5. Run parallel AI agents
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/F1UwPa7lemA?list=PLNBWjViYXaIY" title="How to run parallel AI agents in the GitHub Copilot app" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 
 Run multiple agents on the same project at once, using isolated git worktrees to keep their work conflict-free.
 
-### 6. Using the diff, terminal, and browser
+## 6. Using the diff, terminal, and browser
 
 <div class="video-embed"><iframe src="https://www.youtube-nocookie.com/embed/IyWlcES85Zw?list=PLNBWjViYXaIY" title="GitHub Copilot app for beginners: using the diff, terminal, and browser" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
 

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -3745,3 +3745,15 @@ header .theme-toggle-container {
     flex: 1 1 auto;
   }
 }
+/* Learning Hub video pages: responsive 16:9 YouTube embeds */
+.video-embed {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  margin: 0.75rem 0 0.5rem;
+}
+.video-embed iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 8px;
+}

--- a/website/src/styles/starlight-overrides.css
+++ b/website/src/styles/starlight-overrides.css
@@ -71,7 +71,8 @@ header.header {
   background: var(--sl-color-gray-6) !important;
   border-bottom: 1px solid var(--sl-color-gray-5) !important;
   z-index: 1000;
-  position: relative;
+  position: sticky;
+  top: 0;
 }
 
 /* Header inner content for alignment */


### PR DESCRIPTION
## Summary

Restructures the Learning Hub so its navigation reads by **intent** — understand → learn → practice → watch → look up — and adds video landing pages. Today the sidebar is a flat pile of top-level groups mixing concepts, a course, a workshop, a cookbook, and outbound links, which doesn't scale as new content lands.

### Sidebar → five intent-based groups
- **Fundamentals** — the existing concept articles (unchanged).
- **Courses** — the CLI for Beginners course nests here, with a marked insertion point for upcoming courses.
- **Workshops** — renamed from "Copilot Workshops"; the four harness tracks are unchanged.
- **Video content** — new; in-hub video landing pages that embed the playlists.
- **Additional resources** — merges the Cookbook, Glossary, and the outbound browse links into one group.

All groups (and nested sub-groups) are **collapsed by default**; the active page's group still auto-expands. No URLs change — only labels and nesting — so no redirects are needed.

### Video landing pages
- `learning-hub/videos/cli-for-beginners` — **GitHub Copilot CLI for beginners**
- `learning-hub/videos/copilot-app` — **GitHub Copilot app for beginners**

Each lists every episode with a natively embedded, playable YouTube player (privacy-friendly `youtube-nocookie.com`, lazy-loaded), a short description, and an install link for the respective harness.

### Supporting changes
- Rewrote the Learning Hub landing page (`index.md`) to mirror the five sections.
- Added a `frame-src` directive (`youtube-nocookie.com`, `youtube.com`) to the Content Security Policy in `Head.astro` so the embeds are allowed.
- Made the site header `position: sticky` so toolbars no longer float over content while scrolling.
- Added a small `.video-embed` responsive-embed rule to `global.css`.

## Validation
- `npm run website:data` + `npm run build` pass; the new video pages and localized fallbacks build with no unresolved sidebar slugs.

## Related
This PR is intended to land first; **PR #2800 (Advanced Copilot CLI)** will stack on top of it, nesting its course under the new **Courses** group.
