### PR TITLE
Fix sentry-triage crash when `sentry` package isn't bundled

### DIFF
--- a/extensions/sentry-triage/README.md
+++ b/extensions/sentry-triage/README.md
@@ -61,10 +61,30 @@ that drafts a fix pull request.
 
 ## Install
 
-Drop this folder at `~/.copilot/extensions/sentry-triage/` for user scope, or in
-a repository at `.github/extensions/sentry-triage/` for project scope. Then
-install dependencies from inside the copied folder (this canvas depends on the
-`sentry` npm package at runtime):
+Drop this folder at `~/.copilot/extensions/sentry-triage/` for user scope, or in a
+repository at `.github/extensions/sentry-triage/` for project scope.
+
+This canvas depends on the [`sentry`](https://cli.sentry.dev) npm package at
+runtime, which isn't bundled with the extension source. If it's missing, the canvas
+still **opens** and shows a setup gate explaining what to do instead of crashing.
+
+### Let Copilot set it up (recommended)
+
+Because the canvas runs inside GitHub Copilot, the agent can install the dependency
+for you. Paste this into Copilot:
+
+> Install the `sentry-triage` canvas dependencies by running `npm install` in its
+> extension folder (`~/.copilot/extensions/sentry-triage/` for user scope, or
+> `.github/extensions/sentry-triage/` for project scope), then reload extensions.
+
+Then finish the one interactive step yourself — sign in so Copilot never handles a
+raw secret:
+
+```sh
+sentry auth login
+```
+
+### Or install it manually
 
 ```sh
 # User scope
@@ -74,10 +94,10 @@ cd ~/.copilot/extensions/sentry-triage
 cd .github/extensions/sentry-triage
 
 npm install
+sentry auth login
 ```
 
-Reload extensions in the GitHub Copilot app, then open the `sentry-triage`
-canvas.
+Reload extensions in the GitHub Copilot app, then open the `sentry-triage` canvas.
 
 ## Open the canvas in the correct repository scope
 

--- a/extensions/sentry-triage/preflight.mjs
+++ b/extensions/sentry-triage/preflight.mjs
@@ -50,6 +50,11 @@ export function unknownConnections() {
 
 const msg = (err) => (err instanceof Error ? err.message : String(err))
 
+// The optional `sentry` package isn't installed for this extension (a published
+// awesome-copilot plugin ships source only). This is a one-time setup step, not a
+// network blip and not an auth failure, so it gets its own gate branch.
+const isPackageMissing = (err) => Boolean(err) && err.code === 'SENTRY_PACKAGE_MISSING'
+
 // Text used for classification: the message plus any CLI stderr, since a rejected
 // credential (HTTP 401/403) often surfaces its status in stderr rather than the
 // Error message.
@@ -82,6 +87,9 @@ const isTransient = (err) =>
 // Turn the raw error into something a human can act on.
 const humanizeSentryError = (err) => {
   const t = msg(err)
+  if (isPackageMissing(err)) {
+    return 'The Sentry CLI isn’t installed for this canvas yet. Ask Copilot to “install the sentry-triage dependencies and reload extensions,” or run `npm install` in the extension folder (see the README). Then run `sentry auth login` and re-open this canvas.'
+  }
   if (isNotAuthenticated(err)) {
     return 'Sentry isn’t connected yet. Run `sentry auth login` in your terminal, then re-open this canvas.'
   }
@@ -104,7 +112,7 @@ const humanizeSentryError = (err) => {
 //     when their text happens to mention a network keyword.
 export function classifySentryError(err) {
   return {
-    configured: !isAuthFailure(err),
+    configured: !isAuthFailure(err) && !isPackageMissing(err),
     transient: isTransient(err),
     message: humanizeSentryError(err),
   }

--- a/extensions/sentry-triage/sentryClient.mjs
+++ b/extensions/sentry-triage/sentryClient.mjs
@@ -13,16 +13,62 @@
 // canvas's internal issue model lives in sentry.mjs so this file stays a thin,
 // swappable transport.
 
-import createSentrySDK, { SentryError } from 'sentry'
+// The heavyweight `sentry` CLI package is an OPTIONAL, lazily-loaded dependency.
+// awesome-copilot ships extension *source* only (no node_modules), so an installed
+// plugin may not have it. A top-level `import ... from 'sentry'` would throw
+// `Cannot find package 'sentry'` at module load and take the whole canvas down
+// before any UI renders. Instead we import it dynamically on first use and, when
+// it's absent, throw a clear SentryError (tagged SENTRY_PACKAGE_MISSING) that the
+// setup gate turns into actionable guidance — Copilot can install it for you.
+
+// A stand-in SentryError so callers can `import { SentryError }` at load time and
+// `instanceof`-check even when the package never loads. When the real package IS
+// present we replace this binding (a live ESM export) with the SDK's own
+// SentryError class, so existing `instanceof` + `.exitCode` checks keep matching
+// the errors the SDK actually throws.
+let SentryError = class SentryError extends Error {
+  constructor(message, opts = {}) {
+    super(message)
+    this.name = 'SentryError'
+    if (opts.code) this.code = opts.code
+  }
+}
 
 export { SentryError }
 
+// Fallback message when the optional `sentry` package can't be resolved. The
+// setup gate (preflight.mjs) rewrites this into fuller guidance; this is what
+// surfaces anywhere the raw error is shown.
+const PACKAGE_MISSING_MESSAGE =
+  'The Sentry CLI (the `sentry` npm package) is not installed for this extension. ' +
+  'Ask Copilot to set it up, or run `npm install` in the extension folder — see the README.'
+
 let sdk = null
+let sdkFactory = null
+
+// Import the optional `sentry` package exactly once. Throws a SentryError tagged
+// SENTRY_PACKAGE_MISSING when it can't be resolved, and swaps in the SDK's real
+// SentryError class (live ESM binding) when it can.
+async function loadFactory() {
+  if (sdkFactory) return sdkFactory
+  let mod
+  try {
+    mod = await import('sentry')
+  } catch {
+    throw new SentryError(PACKAGE_MISSING_MESSAGE, { code: 'SENTRY_PACKAGE_MISSING' })
+  }
+  if (mod.SentryError) SentryError = mod.SentryError
+  sdkFactory = mod.default
+  return sdkFactory
+}
 
 // Lazily construct the SDK once. cwd affects the CLI's project-root / DSN
 // detection; we anchor it to the extension's cwd for determinism.
-function getSdk() {
-  if (!sdk) sdk = createSentrySDK({ cwd: process.cwd() })
+async function getSdk() {
+  if (!sdk) {
+    const create = await loadFactory()
+    sdk = create({ cwd: process.cwd() })
+  }
   return sdk
 }
 
@@ -77,13 +123,13 @@ function asArray(res) {
 // credential is present and valid; throws SentryError ("Not authenticated…")
 // otherwise. Used by preflight to gate the board.
 export async function whoami() {
-  return runSerial(() => getSdk().auth.whoami())
+  return runSerial(async () => (await getSdk()).auth.whoami())
 }
 
 // All organizations the stored credential can see. Raw org objects (each has a
 // `slug`).
 export async function orgList(limit = 100) {
-  return runSerial(async () => asArray(await getSdk().org.list({ limit })))
+  return runSerial(async () => asArray(await (await getSdk()).org.list({ limit })))
 }
 
 // Single-page project fetch within an org. Deliberately NOT wrapped in
@@ -96,13 +142,13 @@ export async function orgList(limit = 100) {
 // (see listProjects in sentry.mjs).
 export async function projectListRaw(org, limit = 100, cursor) {
   const orgProject = `${String(org || '').replace(/\/+$/, '')}/`
-  return asArray(await getSdk().project.list({ orgProject, limit, ...(cursor ? { cursor } : {}) }))
+  return asArray(await (await getSdk()).project.list({ orgProject, limit, ...(cursor ? { cursor } : {}) }))
 }
 
 // Verify a specific project exists / is accessible. Returns the raw project
 // object on success; throws SentryError when the slug is unknown or forbidden.
 export async function projectView(org, slug) {
-  return runSerial(() => getSdk().project.view({ orgProject: `${org}/${slug}` }))
+  return runSerial(async () => (await getSdk()).project.view({ orgProject: `${org}/${slug}` }))
 }
 
 // Search issues. `orgProject` is "org/project" (or the trailing-slash "org/" form
@@ -113,7 +159,7 @@ export async function projectView(org, slug) {
 export async function issueList({ orgProject, query, sort = 'date', limit = 100, period } = {}) {
   return runSerial(async () =>
     asArray(
-      await getSdk().issue.list({
+      await (await getSdk()).issue.list({
         ...(orgProject ? { orgProject } : {}),
         ...(query ? { query } : {}),
         ...(period ? { period } : {}),


### PR DESCRIPTION
The published awesome-copilot plugin ships extension source only (no node_modules), so the heavyweight `sentry` CLI dependency is absent at runtime. sentryClient.mjs statically imported it at module load, so the whole canvas crashed with `Cannot find package 'sentry'` before any UI rendered.

- sentryClient.mjs: load `sentry` via a lazy dynamic import on first use. When it's missing, throw a SentryError tagged SENTRY_PACKAGE_MISSING instead of crashing at load. SentryError is a live export that swaps to the SDK's real class when present, so instanceof/exitCode checks still match the errors the SDK throws.
- preflight.mjs: classify the missing package as a one-time setup gate (configured:false, transient:false) with actionable guidance instead of a retry-forever network error.
- README.md: add a "Let Copilot set it up" section with a paste-ready prompt so Copilot runs the install + reload, plus the manual fallback.

## Pull Request Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.
- [ ] I am targeting the `main` branch for this pull request.

---

## Description

<!-- Briefly describe your contribution and its purpose. Include any relevant context or usage notes. -->

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [ ] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

## Additional Notes

<!-- Add any additional information or context for reviewers here. -->

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
