### PR TITLE
Update github-copilot-modernization to 1.23.0

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -813,7 +813,7 @@
     {
       "name": "github-copilot-modernization",
       "description": "Autonomous application modernization using multi-agent orchestration for GitHub Copilot CLI. Supports Java upgrades (8→21, Spring Boot 2.x→3.x), .NET modernization, Azure migration, CVE/vulnerability fixing, and application rearchitecture (monolith-to-microservices). Features a 3-level agent hierarchy (orchestrator → coordinators → executors) with enterprise rulebook support for embedding organizational policies into the workflow.",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "author": {
         "name": "Microsoft",
         "url": "https://github.com/microsoft/github-copilot-modernization"
@@ -837,7 +837,7 @@
         "source": "github",
         "repo": "microsoft/github-copilot-modernization",
         "path": "plugins/github-copilot-modernization",
-        "sha": "8b644bebc7e1f929c01d80788293a37872f480f8"
+        "sha": "5d2a3268d816f794defb03a45cf527360b16071e"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -557,7 +557,7 @@
   {
     "name": "github-copilot-modernization",
     "description": "Autonomous application modernization using multi-agent orchestration for GitHub Copilot CLI. Supports Java upgrades (8→21, Spring Boot 2.x→3.x), .NET modernization, Azure migration, CVE/vulnerability fixing, and application rearchitecture (monolith-to-microservices). Features a 3-level agent hierarchy (orchestrator → coordinators → executors) with enterprise rulebook support for embedding organizational policies into the workflow.",
-    "version": "1.22.0",
+    "version": "1.23.0",
     "author": {
       "name": "Microsoft",
       "url": "https://github.com/microsoft/github-copilot-modernization"
@@ -581,7 +581,7 @@
       "source": "github",
       "repo": "microsoft/github-copilot-modernization",
       "path": "plugins/github-copilot-modernization",
-      "sha": "8b644bebc7e1f929c01d80788293a37872f480f8"
+      "sha": "5d2a3268d816f794defb03a45cf527360b16071e"
     }
   },
   {


### PR DESCRIPTION
Updates the github-copilot-modernization external plugin to 1.23.0, pins upstream commit 5d2a3268d816f794defb03a45cf527360b16071e, and regenerates the marketplace. Validated with the marketplace generator, source/generated entry consistency checks, and git diff --check. Full plugin validation was not run locally because the configured npm registry requires unavailable authentication; CI can perform it.