### PR TITLE
Harden sentry-triage repo/URL metadata validation and split issue/PR repos

### DIFF
--- a/extensions/sentry-triage/README.md
+++ b/extensions/sentry-triage/README.md
@@ -103,7 +103,7 @@ issue** or **Fix with Copilot**.
 ## Agent tools
 
 The canvas exposes structured hand-off tools the agent calls instead of printing
-JSON into the timeline: `submit_issue_summaries`, `submit_projects`,
+JSON into the timeline: `submit_issue_summaries`,
 `submit_tracking`, `submit_related`, and `submit_work_pr`.
 
 ## License

--- a/extensions/sentry-triage/components/page.mjs
+++ b/extensions/sentry-triage/components/page.mjs
@@ -1642,10 +1642,23 @@ export function Page({
       document.addEventListener("click", (e) => {
         const btn = e.target.closest("#refresh, #rescan");
         if (!btn) return;
-        fetch("/api/refresh", { method: "POST" });
         const subtitle = document.querySelector(".page-subtitle");
+        const prevSubtitle = subtitle ? subtitle.textContent : "";
         if (subtitle) subtitle.textContent = "Scanning Sentry...";
         showScanOverlay(currentProject ? "Scanning " + currentProject + "…" : "Scanning all projects…");
+        // Like the org/period rescans, verify the POST was accepted and roll the
+        // optimistic overlay back on failure. Fire-and-forget would otherwise leave
+        // the blocking overlay up (no SSE update ever arrives to clear it) until the
+        // long fallback timer expires when the loopback server is unreachable.
+        fetch("/api/refresh", { method: "POST" })
+          .then((res) => {
+            if (!res.ok) throw new Error("refresh " + res.status);
+          })
+          .catch(() => {
+            hideScanOverlay();
+            if (subtitle) subtitle.textContent = prevSubtitle;
+            window.alert("Couldn't start a rescan — the triage server may have stopped responding. Please try again.");
+          });
       });
 
       // Both "Create issue" and "Fix with Copilot" optimistically paint their
@@ -1742,9 +1755,16 @@ export function Page({
         const localProjectEl = document.getElementById("local-project");
         const localProjectId = localProjectEl?.value || "";
         let localProjectName = "";
+        let localProjectRepo = "";
         if (localProjectId) {
           const match = (Array.isArray(currentProjectOptions) ? currentProjectOptions : []).find((p) => p.id === localProjectId);
           localProjectName = match ? match.name : "";
+          // Freeze the selected project's repo into config at SAVE time. This is the
+          // repo the fix session's PR will land in, and it can differ from the
+          // issue/cloud repo. Capturing it here (a deliberate user selection) lets
+          // onWorkSelected validate the PR against the right repo without re-reading
+          // the live project list mid-batch.
+          localProjectRepo = match && match.repo ? match.repo : "";
         }
         const payload = {
           mode: document.getElementById("pr-mode")?.value || "local",
@@ -1753,6 +1773,7 @@ export function Page({
           localBranch: document.getElementById("local-branch")?.value || "",
           localProjectId: localProjectId,
           localProjectName: localProjectName,
+          localProjectRepo: localProjectRepo,
           cloudRepo: document.getElementById("cloud-repo")?.value || "",
           cloudBranch: document.getElementById("cloud-branch")?.value || "",
         };

--- a/extensions/sentry-triage/components/page.mjs
+++ b/extensions/sentry-triage/components/page.mjs
@@ -48,7 +48,6 @@ export function Page({
   prTargets,
   prSettingsOpen,
   plainEnglishView = false,
-  projectOptions = [],
   projects = [],
   availableModels = [],
   issueTrackers,
@@ -157,17 +156,6 @@ export function Page({
         .join('') +
       `</select></label>`
     : ''
-
-  // Registered app projects for the Local hand-off target dropdown. Loaded
-  // eagerly on open via the agent, so this may be empty on the very first render.
-  const projectList = Array.isArray(projectOptions) ? projectOptions : []
-  const localProjectId = prTargets && prTargets.local ? (prTargets.local.projectId || '') : ''
-  const projectOptionsHtml = projectList
-    .map((p) => {
-      const label = p.repo ? `${p.name} (${p.repo})` : p.name
-      return `<option value="${escapeHtml(p.id)}"${p.id === localProjectId ? ' selected' : ''}>${escapeHtml(label)}</option>`
-    })
-    .join('')
 
   return `<!doctype html>
 <html>
@@ -284,13 +272,7 @@ export function Page({
           <p id="mode-hint" class="settings-hint"></p>
           <div id="local-group" class="settings-subgroup${prTargets && prTargets.mode === 'cloud' ? ' dimmed' : ''}">
             <span class="settings-group-title">Local target</span>
-            <label class="settings-label">
-              Project
-              <select id="local-project" class="settings-input">
-                <option value="">Current project (default)</option>
-                ${projectOptionsHtml}
-              </select>
-            </label>
+            <p class="settings-hint">Runs in the <strong>current project</strong> (this checkout). For a different repo, use Cloud mode.</p>
             <div class="settings-row">
               <label class="settings-label">
                 Local path
@@ -611,7 +593,6 @@ export function Page({
       let currentProject = ${jsonForScript(project)};
       let currentPeriod = ${jsonForScript(period)};
       let currentPeriods = ${jsonForScript(periodList)};
-      let currentProjectOptions = ${jsonForScript(projectList)};
       // Sentry project slugs for the current org (SDK-discovered). Drives the
       // project autocomplete; empty = fall back to a typed slug box.
       let currentSentryProjects = ${jsonForScript(projectSlugs)};
@@ -850,14 +831,8 @@ export function Page({
         if (draftMode === "cloud") {
           draftTarget = (currentPrTargets?.cloud?.repo || "current repo") + " @ " + (currentPrTargets?.cloud?.baseBranch || "default");
         } else {
-          const projName = currentPrTargets?.local?.projectName || "";
-          const projId = currentPrTargets?.local?.projectId || "";
           const localBase = currentPrTargets?.local?.baseBranch || "default";
-          if (projId) {
-            draftTarget = (projName || projId) + " @ " + localBase;
-          } else {
-            draftTarget = (currentPrTargets?.local?.path || "current project") + " @ " + localBase;
-          }
+          draftTarget = (currentPrTargets?.local?.path || "current project") + " @ " + localBase;
         }
         const modelId = currentPrTargets?.model || "";
         const models = Array.isArray(currentAvailableModels) ? currentAvailableModels : [];
@@ -932,25 +907,6 @@ export function Page({
         syncCardModels();
         syncModelControls();
 
-        const localProject = document.getElementById("local-project");
-        if (localProject) {
-          const selectedId = currentPrTargets?.local?.projectId || "";
-          const options = Array.isArray(currentProjectOptions) ? currentProjectOptions : [];
-          localProject.innerHTML = "";
-          const base = document.createElement("option");
-          base.value = "";
-          base.textContent = "Current project (default)";
-          localProject.appendChild(base);
-          options.forEach((p) => {
-            const option = document.createElement("option");
-            option.value = p.id;
-            option.textContent = p.repo ? (p.name + " (" + p.repo + ")") : p.name;
-            option.selected = p.id === selectedId;
-            localProject.appendChild(option);
-          });
-          localProject.value = selectedId;
-        }
-
         const localPath = document.getElementById("local-path");
         if (localPath) localPath.value = currentPrTargets?.local?.path || "";
         const localBranch = document.getElementById("local-branch");
@@ -1015,7 +971,6 @@ export function Page({
           if (psel && psel.value !== msg.period) psel.value = msg.period;
         }
         if (Array.isArray(msg.periods)) currentPeriods = msg.periods;
-        if (Array.isArray(msg.projectOptions)) currentProjectOptions = msg.projectOptions;
         if (Array.isArray(msg.projects)) {
           const forOrg = typeof msg.projectsOrg === "string" ? msg.projectsOrg.trim().toLowerCase() : "";
           // Always cache under the org this list belongs to so re-selecting it is
@@ -1735,35 +1690,16 @@ export function Page({
 
       document.addEventListener("change", (e) => {
         if (e.target && e.target.id === "pr-mode") updateModeHint();
-        if (e.target && e.target.id === "local-project") {
-          const id = e.target.value || "";
-          const match = (Array.isArray(currentProjectOptions) ? currentProjectOptions : []).find((p) => p.id === id);
-          const localPath = document.getElementById("local-path");
-          if (localPath) localPath.value = match && match.path ? match.path : "";
-          // Keep the base branch in step with the selected project. Leaving the
-          // previous project's branch here would pair the new projectId with a
-          // stale (possibly nonexistent) base on save; clearing it falls back to
-          // this project's own default branch.
-          const localBranch = document.getElementById("local-branch");
-          if (localBranch) localBranch.value = match && match.defaultBranch ? match.defaultBranch : "";
-        }
       });
 
       document.addEventListener("click", (e) => {
         const btn = e.target.closest("#save-pr-config");
         if (!btn) return;
-        const localProjectEl = document.getElementById("local-project");
-        const localProjectId = localProjectEl?.value || "";
-        // Only the projectId is sent. Its repo/name are re-bound server-side from
-        // this id against the model-populated project list and used ONLY as display
-        // + dedup-search metadata (fix-session PRs are authorized by the host-resolved
-        // project_id, not this repo), so the browser must not supply them.
         const payload = {
           mode: document.getElementById("pr-mode")?.value || "local",
           model: document.getElementById("toolbar-model")?.value || "",
           localPath: document.getElementById("local-path")?.value || "",
           localBranch: document.getElementById("local-branch")?.value || "",
-          localProjectId: localProjectId,
           cloudRepo: document.getElementById("cloud-repo")?.value || "",
           cloudBranch: document.getElementById("cloud-branch")?.value || "",
         };

--- a/extensions/sentry-triage/components/page.mjs
+++ b/extensions/sentry-triage/components/page.mjs
@@ -1754,10 +1754,10 @@ export function Page({
         if (!btn) return;
         const localProjectEl = document.getElementById("local-project");
         const localProjectId = localProjectEl?.value || "";
-        // Only the projectId is sent. The authorization repo (and display name) are
-        // re-bound server-side from this id against the trusted project list — the
-        // dropdown is model-populated, so the browser must not supply the repo that
-        // gates where fix-session PRs may land.
+        // Only the projectId is sent. Its repo/name are re-bound server-side from
+        // this id against the model-populated project list and used ONLY as display
+        // + dedup-search metadata (fix-session PRs are authorized by the host-resolved
+        // project_id, not this repo), so the browser must not supply them.
         const payload = {
           mode: document.getElementById("pr-mode")?.value || "local",
           model: document.getElementById("toolbar-model")?.value || "",

--- a/extensions/sentry-triage/components/page.mjs
+++ b/extensions/sentry-triage/components/page.mjs
@@ -1754,26 +1754,16 @@ export function Page({
         if (!btn) return;
         const localProjectEl = document.getElementById("local-project");
         const localProjectId = localProjectEl?.value || "";
-        let localProjectName = "";
-        let localProjectRepo = "";
-        if (localProjectId) {
-          const match = (Array.isArray(currentProjectOptions) ? currentProjectOptions : []).find((p) => p.id === localProjectId);
-          localProjectName = match ? match.name : "";
-          // Freeze the selected project's repo into config at SAVE time. This is the
-          // repo the fix session's PR will land in, and it can differ from the
-          // issue/cloud repo. Capturing it here (a deliberate user selection) lets
-          // onWorkSelected validate the PR against the right repo without re-reading
-          // the live project list mid-batch.
-          localProjectRepo = match && match.repo ? match.repo : "";
-        }
+        // Only the projectId is sent. The authorization repo (and display name) are
+        // re-bound server-side from this id against the trusted project list — the
+        // dropdown is model-populated, so the browser must not supply the repo that
+        // gates where fix-session PRs may land.
         const payload = {
           mode: document.getElementById("pr-mode")?.value || "local",
           model: document.getElementById("toolbar-model")?.value || "",
           localPath: document.getElementById("local-path")?.value || "",
           localBranch: document.getElementById("local-branch")?.value || "",
           localProjectId: localProjectId,
-          localProjectName: localProjectName,
-          localProjectRepo: localProjectRepo,
           cloudRepo: document.getElementById("cloud-repo")?.value || "",
           cloudBranch: document.getElementById("cloud-branch")?.value || "",
         };

--- a/extensions/sentry-triage/extension.mjs
+++ b/extensions/sentry-triage/extension.mjs
@@ -22,27 +22,102 @@ function safeSentryUrl(value) {
   return ''
 }
 
-// True iff `value` is an http(s) URL whose HOST is exactly `allowedHost` AND
-// whose path is a GitHub issue/PR in exactly `expectedRepo` (owner/repo), i.e.
-// https://<allowedHost>/<owner>/<repo>/(issues|pull)/<n>. Validating the host as
-// well as owner/repo is essential: a path-only check would accept a look-alike
-// like https://attacker.example/<owner>/<repo>/pull/1 and let a model-reported
-// link masquerade as living in the authorized repository. `expectedRepo` and
-// `allowedHost` come from trusted config (Settings / local git / env), never from
-// the model or Sentry. Any parse failure, host mismatch, or shape mismatch → false
-// (fail closed).
-function urlInRepo(value, expectedRepo, allowedHost) {
-  if (!expectedRepo || !allowedHost) return false
+// Path shapes for the GitHub artifact kinds we validate. Anchoring on the exact
+// segment matters for correctness AND safety: a PR URL must never pass as an
+// issue, and — critically — an issue URL must never be trusted as a PR and mint a
+// bogus "PR #N" badge. The `(?:\/|$)` boundary after the id is required so a
+// look-alike like `/pull/123evil` or `/issues/7anything` can't be truncated to a
+// valid id — only the exact artifact path or one of its subpaths validates. `any`
+// is only for soft "related" hints that may be either kind.
+const REPO_REF_PATTERNS = {
+  issue: /^\/([^/]+)\/([^/]+)\/issues\/(\d+)(?:\/|$)/,
+  pull: /^\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:\/|$)/,
+  any: /^\/([^/]+)\/([^/]+)\/(?:issues|pull)\/(\d+)(?:\/|$)/,
+}
+
+// Parse a model-reported URL and return its numeric id ONLY when it is an http(s)
+// URL whose HOST is exactly `allowedHost` and whose path is a GitHub artifact of
+// the requested `kind` in exactly `expectedRepo` (owner/repo), i.e.
+// https://<allowedHost>/<owner>/<repo>/(issues|pull)/<n>. Returns null on any
+// parse failure, host mismatch, repo mismatch, or shape mismatch (fail closed).
+// Validating the host as well as owner/repo is essential: a path-only check would
+// accept a look-alike like https://attacker.example/<owner>/<repo>/pull/1 and let
+// a model-reported link masquerade as living in the authorized repository.
+// `expectedRepo` and `allowedHost` come from trusted config (Settings / local git
+// / env), never from the model or Sentry. The id must be a positive safe integer:
+// an unbounded digit run can parse to Infinity or a precision-losing value, and
+// any non-null result here is treated as verified, so reject those too.
+function repoRefNumber(value, expectedRepo, allowedHost, kind = 'any') {
+  if (!expectedRepo || !allowedHost) return null
   const href = safeSentryUrl(value)
-  if (!href) return false
+  if (!href) return null
   try {
     const url = new URL(href)
-    if (url.hostname.toLowerCase() !== String(allowedHost).toLowerCase()) return false
-    const m = url.pathname.match(/^\/([^/]+)\/([^/]+)\/(?:issues|pull)\/\d+/)
-    return !!m && `${m[1]}/${m[2]}`.toLowerCase() === String(expectedRepo).toLowerCase()
+    if (url.hostname.toLowerCase() !== String(allowedHost).toLowerCase()) return null
+    const m = url.pathname.match(REPO_REF_PATTERNS[kind] || REPO_REF_PATTERNS.any)
+    if (!m || `${m[1]}/${m[2]}`.toLowerCase() !== String(expectedRepo).toLowerCase()) return null
+    const n = Number(m[3])
+    if (!Number.isSafeInteger(n) || n <= 0) return null
+    return n
   } catch {
-    return false
+    return null
   }
+}
+
+// Boolean form: does `value` point at a GitHub artifact of `kind` in the expected
+// repo on the trusted host? Fails closed (false) on any mismatch.
+function urlInRepo(value, expectedRepo, allowedHost, kind = 'any') {
+  return repoRefNumber(value, expectedRepo, allowedHost, kind) !== null
+}
+
+// Validate a candidate GitHub "owner/repo" and return it lowercased, or '' when
+// blank/malformed (fails closed). Restrict each component to the characters GitHub
+// actually allows so a masquerading slug — `owner/repo?tab=x`, `owner/#frag`,
+// `owner/..`, or one carrying a path/query/fragment — can't slip through a lax
+// "one slash" check and authorize a write. Owner: alphanumerics and hyphens, no
+// leading/trailing hyphen, <=39 chars. Repo: alphanumerics plus `.`, `-`, `_`,
+// <=100 chars, but never the reserved `.` or `..` segments.
+function normalizeRepo(value) {
+  const raw = String(value || '').trim()
+  const m = /^([A-Za-z0-9-]{1,39})\/([A-Za-z0-9._-]{1,100})$/.exec(raw)
+  if (!m) return ''
+  const [, owner, repo] = m
+  if (owner.startsWith('-') || owner.endsWith('-')) return ''
+  if (repo === '.' || repo === '..') return ''
+  return raw.toLowerCase()
+}
+
+// Derive the two repo anchors the split-repo model enforces, from TRUSTED canvas
+// state only (Settings-configured prTargets / locally-detected defaults — never the
+// model or injected Sentry text):
+//   - expectedRepo:   where the tracking ISSUE is filed (the issue/cloud repo).
+//   - prExpectedRepo: where the fix session opens its PR.
+// They can differ, and the PR anchor depends on WHERE the fix session runs:
+//   - Cloud mode: the session runs on the cloud repo, where the issue is also
+//     filed, so the PR anchor is the issue repo.
+//   - Local mode with an EXPLICITLY selected registered project (local.projectId
+//     set): the session runs in THAT project, so the PR lands in its config-time
+//     repo (local.repo, frozen when the user picked it in Settings — NOT re-read
+//     from the model-relayed project list at work time, which is refreshed inside
+//     the same turn that ingests untrusted Sentry data). If that repo is empty or
+//     malformed we FAIL CLOSED (prExpectedRepo='') rather than silently authorizing
+//     an unrelated repo; the caller's preflight then blocks.
+//   - Local mode with "Current project" (no explicit selection): the session runs
+//     in the canvas's OWN checkout, so the PR lands in the trusted current-project
+//     repo (`currentProjectRepo`, seeded from the session cwd's git remote) — NOT
+//     the issue repo, which Settings may point at a separate cloud repo. Using the
+//     issue repo here would make dedup search the wrong repo and reject the real
+//     PR callback.
+// Both values are '' unless a concrete "owner/repo" resolves.
+function deriveRepoAnchors(prTargets, issueRepo, currentProjectRepo) {
+  const expectedRepo = normalizeRepo(issueRepo)
+  const isCloudMode = prTargets?.mode === 'cloud'
+  if (isCloudMode) return { expectedRepo, prExpectedRepo: expectedRepo }
+  const localProjectSelected = Boolean(prTargets?.local?.projectId)
+  const prExpectedRepo = localProjectSelected
+    ? normalizeRepo(prTargets?.local?.repo)
+    : normalizeRepo(currentProjectRepo)
+  return { expectedRepo, prExpectedRepo }
 }
 
 // Every model turn (scan enrichment and each work item) runs on the ONE shared
@@ -463,6 +538,12 @@ function buildWorkPrompt({ key, issue, org, prTargets, model: modelOverride, ass
   const prMode = prTargets?.mode === 'cloud' ? 'cloud' : 'local'
   const model = modelOverride || prTargets?.model || ''
   const targetRepo = issueRepo || cloudRepo || defaults.repo || '(current repository)'
+  // The draft PR is opened where the fix session runs, which in local mode with an
+  // explicitly selected project is that project's repo — NOT the issue repo. Use
+  // this PR-repo anchor for the Step-0 open-PR dedup search; issue lookup/creation
+  // stays on the issue repo (targetRepo). Mirrors the enforcement in onWorkSelected.
+  const { prExpectedRepo } = deriveRepoAnchors(prTargets, issueRepo, defaults.repo)
+  const prSearchRepo = prExpectedRepo || targetRepo
   const plain = sanitizeForPrompt(issue.plainEnglish || issue.summary || 'User-visible failure in production', 200)
   const issueTitle = `[sentry-triage][${key}] ${plain}`.slice(0, 120)
   const markerLabel = 'sentry-triage'
@@ -592,13 +673,13 @@ Return JSON only (no markdown), using one of these shapes:
   // Step 0 dedup is tracker-aware: the ISSUE may live in Linear/Jira, but the
   // draft PR is always a GitHub PR, so we always also check GitHub for an open PR.
   const dedupBlock = selectedTracker === 'github'
-    ? `0. BEFORE creating anything, check whether this Sentry issue is ALREADY BEING WORKED ON in repo ${targetRepo}. "Being worked on" means an OPEN pull request exists for it — nothing else counts:
-   - Search OPEN PRs for "${key}" and "${urlSafe}", preferring the marker label "${markerLabel}" and/or title/body references.
+    ? `0. BEFORE creating anything, check whether this Sentry issue is ALREADY BEING WORKED ON. "Being worked on" means an OPEN pull request exists for it — nothing else counts:
+   - Search OPEN PRs in the PR repo ${prSearchRepo} for "${key}" and "${urlSafe}", preferring the marker label "${markerLabel}" and/or title/body references.
    - A CLOSED or MERGED PR does NOT count as active work. If the only PR you find is closed/merged, this is NOT a duplicate — proceed to Steps 1-2 to open fresh work.
-   - Also look for an existing OPEN tracking issue (marker label "${markerLabel}", or title/body references "${key}"). An open issue on its own, with NO open PR, does NOT count as "being worked on" — but remember it so Step 1 can REUSE it instead of filing a duplicate.
+   - Also look in the issue repo ${targetRepo} for an existing OPEN tracking issue (marker label "${markerLabel}", or title/body references "${key}"). An open issue on its own, with NO open PR, does NOT count as "being worked on" — but remember it so Step 1 can REUSE it instead of filing a duplicate.
    - ONLY if an OPEN PR exists: STOP. Do not create anything. Return JSON with status "skipped" and the existing open PR's number, url, and state "open" (or "draft" for a draft PR) (and its issue if any).`
     : `0. BEFORE creating anything, check whether this Sentry issue is ALREADY BEING WORKED ON. "Being worked on" means an OPEN GitHub pull request exists for it — nothing else counts:
-   - In GitHub repo ${targetRepo}: search OPEN PRs for "${key}" and "${urlSafe}".
+   - In GitHub PR repo ${prSearchRepo}: search OPEN PRs for "${key}" and "${urlSafe}".
    - A CLOSED or MERGED PR does NOT count as active work. If the only PR you find is closed/merged, this is NOT a duplicate — proceed to Steps 1-2.
    - In tracker "${selectedTrackerLabel}" (id: ${selectedTracker}): look for an existing OPEN issue referencing "${key}". An open issue on its own, with NO open PR, does NOT count as "being worked on" — but remember it so Step 1 can REUSE it instead of filing a duplicate.
    - ONLY if an OPEN PR exists: STOP. Do not create anything. Return JSON with status "skipped" and the existing open PR's number, url, and state "open" (or "draft" for a draft PR) (and its issue if any).`
@@ -811,6 +892,11 @@ Also, in the SAME turn, silently load the user's registered app projects for the
   const trackRepo = selectedTracker === 'github'
     ? (trackPrTargets?.cloud?.repo || runtimeDefaults.repo || '')
     : ''
+  // Issue vs PR repo split for enrichment: the tracking ISSUE lives in trackRepo,
+  // but its linked PR can live in the selected project's repo (see
+  // deriveRepoAnchors). Validate each reported URL against its own anchor below.
+  const { prExpectedRepo: trackPrExpectedRepo } = deriveRepoAnchors(trackPrTargets, trackRepo, runtimeDefaults.repo)
+  const trackPrRepo = trackPrExpectedRepo || trackRepo
   const needTracking = !!trackRepo
   const trackingToken = needTracking ? makeTrackingToken() : ''
   const trackingBlock = needTracking
@@ -818,7 +904,7 @@ Also, in the SAME turn, silently load the user's registered app projects for the
 
 Also, in the SAME turn, silently detect which of these Sentry issues already have a tracking GitHub issue/PR (best-effort; do not mention this in your reply, and if the searches fail or find nothing just call the tool with an empty object):
 - Tracking issues were filed with the label "sentry-triage" and contain the Sentry key in their title. Search the repo ${trackRepo} for them, e.g. run: gh search issues --repo ${trackRepo} --label sentry-triage --limit 100 --json number,title,url,state
-- For each Sentry key listed below, if a tracking issue's title contains that EXACT key, record it. Then find that issue's linked/closing pull request, e.g. gh issue view <number> --repo ${trackRepo} --json number,url,state,closedByPullRequestsReferences  (or: gh pr list --repo ${trackRepo} --state all --search "<key>" --json number,url,state,isDraft).
+- For each Sentry key listed below, if a tracking issue's title contains that EXACT key, record it. Then find that issue's linked/closing pull request (the PR may live in a DIFFERENT repo, ${trackPrRepo}), e.g. gh issue view <number> --repo ${trackRepo} --json number,url,state,closedByPullRequestsReferences  (or: gh pr list --repo ${trackPrRepo} --state all --search "<key>" --json number,url,state,isDraft).
 - Call the tool "submit_tracking" exactly once with token "${trackingToken}" (unchanged) and tracking: an object mapping each matched Sentry key to { issueNumber, issueUrl, issueState, prNumber, prUrl, prState }. Include ONLY keys that have a tracking issue; omit the pr* fields when there is no linked PR. Use lowercase state strings: "open", "closed", "merged", or "draft" (use "draft" for an open draft PR).`
     : ''
 
@@ -905,22 +991,41 @@ ${items.map((i) => `${i.key}: ${i.title}`).join('\n')}`
         // badge we verify (1) the key is a real board issue for THIS scope and
         // (2) every link it carries lives on the trusted host + configured repo.
         // A record whose issueUrl can't be confirmed (missing, wrong host, wrong
-        // repo, or bad shape), or whose prUrl is present but doesn't match, is
-        // discarded — a look-alike link must never mint a Tracked badge.
+        // repo, or bad shape) is discarded entirely. The PR is a separate, weaker
+        // signal: its pr* fields are kept ONLY when a concrete prUrl validates
+        // against the PR repo — otherwise they are stripped while the authorized
+        // issue is retained. A look-alike (or URL-less) link must never mint a badge.
         const validKeys = new Set()
         for (const category of categories) {
           for (const issue of category.issues) validKeys.add(issue.key)
         }
-        const trackExpectedRepo = /^[^/\s]+\/[^/\s]+$/.test(String(trackRepo || ''))
-          ? String(trackRepo).toLowerCase()
-          : ''
+        const trackExpectedRepo = normalizeRepo(trackRepo)
         const allowedHost = runtimeDefaults.host || 'github.com'
         for (const [issueKey, info] of Object.entries(tracking)) {
           if (!validKeys.has(issueKey)) continue
           if (!info || typeof info !== 'object') continue
-          if (!urlInRepo(info.issueUrl, trackExpectedRepo, allowedHost)) continue
-          if (info.prUrl && !urlInRepo(info.prUrl, trackExpectedRepo, allowedHost)) continue
-          entry.state.setTrackedWorkStatus(issueKey, info)
+          // The tracking ISSUE is the source of truth: its URL must be an issue in
+          // the issue repo or the whole record is worthless — drop it. Require the
+          // `/issues/<n>` shape so a PR URL can't masquerade as the issue, and derive
+          // issueNumber from that validated URL so a mismatched model-reported number
+          // can't render "issue #999" while linking to a different /issues/<n>.
+          const verifiedIssueNumber = repoRefNumber(info.issueUrl, trackExpectedRepo, allowedHost, 'issue')
+          if (verifiedIssueNumber === null) continue
+          // Trust the PR's pr* fields ONLY when a concrete prUrl is a `/pull/<n>` in
+          // the PR anchor (which can differ from the issue repo in split-repo local
+          // mode). A model-reported prNumber/prState with NO url, an issue URL, or a
+          // url in the wrong repo is unverifiable: strip EVERY pr* field (the card
+          // renders a badge from prNumber alone, and prState alone can keep a closed
+          // issue "tracked") but KEEP the authorized issue. Derive prNumber from the
+          // validated URL itself so a mismatched model-reported number can never
+          // render a badge pointing at a different PR than the one we verified.
+          const verifiedPrNumber = info.prUrl
+            ? repoRefNumber(info.prUrl, trackPrExpectedRepo, allowedHost, 'pull')
+            : null
+          const record = verifiedPrNumber !== null
+            ? { ...info, issueNumber: verifiedIssueNumber, prNumber: verifiedPrNumber }
+            : { issueNumber: verifiedIssueNumber, issueUrl: info.issueUrl, issueState: info.issueState }
+          entry.state.setTrackedWorkStatus(issueKey, record)
         }
       }
     }
@@ -1263,9 +1368,12 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
   // have filed where we asked. Empty unless a concrete "owner/repo" is known, in
   // which case URL checking is skipped (no anchor to compare against).
   const isGithubTracker = selectedTrackerConfig.id === 'github'
-  const expectedRepo = /^[^/\s]+\/[^/\s]+$/.test(String(issueRepo || ''))
-    ? String(issueRepo).toLowerCase()
-    : ''
+  // The tracking ISSUE and the code PR can live in DIFFERENT repos, both derived
+  // OUTSIDE the model from trusted canvas state (see deriveRepoAnchors). Each gates
+  // the outside-the-model URL enforcement for its own artifact: only a well-formed
+  // "owner/repo" anchor can validate a model-reported artifact URL, so a blank or
+  // malformed value resolves to '' (fails closed — no URL check, and blocked below).
+  const { expectedRepo, prExpectedRepo } = deriveRepoAnchors(prTargets, issueRepo, runtimeDefaults.repo)
   // Trusted host the authorized issue/PR links must live on, paired with
   // `expectedRepo`. Repo alone is not enough: a look-alike host would otherwise
   // let a model-reported link pass the repo check (see urlInRepo). Sourced from
@@ -1279,18 +1387,30 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
   // action would write to GitHub. Without a trusted `expectedRepo` the
   // outside-the-model URL enforcement below has nothing to compare against and is
   // skipped entirely — precisely the state injected Sentry text could exploit to
-  // steer a write elsewhere. Every GitHub-writing path needs the anchor: the
-  // "Fix with Copilot" path ALWAYS opens a GitHub PR, and the tracking-only path
-  // files a GitHub issue whenever the GitHub tracker is selected. Only a
-  // tracking-only run on a non-GitHub tracker (Linear/Jira) performs no GitHub
-  // write, so it may proceed without a repo anchor. Normal checkouts resolve a
-  // repo from the git remote; this trips only when detection fails or no target
-  // is configured — tell the user to set one rather than writing unverifiably.
-  if (!expectedRepo && (wantsCopilot || isGithubTracker)) {
+  // steer a write elsewhere. The "Fix with Copilot" path ALWAYS opens a GitHub PR,
+  // so it needs a concrete PR-repo anchor; a GitHub tracker ALWAYS files an issue,
+  // so it needs a concrete issue-repo anchor. Only a tracking-only run on a
+  // non-GitHub tracker (Linear/Jira) performs no GitHub write, so it may proceed
+  // without a repo anchor. Normal checkouts resolve a repo from the git remote;
+  // this trips only when detection fails or a target lacks a valid repo. The two
+  // failures have different fixes, so report the one that actually bit: a missing
+  // ISSUE anchor means no target repo is configured (fix in Settings), while a
+  // missing PR anchor with a VALID issue repo means the resolved PR project has
+  // empty/malformed repo metadata. That happens two ways: an explicitly selected
+  // local project whose config-time repo is blank/malformed (fix: pick a project
+  // with a valid owner/repo), or "Current project" running in a checkout with no
+  // detectable GitHub remote (fix: run from a repo-backed checkout). Both share a
+  // message that names either remedy.
+  const missingIssueRepo = isGithubTracker && !expectedRepo
+  const missingPrRepo = wantsCopilot && !prExpectedRepo
+  if (missingIssueRepo || missingPrRepo) {
+    const error = missingIssueRepo
+      ? 'No target repository is configured, so issue creation cannot be verified. Set a target repository in Settings before starting work.'
+      : 'The pull request destination has no valid repository (owner/repo), so it cannot be verified. Select a project with valid repository metadata, or open this canvas from a checkout with a GitHub remote, before starting work.'
     for (const key of startableKeys) {
       entry.notifyWork(key, {
         phase: 'error',
-        error: 'No target repository is configured, so issue/PR creation cannot be verified. Set a target repository in Settings before starting work.',
+        error,
       })
     }
     return
@@ -1341,9 +1461,10 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
     // validated against THAT repo, not whatever the target settings happen to be
     // when the callback lands — changing the target mid-flight must not cause a
     // legitimate PR in the original repo to be rejected (or an attacker one in a
-    // newly-set repo to pass).
+    // newly-set repo to pass). The callback carries a PR, which lands in the PR
+    // repo (`prExpectedRepo`) — in local mode that can differ from the issue repo.
     const workToken = randomUUID()
-    workRegistry.set(workToken, { entry, key, scopeGen, authorizedRepo: expectedRepo, authorizedHost: allowedHost })
+    workRegistry.set(workToken, { entry, key, scopeGen, authorizedRepo: prExpectedRepo, authorizedHost: allowedHost })
 
     entry.notifyWork(key, { phase: 'working', error: '' })
     try {
@@ -1401,11 +1522,13 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
         // A bare PR number is not proof the dedup work lives in the authorized
         // repo — the card would render "already being worked on · PR #N" as an
         // authoritative claim, and the repo check below only covers URL-bearing
-        // artifacts. When a concrete repo is set, require the confirming PR to
-        // carry a URL (validated against expectedRepo just below); a number-only
-        // reference counts as no confirming PR and surfaces the retryable "no open
-        // pull request" error rather than a spoofable skip.
-        const hasPrRef = expectedRepo
+        // artifacts. When a concrete PR-repo anchor is set, require the confirming
+        // PR to carry a URL (validated against prExpectedRepo just below); a
+        // number-only reference counts as no confirming PR and surfaces the
+        // retryable "no open pull request" error rather than a spoofable skip. The
+        // PR lives in the PR repo, which in local mode can differ from the issue
+        // repo, so anchor this guard on prExpectedRepo — not expectedRepo.
+        const hasPrRef = prExpectedRepo
           ? Boolean(result.existingPrUrl)
           : Boolean(result.existingPrNumber || result.existingPrUrl)
         const hasActivePr = hasPrRef && ACTIVE_PR_STATES.has(result.existingPrState)
@@ -1423,23 +1546,24 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
         // Same outside-the-model repo enforcement for the dedup ("already being
         // worked on") links. A spoofed skip — injected Sentry text claiming work
         // already exists in an attacker-chosen repo — would otherwise surface a
-        // false "already being worked on" card linking off to that repo.
-        // `existingPrUrl` is always a GitHub PR, so it's checked whenever a concrete
-        // anchor is known; `existingIssueUrl` only on the GitHub tracker (Linear/Jira
-        // issue URLs legitimately live elsewhere). '' fails closed.
-        if (expectedRepo) {
-          const dedupArtifacts = [
-            ...(isGithubTracker ? [['issue', result.existingIssueUrl]] : []),
-            ['pull request', result.existingPrUrl],
-          ].filter(([, url]) => url)
-          const bad = dedupArtifacts.find(([, url]) => !urlInRepo(url, expectedRepo, allowedHost))
-          if (bad) {
-            entry.notifyWork(key, {
-              phase: 'error',
-              error: `The ${bad[0]} the agent reported as existing work is not in the expected repository (${expectedRepo}). Nothing was trusted — retry.`,
-            })
-            continue
-          }
+        // false "already being worked on" card linking off to that repo. Each URL
+        // is paired with the repo it must ACTUALLY live in: the issue URL with the
+        // issue repo (`expectedRepo`, GitHub tracker only — Linear/Jira issue URLs
+        // legitimately live elsewhere), and the PR URL with the PR repo
+        // (`prExpectedRepo`), which in local mode can differ from the issue repo.
+        // Each check is gated on its own anchor, so an empty anchor ('') skips just
+        // that artifact (failing closed for it) instead of shadowing the other.
+        const dedupArtifacts = [
+          ...(isGithubTracker && expectedRepo ? [['issue', result.existingIssueUrl, expectedRepo, 'issue']] : []),
+          ...(prExpectedRepo ? [['pull request', result.existingPrUrl, prExpectedRepo, 'pull']] : []),
+        ].filter(([, url]) => url)
+        const bad = dedupArtifacts.find(([, url, anchor, kind]) => !urlInRepo(url, anchor, allowedHost, kind))
+        if (bad) {
+          entry.notifyWork(key, {
+            phase: 'error',
+            error: `The ${bad[0]} the agent reported as existing work is not in the expected repository (${bad[2]}). Nothing was trusted — retry.`,
+          })
+          continue
         }
         entry.notifyWork(key, {
           phase: 'skipped',
@@ -1510,34 +1634,37 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
       // Only a hand-off leaves work pending an out-of-band PR callback; anything
       // else is terminal here, so release its token immediately.
       if (!handedOff) workRegistry.delete(workToken)
-      // Enforcement boundary OUTSIDE the model: the target repository was fixed by
-      // the canvas (trusted `expectedRepo`), not by the model or the untrusted
-      // Sentry text folded into the prompt. Independently re-derive the repo from
-      // every artifact URL the turn reported and reject the whole result if any
-      // doesn't live in `expectedRepo` — a mismatch means the turn filed somewhere
-      // we never authorized (a model slip, or injected data steering it elsewhere),
-      // so we must not surface or persist those links. A false from urlInRepo
-      // ("cannot confirm": wrong host, non-GitHub host, wrong repo, or wrong
-      // shape) also fails closed. A code PR is ALWAYS a GitHub artifact, so
-      // `prUrl` is validated whenever a concrete anchor is known, independent of
-      // the issue tracker. An issue URL is only GitHub on the GitHub tracker —
-      // Linear/Jira issue URLs legitimately live elsewhere — so `issueUrl` is
-      // validated only then. The placeholder-repo case (no concrete
-      // `expectedRepo`) has no anchor to compare against.
-      if (expectedRepo) {
-        const artifacts = [
-          ...(isGithubTracker ? [['issue', result.issueUrl]] : []),
-          ['pull request', result.prUrl],
-        ].filter(([, url]) => url)
-        const bad = artifacts.find(([, url]) => !urlInRepo(url, expectedRepo, allowedHost))
-        if (bad) {
-          workRegistry.delete(workToken)
-          entry.notifyWork(key, {
-            phase: 'error',
-            error: `The ${bad[0]} the agent reported is not in the expected repository (${expectedRepo}). Nothing was trusted — retry.`,
-          })
-          continue
-        }
+      // Enforcement boundary OUTSIDE the model: the target repositories were fixed
+      // by the canvas (trusted `expectedRepo` for the issue, `prExpectedRepo` for
+      // the code PR), not by the model or the untrusted Sentry text folded into the
+      // prompt. Independently re-derive the repo from every artifact URL the turn
+      // reported and reject the whole result if any doesn't live in its authorized
+      // repo — a mismatch means the turn filed somewhere we never authorized (a
+      // model slip, or injected data steering it elsewhere), so we must not surface
+      // or persist those links. A false from urlInRepo ("cannot confirm": wrong
+      // host, non-GitHub host, wrong repo, or wrong shape) also fails closed. An
+      // issue URL is only a GitHub artifact on the GitHub tracker — Linear/Jira
+      // issue URLs legitimately live elsewhere — so `issueUrl` is validated only
+      // then, against the issue repo. A code PR is ALWAYS a GitHub artifact but
+      // lands in the PR repo (which in local mode may differ from the issue repo),
+      // so `prUrl` is validated against `prExpectedRepo` whenever a concrete PR
+      // anchor is known. The placeholder-repo case (no concrete anchor) has nothing
+      // to compare against.
+      if (isGithubTracker && expectedRepo && result.issueUrl && !urlInRepo(result.issueUrl, expectedRepo, allowedHost, 'issue')) {
+        workRegistry.delete(workToken)
+        entry.notifyWork(key, {
+          phase: 'error',
+          error: `The issue the agent reported is not in the expected repository (${expectedRepo}). Nothing was trusted — retry.`,
+        })
+        continue
+      }
+      if (prExpectedRepo && result.prUrl && !urlInRepo(result.prUrl, prExpectedRepo, allowedHost, 'pull')) {
+        workRegistry.delete(workToken)
+        entry.notifyWork(key, {
+          phase: 'error',
+          error: `The pull request the agent reported is not in the expected repository (${prExpectedRepo}). Nothing was trusted — retry.`,
+        })
+        continue
       }
       // A fast spawned session can fire submit_work_pr BEFORE this parent turn
       // settles, merging real PR fields into state. This terminal patch must not
@@ -1553,7 +1680,7 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
       // number still shows. The real PR for a hand-off arrives later via the
       // validated submit_work_pr callback, so dropping an unverifiable number here
       // loses nothing.
-      if (result.prNumber != null && (result.prUrl || !expectedRepo)) patch.prNumber = result.prNumber
+      if (result.prNumber != null && (result.prUrl || !prExpectedRepo)) patch.prNumber = result.prNumber
       if (result.prUrl) patch.prUrl = result.prUrl
       if (result.sessionId) patch.sessionId = result.sessionId
       if (result.sessionName) patch.sessionName = result.sessionName
@@ -1825,7 +1952,7 @@ const session = await joinSession({
         // here because onWorkSelected refuses to start GitHub work without one.
         const regRepo = registered.authorizedRepo || ''
         const regHost = registered.authorizedHost || ''
-        if (regRepo && !urlInRepo(prUrl, regRepo, regHost)) {
+        if (regRepo && !urlInRepo(prUrl, regRepo, regHost, 'pull')) {
           return `Ignored: the reported PR for ${key} is not in the expected repository (${regRepo}).`
         }
         workRegistry.delete(workToken)

--- a/extensions/sentry-triage/extension.mjs
+++ b/extensions/sentry-triage/extension.mjs
@@ -868,21 +868,14 @@ async function enrichPlainEnglish(entry, categories, isCurrent) {
   const total = all.length
   const noun = total === 1 ? 'issue' : 'issues'
 
-  // Fold the one-time project enumeration into THIS triage round-trip instead of
-  // firing a separate "Loading your projects…" turn — projects persist in state,
-  // so we only tack the ask on when we don't have them yet. The extra tool calls
-  // are silent; the user still just sees "Triaging Sentry issues…".
+  // Project enumeration is deliberately NOT folded into this triage turn. The
+  // projectId->repo mapping it produces is a security anchor (the saved repo is
+  // what onWorkSelected validates fix-session PRs against), and this prompt ingests
+  // untrusted Sentry titles below — a prompt injection could otherwise forge that
+  // mapping and steer PR validation at an attacker-chosen repo. It runs in its own
+  // Sentry-free turn (loadProjectOptions) after this one instead.
   const loadedProjects = entry.state.getProjectOptions()
   const needProjects = !Array.isArray(loadedProjects) || loadedProjects.length === 0
-  const projectsToken = needProjects ? makeProjectsToken() : ''
-  const projectsBlock = needProjects
-    ? `
-
-Also, in the SAME turn, silently load the user's registered app projects for the canvas Settings dropdown (do not mention this in your reply):
-- Call the tool "list_projects".
-- Then call the tool "submit_projects" exactly once with token "${projectsToken}" (unchanged) and projects: an array of { id, name, repo, defaultBranch, path } using each project's id, name, github repo, default branch, and local main_repo_path (empty string if a field is missing).`
-    : ''
-
   // Fold tracking detection into the same round-trip: the canvas files tracking
   // issues with the "sentry-triage" label and the Sentry key in the title, so a
   // single label search of the target repo (matched by key) tells us which board
@@ -927,7 +920,7 @@ Do NOT use class names, exception type names, stack-trace terms, file paths, or 
 
 Do NOT print the summaries or any JSON in your reply. Instead call the tool "submit_issue_summaries" exactly once with:
 - token: "${token}" (pass it back unchanged)
-- summaries: an object mapping each issue key to its sentence, e.g. {"PROJ-123":"Shoppers cannot complete checkout after clicking pay."}${projectsBlock}${trackingBlock}${relatedBlock}
+- summaries: an object mapping each issue key to its sentence, e.g. {"PROJ-123":"Shoppers cannot complete checkout after clicking pay."}${trackingBlock}${relatedBlock}
 
 After the tool call(s), reply to the user with a confirmation sentence, then a blank line, then a clearly-labeled next-step note (no summaries, no JSON). Format it exactly like this (keep the blank line and the bold heading):
 
@@ -969,16 +962,13 @@ ${items.map((i) => `${i.key}: ${i.title}`).join('\n')}`
   try {
     if (summariesInbox.has(token)) map = summariesInbox.get(token)
     // A newer scan may have started while this enrichment turn was in flight (up
-    // to 240s). Applying THIS turn's project/tracking data to entry.state now
+    // to 240s). Applying THIS turn's tracking/related data to entry.state now
     // would clobber the newer scan's already-published state, so bail out of all
     // shared-state writes when we're stale. We still fall through to the finally
     // block (drop the inbox tokens) and the local plainEnglish loop below only
     // mutates this scan's own — now detached — category objects, which the caller
     // won't publish once isCurrent() is false.
     const current = typeof isCurrent !== 'function' || isCurrent()
-    if (current && projectsToken && projectsInbox.has(projectsToken)) {
-      entry.state.setProjectOptions(projectsInbox.get(projectsToken))
-    }
     // Only rewrite tracked badges when the model actually submitted tracking
     // (an empty {} still counts). If the turn died before submit_tracking ran,
     // leave any prior badges in place rather than wiping them.
@@ -1071,7 +1061,6 @@ ${items.map((i) => `${i.key}: ${i.title}`).join('\n')}`
     }
   } finally {
     summariesInbox.delete(token)
-    if (projectsToken) projectsInbox.delete(projectsToken)
     if (trackingToken) trackingInbox.delete(trackingToken)
     if (relatedToken) relatedInbox.delete(relatedToken)
   }
@@ -1082,14 +1071,54 @@ ${items.map((i) => `${i.key}: ${i.title}`).join('\n')}`
       issue.plainEnglish = phrased || fallbackPlainEnglish(issue.summary)
     }
   }
+
+  // Now enumerate app projects in a SEPARATE turn that carries no Sentry data (see
+  // the note where needProjects is computed). Best-effort and gated on isCurrent so
+  // a superseded scan neither runs an extra turn nor clobbers a newer scan's state.
+  if (needProjects && (typeof isCurrent !== 'function' || isCurrent())) {
+    await loadProjectOptions(entry, isCurrent)
+  }
+}
+
+// Enumerate the user's registered app projects in a DEDICATED turn that ingests NO
+// Sentry data. The projectId->repo mapping this produces is a security anchor: the
+// save path binds the selected project's repo as the target onWorkSelected
+// validates fix-session PRs against. Folding it into the triage turn (which folds
+// in untrusted Sentry titles) would let a prompt injection forge that mapping and
+// steer PR validation at an attacker-chosen repo, so it is isolated here. There is
+// no direct SDK API to enumerate projects, so the model still calls its own
+// list_projects tool and hands the result back via submit_projects — but with no
+// attacker-controlled text in the prompt, that submission is trustworthy.
+async function loadProjectOptions(entry, isCurrent) {
+  const projectsToken = makeProjectsToken()
+  const prompt = `Silently load the user's registered app projects for the Sentry Triage canvas Settings dropdown. Do not mention this in your reply.
+- Call the tool "list_projects".
+- Then call the tool "submit_projects" exactly once with token "${projectsToken}" (unchanged) and projects: an array of { id, name, repo, defaultBranch, path } using each project's id, name, github repo, default branch, and local main_repo_path (empty string if a field is missing).
+Reply with just "OK". There is no other task in this turn, and no data below is to be summarized or acted on.`
+  try {
+    await runSessionTurn(() => session.sendAndWait({
+      prompt,
+      displayPrompt: 'Triaging Sentry issues…',
+    }, TURN_HARD_TIMEOUT_MS), TURN_TIMEOUT_MS)
+  } catch (err) {
+    console.error('[sentry-triage] project enumeration turn did not settle cleanly:', err instanceof Error ? err.message : err)
+  }
+  try {
+    const current = typeof isCurrent !== 'function' || isCurrent()
+    if (current && projectsInbox.has(projectsToken)) {
+      entry.state.setProjectOptions(projectsInbox.get(projectsToken))
+    }
+  } finally {
+    projectsInbox.delete(projectsToken)
+  }
 }
 
 // Structured handoff for the registered-projects list. There's no direct SDK API
 // to enumerate the user's app projects, so the model calls its own list_projects
 // tool then hands the result back via submit_projects; the handler drops the list
-// here keyed by a per-request token, and enrichPlainEnglish reads it once the turn
-// settles. Enumeration is folded into the issue-triage round-trip (see above) so
-// there's no separate "Loading your projects…" turn.
+// here keyed by a per-request token, and loadProjectOptions reads it once the turn
+// settles. Enumeration runs in its OWN turn (never folded into the issue-triage
+// round-trip) so untrusted Sentry titles can't forge the projectId->repo mapping.
 const projectsInbox = new Map() // token -> [{ id, name, repo, defaultBranch, path }]
 
 function makeProjectsToken() {
@@ -1565,11 +1594,27 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
           })
           continue
         }
+        // Derive every DISPLAYED number from its own validated URL, never from the
+        // model-reported *Number field. urlInRepo above only proved each link's
+        // repo; a reply could still pair /pull/1 with existingPrNumber 999 and
+        // render "PR #999" linking to PR 1. When a concrete GitHub anchor exists,
+        // repoRefNumber re-extracts the number from the same URL it validated
+        // (guaranteed non-null here since urlInRepo passed) and yields undefined for
+        // a missing/unverifiable URL, so no bare number is shown. With no concrete
+        // anchor (placeholder repo) or a non-GitHub issue tracker there is nothing
+        // to validate against, so the model value stands.
+        const skipIssueAnchored = isGithubTracker && Boolean(expectedRepo)
+        const skippedIssueNumber = skipIssueAnchored
+          ? (repoRefNumber(result.existingIssueUrl, expectedRepo, allowedHost, 'issue') ?? undefined)
+          : result.existingIssueNumber
+        const skippedPrNumber = prExpectedRepo
+          ? (repoRefNumber(result.existingPrUrl, prExpectedRepo, allowedHost, 'pull') ?? undefined)
+          : result.existingPrNumber
         entry.notifyWork(key, {
           phase: 'skipped',
-          existingIssueNumber: result.existingIssueNumber,
+          existingIssueNumber: skippedIssueNumber,
           existingIssueUrl: result.existingIssueUrl,
-          existingPrNumber: result.existingPrNumber,
+          existingPrNumber: skippedPrNumber,
           existingPrUrl: result.existingPrUrl,
           existingPrState: result.existingPrState,
         })
@@ -1671,16 +1716,32 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
       // clobber that: setWorkStatus shallow-merges, so an explicit `undefined`
       // here would erase the callback's link. Include only fields we actually have.
       const patch = { phase: handedOff ? 'handed-off' : 'done' }
-      if (result.issueNumber != null) patch.issueNumber = result.issueNumber
+      // Derive both displayed numbers from their validated URLs, not the
+      // model-reported *Number fields: the URL checks above proved each link's
+      // repo, but a reply could still pair /pull/1 with prNumber 999 and render
+      // "PR #999" linking to PR 1 (same for the issue). With a concrete GitHub
+      // anchor, repoRefNumber re-extracts the number from the same URL it validated
+      // (null → drop, so a bare unverifiable number is never surfaced). With no
+      // concrete anchor there's nothing to validate against, so the model number
+      // stands. Each field is assigned only when present so this terminal patch —
+      // shallow-merged by setWorkStatus — never overwrites a live submit_work_pr
+      // callback's link with undefined.
+      const doneIssueNumber = (isGithubTracker && expectedRepo)
+        ? repoRefNumber(result.issueUrl, expectedRepo, allowedHost, 'issue')
+        : (result.issueNumber != null ? result.issueNumber : null)
+      if (doneIssueNumber != null) patch.issueNumber = doneIssueNumber
       if (result.issueUrl) patch.issueUrl = result.issueUrl
-      // A PR is always a GitHub artifact. With a concrete repo, only surface its
-      // number when a URL proved (in the block above) it lives in expectedRepo —
+      // A PR is always a GitHub artifact. With a concrete repo, surface only the
+      // number parsed from a URL that proved (above) it lives in prExpectedRepo —
       // otherwise a bare, unverifiable "PR #N" could render as authoritative
-      // success. Without a concrete repo there's nothing to validate against, so a
-      // number still shows. The real PR for a hand-off arrives later via the
+      // success. Without a concrete repo there's nothing to validate against, so the
+      // model number still shows. The real PR for a hand-off arrives later via the
       // validated submit_work_pr callback, so dropping an unverifiable number here
       // loses nothing.
-      if (result.prNumber != null && (result.prUrl || !prExpectedRepo)) patch.prNumber = result.prNumber
+      const donePrNumber = prExpectedRepo
+        ? repoRefNumber(result.prUrl, prExpectedRepo, allowedHost, 'pull')
+        : (result.prNumber != null ? result.prNumber : null)
+      if (donePrNumber != null) patch.prNumber = donePrNumber
       if (result.prUrl) patch.prUrl = result.prUrl
       if (result.sessionId) patch.sessionId = result.sessionId
       if (result.sessionName) patch.sessionName = result.sessionName
@@ -1916,7 +1977,7 @@ const session = await joinSession({
         // 'handed-off' with a dead ("#") link — unrecoverable. Rejecting here
         // leaves the token intact so the session can retry with a real URL.
         const prUrl = safeSentryUrl(args?.prUrl)
-        const prNumber = Number.isFinite(Number(args?.prNumber)) ? Number(args.prNumber) : undefined
+        const reportedPrNumber = Number.isFinite(Number(args?.prNumber)) ? Number(args.prNumber) : undefined
         const prState = typeof args?.prState === 'string' && args.prState.trim() ? args.prState.trim().toLowerCase() : 'draft'
         if (!key || !prUrl) return 'Ignored: a Sentry issue key and a valid http(s) prUrl are both required.'
         if (!workToken) return 'Ignored: a workToken is required — pass the token from the hand-off prompt unchanged.'
@@ -1926,7 +1987,7 @@ const session = await joinSession({
         // would keep that phase through the shallow merge and the PR link — gated
         // on 'done'/'handed-off' by the renderer — would never show.
         const patch = { phase: 'handed-off', prUrl, prState }
-        if (prNumber !== undefined) patch.prNumber = prNumber
+        // patch.prNumber is added after the repo check below, derived from prUrl.
         // The token identifies the exact instance + issue that started this work
         // and is single-use. Consume it so a replayed call can't double-apply,
         // and reject an unknown/expired token instead of falling back to
@@ -1952,9 +2013,20 @@ const session = await joinSession({
         // here because onWorkSelected refuses to start GitHub work without one.
         const regRepo = registered.authorizedRepo || ''
         const regHost = registered.authorizedHost || ''
-        if (regRepo && !urlInRepo(prUrl, regRepo, regHost, 'pull')) {
+        // Derive the DISPLAYED PR number from the same validated URL, never from the
+        // model-reported prNumber: a session could pair /pull/1 with prNumber 999 and
+        // render "PR #999" linking to PR 1. repoRefNumber returns null on any
+        // host/repo/shape mismatch (the reject below, equivalent to the old urlInRepo
+        // guard) and otherwise the number parsed from the URL. '' ("cannot confirm")
+        // fails closed, but if the authorized repo somehow weren't concrete there's
+        // nothing to validate against, so fall back to the reported number.
+        const verifiedPrNumber = regRepo
+          ? repoRefNumber(prUrl, regRepo, regHost, 'pull')
+          : (reportedPrNumber ?? null)
+        if (regRepo && verifiedPrNumber === null) {
           return `Ignored: the reported PR for ${key} is not in the expected repository (${regRepo}).`
         }
+        if (verifiedPrNumber != null) patch.prNumber = verifiedPrNumber
         workRegistry.delete(workToken)
         // Reject a callback whose originating org/scope is no longer current, so a
         // late PR link can't land on a different org's board (short keys collide
@@ -1963,7 +2035,7 @@ const session = await joinSession({
           return `Ignored: ${registered.key} belongs to a previous org/scope that is no longer active.`
         }
         registered.entry.notifyWork(registered.key, patch)
-        return `Updated ${registered.key} with PR #${prNumber ?? '?'} (${prState}).`
+        return `Updated ${registered.key} with PR #${verifiedPrNumber ?? '?'} (${prState}).`
       },
     },
   ],

--- a/extensions/sentry-triage/extension.mjs
+++ b/extensions/sentry-triage/extension.mjs
@@ -892,11 +892,17 @@ Also, in the SAME turn, silently load the user's registered app projects for the
   const trackRepo = selectedTracker === 'github'
     ? (trackPrTargets?.cloud?.repo || runtimeDefaults.repo || '')
     : ''
-  // Issue vs PR repo split for enrichment: the tracking ISSUE lives in trackRepo,
-  // but its linked PR can live in the selected project's repo (see
-  // deriveRepoAnchors). Validate each reported URL against its own anchor below.
+  // Issue vs PR repo split for enrichment: the tracking ISSUE lives in trackRepo, but
+  // its linked PR can live in the selected project's repo. deriveRepoAnchors publishes
+  // no TRUSTED PR anchor for an explicitly selected project (it authorizes by
+  // host-resolved project_id, not a model-relayed repo), so for the tracked-PR BADGE —
+  // which is read-only display, not a write/authorization gate — fall back to the
+  // project's declared repo when there's no trusted anchor. Validating a model-reported
+  // PR URL against that model-declared repo still pins the badge number to the URL it
+  // links to and to the trusted host; it only accepts a model-asserted repo, which is
+  // inherent to any model-reported tracking claim. Falls back to the issue repo last.
   const { prExpectedRepo: trackPrExpectedRepo } = deriveRepoAnchors(trackPrTargets, trackRepo, runtimeDefaults.repo)
-  const trackPrRepo = trackPrExpectedRepo || trackRepo
+  const trackPrRepo = trackPrExpectedRepo || normalizeRepo(trackPrTargets?.local?.repo) || normalizeRepo(trackRepo)
   const needTracking = !!trackRepo
   const trackingToken = needTracking ? makeTrackingToken() : ''
   const trackingBlock = needTracking
@@ -1013,14 +1019,15 @@ ${items.map((i) => `${i.key}: ${i.title}`).join('\n')}`
           if (verifiedIssueNumber === null) continue
           // Trust the PR's pr* fields ONLY when a concrete prUrl is a `/pull/<n>` in
           // the PR anchor (which can differ from the issue repo in split-repo local
-          // mode). A model-reported prNumber/prState with NO url, an issue URL, or a
-          // url in the wrong repo is unverifiable: strip EVERY pr* field (the card
-          // renders a badge from prNumber alone, and prState alone can keep a closed
-          // issue "tracked") but KEEP the authorized issue. Derive prNumber from the
-          // validated URL itself so a mismatched model-reported number can never
-          // render a badge pointing at a different PR than the one we verified.
+          // mode; for a selected project the anchor is the model-declared project
+          // repo — display-only, see trackPrRepo). A model-reported prNumber/prState
+          // with NO url, an issue URL, or a url in the wrong repo is unverifiable:
+          // strip EVERY pr* field (the card renders a badge from prNumber alone, and
+          // prState alone can keep a closed issue "tracked") but KEEP the authorized
+          // issue. Derive prNumber from the validated URL itself so a mismatched
+          // model-reported number can never render a badge pointing at a different PR.
           const verifiedPrNumber = info.prUrl
-            ? repoRefNumber(info.prUrl, trackPrExpectedRepo, allowedHost, 'pull')
+            ? repoRefNumber(info.prUrl, trackPrRepo, allowedHost, 'pull')
             : null
           const record = verifiedPrNumber !== null
             ? { ...info, issueNumber: verifiedIssueNumber, prNumber: verifiedPrNumber }

--- a/extensions/sentry-triage/extension.mjs
+++ b/extensions/sentry-triage/extension.mjs
@@ -1527,26 +1527,32 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
         // "already being worked on"; surface an unconfirmed-result error instead
         // so the user can retry.
         const ACTIVE_PR_STATES = new Set(['open', 'draft'])
-        // A bare PR number is not proof the dedup work lives in the authorized
-        // repo — the card would render "already being worked on · PR #N" as an
-        // authoritative claim, and the repo check below only covers URL-bearing
-        // artifacts. When a concrete PR-repo anchor is set, require the confirming
-        // PR to carry a URL (validated against prExpectedRepo just below); a
-        // number-only reference counts as no confirming PR and surfaces the
-        // retryable "no open pull request" error rather than a spoofable skip. The
-        // PR lives in the PR repo, which in local mode can differ from the issue
-        // repo, so anchor this guard on prExpectedRepo — not expectedRepo.
-        const hasPrRef = prExpectedRepo
-          ? Boolean(result.existingPrUrl)
-          : Boolean(result.existingPrNumber || result.existingPrUrl)
+        // An authoritative "already being worked on" skip SUPPRESSES the trusted
+        // host-resolved create_session flow and surfaces a PR link on the card, so it
+        // must rest on a TRUSTED PR-repo anchor. Otherwise injected Sentry text — this
+        // dedup result and the project list come from the same model turn — could both
+        // block real work and surface an attacker-chosen PR. When a concrete
+        // prExpectedRepo is known, require the confirming PR to carry a URL (validated
+        // against it just below); a number-only reference counts as no confirming PR
+        // and surfaces the retryable "no open pull request" error rather than a
+        // spoofable skip. For an explicitly selected project there is NO trusted
+        // anchor (deriveRepoAnchors publishes prExpectedRepo=''), so no skip is
+        // confirmable at all: fail closed to a retryable error instead of honoring an
+        // unverifiable skip. The PR lives in the PR repo, which in local mode can
+        // differ from the issue repo, so anchor this guard on prExpectedRepo — not
+        // expectedRepo.
+        const hasTrustedPrAnchor = Boolean(prExpectedRepo)
+        const hasPrRef = hasTrustedPrAnchor && Boolean(result.existingPrUrl)
         const hasActivePr = hasPrRef && ACTIVE_PR_STATES.has(result.existingPrState)
         if (!hasActivePr) {
           workRegistry.delete(workToken)
           entry.notifyWork(key, {
             phase: 'error',
-            error: hasPrRef
-              ? 'Agent reported this issue as already being worked on, but the referenced pull request is not open (it may be closed or merged). Retry to open fresh work.'
-              : 'Agent reported this issue as already being worked on but returned no open pull request to confirm it.',
+            error: !hasTrustedPrAnchor
+              ? 'Agent reported this issue as already being worked on, but that can’t be confirmed for a selected project (its pull-request repository isn’t verifiable). Retry to start fresh work, or open the existing pull request manually if there is one.'
+              : hasPrRef
+                ? 'Agent reported this issue as already being worked on, but the referenced pull request is not open (it may be closed or merged). Retry to open fresh work.'
+                : 'Agent reported this issue as already being worked on but returned no open pull request to confirm it.',
           })
           continue
         }
@@ -1558,12 +1564,13 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
         // is paired with the repo it must ACTUALLY live in: the issue URL with the
         // issue repo (`expectedRepo`, GitHub tracker only — Linear/Jira issue URLs
         // legitimately live elsewhere), and the PR URL with the PR repo
-        // (`prExpectedRepo`), which in local mode can differ from the issue repo.
-        // Each check is gated on its own anchor, so an empty anchor ('') skips just
-        // that artifact (failing closed for it) instead of shadowing the other.
+        // (`prExpectedRepo`). The PR anchor is guaranteed concrete here (a selected
+        // project has no trusted anchor and already failed closed above), so only the
+        // issue anchor can be empty — on a non-GitHub tracker — in which case its
+        // check is skipped (failing closed for it) instead of shadowing the PR.
         const dedupArtifacts = [
           ...(isGithubTracker && expectedRepo ? [['issue', result.existingIssueUrl, expectedRepo, 'issue']] : []),
-          ...(prExpectedRepo ? [['pull request', result.existingPrUrl, prExpectedRepo, 'pull']] : []),
+          ['pull request', result.existingPrUrl, prExpectedRepo, 'pull'],
         ].filter(([, url]) => url)
         const bad = dedupArtifacts.find(([, url, anchor, kind]) => !urlInRepo(url, anchor, allowedHost, kind))
         if (bad) {
@@ -1576,19 +1583,16 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
         // Derive every DISPLAYED number from its own validated URL, never from the
         // model-reported *Number field. urlInRepo above only proved each link's
         // repo; a reply could still pair /pull/1 with existingPrNumber 999 and
-        // render "PR #999" linking to PR 1. When a concrete GitHub anchor exists,
-        // repoRefNumber re-extracts the number from the same URL it validated
-        // (guaranteed non-null here since urlInRepo passed) and yields undefined for
-        // a missing/unverifiable URL, so no bare number is shown. With no concrete
-        // anchor (placeholder repo) or a non-GitHub issue tracker there is nothing
-        // to validate against, so the model value stands.
+        // render "PR #999" linking to PR 1. repoRefNumber re-extracts the number from
+        // the same URL it validated and yields undefined for a missing/unverifiable
+        // URL, so no bare number is shown. The PR anchor is always concrete here; the
+        // issue anchor may be empty on a non-GitHub tracker, where there is nothing to
+        // validate against and the model value stands.
         const skipIssueAnchored = isGithubTracker && Boolean(expectedRepo)
         const skippedIssueNumber = skipIssueAnchored
           ? (repoRefNumber(result.existingIssueUrl, expectedRepo, allowedHost, 'issue') ?? undefined)
           : result.existingIssueNumber
-        const skippedPrNumber = prExpectedRepo
-          ? (repoRefNumber(result.existingPrUrl, prExpectedRepo, allowedHost, 'pull') ?? undefined)
-          : result.existingPrNumber
+        const skippedPrNumber = repoRefNumber(result.existingPrUrl, prExpectedRepo, allowedHost, 'pull') ?? undefined
         entry.notifyWork(key, {
           phase: 'skipped',
           existingIssueNumber: skippedIssueNumber,

--- a/extensions/sentry-triage/extension.mjs
+++ b/extensions/sentry-triage/extension.mjs
@@ -95,25 +95,20 @@ function normalizeRepo(value) {
 // text:
 //   - Cloud mode: the fix session runs on the cloud repo (user-typed in Settings),
 //     where the issue is also filed, so the PR anchor is that issue repo.
-//   - Local mode, EXPLICITLY selected project (local.projectId set): the session is
-//     created by its host-resolved project_id — a trusted handle — so authorization
-//     rides on the project_id, NOT on a repo. The project's repo is only known via
-//     the model-relayed project list, which we do NOT treat as an authorization
-//     anchor, so we publish NO PR-repo gate here (prExpectedRepo='') and signal that
-//     via prProjectSelected. (The model list still feeds the Settings dropdown and a
-//     dedup search hint — display only, never authorization.)
-//   - Local mode, "Current project" (no explicit selection): the session runs in the
-//     canvas's OWN checkout, so the PR lands in the trusted current-project repo
+//   - Local mode: the fix session ALWAYS runs in the canvas's OWN checkout (the
+//     "Current project"), so the PR lands in the trusted current-project repo
 //     (`currentProjectRepo`, seeded from the session cwd's git remote) — NOT the
-//     issue repo, which Settings may point at a separate cloud repo.
+//     issue repo, which Settings may point at a separate cloud repo. There is no
+//     model-relayed "selected project" handoff: routing a fix session by a
+//     model-supplied project_id would authorize the write with a repo we could only
+//     learn from the same untrusted Sentry turn, so that path was removed. Cross-repo
+//     work goes through Cloud mode (repo typed in Settings = trusted).
 // Both repo values are '' unless a concrete "owner/repo" resolves.
 function deriveRepoAnchors(prTargets, issueRepo, currentProjectRepo) {
   const expectedRepo = normalizeRepo(issueRepo)
   const isCloudMode = prTargets?.mode === 'cloud'
-  if (isCloudMode) return { expectedRepo, prExpectedRepo: expectedRepo, prProjectSelected: false }
-  const prProjectSelected = Boolean(prTargets?.local?.projectId)
-  const prExpectedRepo = prProjectSelected ? '' : normalizeRepo(currentProjectRepo)
-  return { expectedRepo, prExpectedRepo, prProjectSelected }
+  if (isCloudMode) return { expectedRepo, prExpectedRepo: expectedRepo }
+  return { expectedRepo, prExpectedRepo: normalizeRepo(currentProjectRepo) }
 }
 
 // The TRUSTED current-checkout repo for the "Current project" PR anchor. Always
@@ -548,11 +543,10 @@ function buildWorkPrompt({ key, issue, org, prTargets, model: modelOverride, ass
   const targetRepo = issueRepo || cloudRepo || defaults.repo || '(current repository)'
   // The draft PR is opened where the fix session runs. Use a best-effort PR-repo
   // hint for the Step-0 open-PR dedup SEARCH only (never an authorization anchor):
-  // the trusted PR anchor when we have one, else the selected project's declared
-  // repo (model-relayed — acceptable for a search hint), else the issue repo. Issue
+  // the trusted PR anchor when we have one, else the issue repo. Issue
   // lookup/creation stays on the issue repo (targetRepo).
   const { prExpectedRepo } = deriveRepoAnchors(prTargets, issueRepo, currentCheckoutRepo(defaults))
-  const prSearchRepo = prExpectedRepo || normalizeRepo(prTargets?.local?.repo) || targetRepo
+  const prSearchRepo = prExpectedRepo || targetRepo
   const plain = sanitizeForPrompt(issue.plainEnglish || issue.summary || 'User-visible failure in production', 200)
   const issueTitle = `[sentry-triage][${key}] ${plain}`.slice(0, 120)
   const markerLabel = 'sentry-triage'
@@ -652,24 +646,16 @@ Return JSON only (no markdown), using one of these shapes:
   }
 
   const sessionLocation = prMode === 'cloud' ? 'cloud' : 'local'
-  const localProjectId = prTargets?.local?.projectId || ''
-  const localProjectName = prTargets?.local?.projectName || ''
-  // Local mode can target a specific registered project (chosen in Settings). When
-  // one is picked we tell the agent to create the session in THAT project by id;
-  // otherwise it falls back to the current project the canvas is driving.
-  const createSessionTarget = sessionLocation === 'local' && localProjectId
-    ? `- Use the create_session tool targeting project_id "${localProjectId}"${localProjectName ? ` (project "${localProjectName}")` : ''}.`
-    : '- Use the create_session tool in the CURRENT project.'
   const prFlow = [
     'Step 2 (Draft PR): Spin up a DEDICATED, separate session for THIS bug only — do NOT draft the PR inline in the current session.',
-    createSessionTarget,
+    '- Use the create_session tool in the CURRENT project.',
     model
       ? `- Run that session under model "${model}": pass model: "${model}" to the create_session tool.`
       : '- Let that session use its default model (do not set the model parameter).',
     `- execution_location: "${sessionLocation}".`,
     sessionLocation === 'cloud'
       ? `- Cloud target repo: ${cloudRepo || '(current repository)'}; base ref: ${cloudBase || 'repository default'}.`
-      : `- Local checkout: ${localProjectId ? `project "${localProjectName || localProjectId}" (${localPath})` : localPath}; base branch: ${localBase || 'repository default'}.`,
+      : `- Local checkout: ${localPath}; base branch: ${localBase || 'repository default'}.`,
     `- Name the session after the bug (e.g. "Fix ${key}").`,
     '- Keep coordinate_with_creator on so the spawned session reports its PR back.',
     '- Provide a kickoff prompt (autopilot mode) instructing that session to:',
@@ -877,24 +863,6 @@ async function enrichPlainEnglish(entry, categories, isCurrent) {
   const total = all.length
   const noun = total === 1 ? 'issue' : 'issues'
 
-  // Fold the one-time project enumeration into THIS triage round-trip. The list only
-  // populates the Settings dropdown (display + a dedup search hint); it is NOT an
-  // authorization anchor — fix-session PRs are authorized by the host-resolved
-  // project_id chosen at create_session time, never by this model-relayed repo (see
-  // deriveRepoAnchors). So even though this prompt ingests untrusted Sentry titles, a
-  // forged projectId->repo mapping can't steer PR authorization, and no separate
-  // Sentry-free turn is needed. Projects persist in state, so we only ask when we
-  // don't have them yet; the extra tool calls are silent.
-  const loadedProjects = entry.state.getProjectOptions()
-  const needProjects = !Array.isArray(loadedProjects) || loadedProjects.length === 0
-  const projectsToken = needProjects ? makeProjectsToken() : ''
-  const projectsBlock = needProjects
-    ? `
-
-Also, in the SAME turn, silently load the user's registered app projects for the canvas Settings dropdown (do not mention this in your reply):
-- Call the tool "list_projects".
-- Then call the tool "submit_projects" exactly once with token "${projectsToken}" (unchanged) and projects: an array of { id, name, repo, defaultBranch, path } using each project's id, name, github repo, default branch, and local main_repo_path (empty string if a field is missing).`
-    : ''
   // Fold tracking detection into the same round-trip: the canvas files tracking
   // issues with the "sentry-triage" label and the Sentry key in the title, so a
   // single label search of the target repo (matched by key) tells us which board
@@ -905,16 +873,12 @@ Also, in the SAME turn, silently load the user's registered app projects for the
     ? (trackPrTargets?.cloud?.repo || runtimeDefaults.repo || '')
     : ''
   // Issue vs PR repo split for enrichment: the tracking ISSUE lives in trackRepo, but
-  // its linked PR can live in the selected project's repo. deriveRepoAnchors publishes
-  // no TRUSTED PR anchor for an explicitly selected project (it authorizes by
-  // host-resolved project_id, not a model-relayed repo), so for the tracked-PR BADGE —
-  // which is read-only display, not a write/authorization gate — fall back to the
-  // project's declared repo when there's no trusted anchor. Validating a model-reported
-  // PR URL against that model-declared repo still pins the badge number to the URL it
-  // links to and to the trusted host; it only accepts a model-asserted repo, which is
-  // inherent to any model-reported tracking claim. Falls back to the issue repo last.
+  // its linked PR can live in a DIFFERENT repo in local mode (the fix session runs in
+  // the current checkout, whose repo may differ from the issue repo). deriveRepoAnchors
+  // yields the trusted PR anchor for the tracked-PR BADGE — Cloud mode: the configured
+  // repo; Local mode: the current checkout's repo. Falls back to the issue repo last.
   const { prExpectedRepo: trackPrExpectedRepo } = deriveRepoAnchors(trackPrTargets, trackRepo, currentCheckoutRepo(runtimeDefaults))
-  const trackPrRepo = trackPrExpectedRepo || normalizeRepo(trackPrTargets?.local?.repo) || normalizeRepo(trackRepo)
+  const trackPrRepo = trackPrExpectedRepo || normalizeRepo(trackRepo)
   const needTracking = !!trackRepo
   const trackingToken = needTracking ? makeTrackingToken() : ''
   const trackingBlock = needTracking
@@ -945,7 +909,7 @@ Do NOT use class names, exception type names, stack-trace terms, file paths, or 
 
 Do NOT print the summaries or any JSON in your reply. Instead call the tool "submit_issue_summaries" exactly once with:
 - token: "${token}" (pass it back unchanged)
-- summaries: an object mapping each issue key to its sentence, e.g. {"PROJ-123":"Shoppers cannot complete checkout after clicking pay."}${projectsBlock}${trackingBlock}${relatedBlock}
+- summaries: an object mapping each issue key to its sentence, e.g. {"PROJ-123":"Shoppers cannot complete checkout after clicking pay."}${trackingBlock}${relatedBlock}
 
 After the tool call(s), reply to the user with a confirmation sentence, then a blank line, then a clearly-labeled next-step note (no summaries, no JSON). Format it exactly like this (keep the blank line and the bold heading):
 
@@ -994,9 +958,6 @@ ${items.map((i) => `${i.key}: ${i.title}`).join('\n')}`
     // mutates this scan's own — now detached — category objects, which the caller
     // won't publish once isCurrent() is false.
     const current = typeof isCurrent !== 'function' || isCurrent()
-    if (current && projectsToken && projectsInbox.has(projectsToken)) {
-      entry.state.setProjectOptions(projectsInbox.get(projectsToken))
-    }
     // Only rewrite tracked badges when the model actually submitted tracking
     // (an empty {} still counts). If the turn died before submit_tracking ran,
     // leave any prior badges in place rather than wiping them.
@@ -1031,8 +992,7 @@ ${items.map((i) => `${i.key}: ${i.title}`).join('\n')}`
           if (verifiedIssueNumber === null) continue
           // Trust the PR's pr* fields ONLY when a concrete prUrl is a `/pull/<n>` in
           // the PR anchor (which can differ from the issue repo in split-repo local
-          // mode; for a selected project the anchor is the model-declared project
-          // repo — display-only, see trackPrRepo). A model-reported prNumber/prState
+          // mode — see trackPrRepo). A model-reported prNumber/prState
           // with NO url, an issue URL, or a url in the wrong repo is unverifiable:
           // strip EVERY pr* field (the card renders a badge from prNumber alone, and
           // prState alone can keep a closed issue "tracked") but KEEP the authorized
@@ -1090,7 +1050,6 @@ ${items.map((i) => `${i.key}: ${i.title}`).join('\n')}`
     }
   } finally {
     summariesInbox.delete(token)
-    if (projectsToken) projectsInbox.delete(projectsToken)
     if (trackingToken) trackingInbox.delete(trackingToken)
     if (relatedToken) relatedInbox.delete(relatedToken)
   }
@@ -1101,18 +1060,6 @@ ${items.map((i) => `${i.key}: ${i.title}`).join('\n')}`
       issue.plainEnglish = phrased || fallbackPlainEnglish(issue.summary)
     }
   }
-}
-
-// Structured handoff for the registered-projects list. There's no direct SDK API
-// to enumerate the user's app projects, so the model calls its own list_projects
-// tool then hands the result back via submit_projects; the handler drops the list
-// here keyed by a per-request token, and enrichPlainEnglish reads it once the turn
-// settles. Enumeration is folded into the issue-triage round-trip; the list is
-// display/dedup only, not an authorization anchor, so it needs no isolated turn.
-const projectsInbox = new Map() // token -> [{ id, name, repo, defaultBranch, path }]
-
-function makeProjectsToken() {
-  return `proj_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
 }
 
 // Structured handoff for pre-existing GitHub tracking issues/PRs. The model runs
@@ -1392,10 +1339,9 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
   // gates the outside-the-model URL enforcement for the tracking issue: only a
   // well-formed "owner/repo" anchor can validate a model-reported issue URL, so a
   // blank value resolves to '' (fails closed — no URL check, and blocked below).
-  // `prExpectedRepo` is the TRUSTED PR anchor when one exists, or '' for an
-  // explicitly selected project — which authorizes by host-resolved project_id, not
-  // a repo — signalled by `prProjectSelected` so the preflight below does NOT block.
-  const { expectedRepo, prExpectedRepo, prProjectSelected } = deriveRepoAnchors(prTargets, issueRepo, currentCheckoutRepo(runtimeDefaults))
+  // `prExpectedRepo` is the TRUSTED PR anchor: the cloud repo in Cloud mode, or the
+  // current checkout's repo in Local mode — never a model-relayed value.
+  const { expectedRepo, prExpectedRepo } = deriveRepoAnchors(prTargets, issueRepo, currentCheckoutRepo(runtimeDefaults))
   // Trusted host the authorized issue/PR links must live on, paired with
   // `expectedRepo`. Repo alone is not enough: a look-alike host would otherwise
   // let a model-reported link pass the repo check (see urlInRepo). Sourced from
@@ -1417,16 +1363,14 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
   // this trips only when detection fails. The two failures have different fixes, so
   // report the one that actually bit: a missing ISSUE anchor means no target repo is
   // configured (fix in Settings), while a missing PR anchor is "Current project"
-  // running in a checkout with no detectable GitHub remote — an explicitly selected
-  // project is authorized by its host-resolved project_id, needs no repo anchor, and
-  // is exempted here via prProjectSelected (fix: run from a repo-backed checkout, or
-  // pick a registered project).
+  // running in a checkout with no detectable GitHub remote (fix: run from a
+  // repo-backed checkout, or use Cloud mode with a repo set in Settings).
   const missingIssueRepo = isGithubTracker && !expectedRepo
-  const missingPrRepo = wantsCopilot && !prExpectedRepo && !prProjectSelected
+  const missingPrRepo = wantsCopilot && !prExpectedRepo
   if (missingIssueRepo || missingPrRepo) {
     const error = missingIssueRepo
       ? 'No target repository is configured, so issue creation cannot be verified. Set a target repository in Settings before starting work.'
-      : 'The pull request destination has no valid repository (owner/repo), so it cannot be verified. Open this canvas from a checkout with a GitHub remote, or select a registered project, before starting work.'
+      : 'The pull request destination has no valid repository (owner/repo), so it cannot be verified. Open this canvas from a checkout with a GitHub remote, or use Cloud mode with a repository set in Settings, before starting work.'
     for (const key of startableKeys) {
       entry.notifyWork(key, {
         phase: 'error',
@@ -1480,9 +1424,9 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
     // Capture the repo the PR is authorized against AT hand-off time (frozen, not
     // recomputed from live settings) so retargeting the canvas mid-flight can't
     // reject a legitimate PR in the original repo or admit one in a newly-set repo.
-    // This anchor is '' for an explicitly selected project — such work is authorized
-    // by its host-resolved project_id, not a model-relayed repo — and submit_work_pr
-    // treats an empty anchor as "no URL gate" accordingly.
+    // This anchor is '' only for non-GitHub trackers or a local checkout with no
+    // detectable GitHub remote; submit_work_pr treats an empty anchor as "no URL
+    // gate" accordingly.
     const workToken = randomUUID()
     workRegistry.set(workToken, { entry, key, scopeGen, authorizedRepo: prExpectedRepo, authorizedHost: allowedHost })
 
@@ -1540,31 +1484,24 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
         // so the user can retry.
         const ACTIVE_PR_STATES = new Set(['open', 'draft'])
         // An authoritative "already being worked on" skip SUPPRESSES the trusted
-        // host-resolved create_session flow and surfaces a PR link on the card, so it
-        // must rest on a TRUSTED PR-repo anchor. Otherwise injected Sentry text — this
-        // dedup result and the project list come from the same model turn — could both
-        // block real work and surface an attacker-chosen PR. When a concrete
-        // prExpectedRepo is known, require the confirming PR to carry a URL (validated
-        // against it just below); a number-only reference counts as no confirming PR
-        // and surfaces the retryable "no open pull request" error rather than a
-        // spoofable skip. For an explicitly selected project there is NO trusted
-        // anchor (deriveRepoAnchors publishes prExpectedRepo=''), so no skip is
-        // confirmable at all: fail closed to a retryable error instead of honoring an
-        // unverifiable skip. The PR lives in the PR repo, which in local mode can
-        // differ from the issue repo, so anchor this guard on prExpectedRepo — not
-        // expectedRepo.
-        const hasTrustedPrAnchor = Boolean(prExpectedRepo)
-        const hasPrRef = hasTrustedPrAnchor && Boolean(result.existingPrUrl)
+        // create_session flow and surfaces a PR link on the card, so it must rest on a
+        // TRUSTED PR-repo anchor (Cloud mode: the configured repo; Local mode: the
+        // current checkout's repo — never a model-relayed value). Require the
+        // confirming PR to carry a URL, validated against that anchor just below; a
+        // number-only reference, a missing anchor (a checkout with no detectable
+        // remote), or a non-open state all count as no confirmed PR and surface a
+        // retryable error rather than a spoofable skip. The PR lives in the PR repo,
+        // which in local mode can differ from the issue repo, so anchor this guard on
+        // prExpectedRepo — not expectedRepo.
+        const hasPrRef = Boolean(prExpectedRepo) && Boolean(result.existingPrUrl)
         const hasActivePr = hasPrRef && ACTIVE_PR_STATES.has(result.existingPrState)
         if (!hasActivePr) {
           workRegistry.delete(workToken)
           entry.notifyWork(key, {
             phase: 'error',
-            error: !hasTrustedPrAnchor
-              ? 'Agent reported this issue as already being worked on, but that can’t be confirmed for a selected project (its pull-request repository isn’t verifiable). Retry to start fresh work, or open the existing pull request manually if there is one.'
-              : hasPrRef
-                ? 'Agent reported this issue as already being worked on, but the referenced pull request is not open (it may be closed or merged). Retry to open fresh work.'
-                : 'Agent reported this issue as already being worked on but returned no open pull request to confirm it.',
+            error: hasPrRef
+              ? 'Agent reported this issue as already being worked on, but the referenced pull request is not open (it may be closed or merged). Retry to open fresh work.'
+              : 'Agent reported this issue as already being worked on but returned no verifiable open pull request to confirm it.',
           })
           continue
         }
@@ -1576,10 +1513,10 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
         // is paired with the repo it must ACTUALLY live in: the issue URL with the
         // issue repo (`expectedRepo`, GitHub tracker only — Linear/Jira issue URLs
         // legitimately live elsewhere), and the PR URL with the PR repo
-        // (`prExpectedRepo`). The PR anchor is guaranteed concrete here (a selected
-        // project has no trusted anchor and already failed closed above), so only the
-        // issue anchor can be empty — on a non-GitHub tracker — in which case its
-        // check is skipped (failing closed for it) instead of shadowing the PR.
+        // (`prExpectedRepo`). The PR anchor is guaranteed concrete here (the skip
+        // guard above requires it), so only the issue anchor can be empty — on a
+        // non-GitHub tracker — in which case its check is skipped (failing closed for
+        // it) instead of shadowing the PR.
         const dedupArtifacts = [
           ...(isGithubTracker && expectedRepo ? [['issue', result.existingIssueUrl, expectedRepo, 'issue']] : []),
           ['pull request', result.existingPrUrl, prExpectedRepo, 'pull'],
@@ -1828,42 +1765,6 @@ const session = await joinSession({
       },
     },
     {
-      name: 'submit_projects',
-      description:
-        'Submit the list of the user\'s registered app projects for the Sentry Triage canvas Local target dropdown. Call this exactly once after list_projects; pass back the token from the request unchanged.',
-      parameters: {
-        type: 'object',
-        properties: {
-          token: {
-            type: 'string',
-            description: 'The exact token given in the request. Pass it back unchanged.',
-          },
-          projects: {
-            type: 'array',
-            description: 'The registered app projects.',
-            items: {
-              type: 'object',
-              properties: {
-                id: { type: 'string', description: 'The project id.' },
-                name: { type: 'string', description: 'The project display name.' },
-                repo: { type: 'string', description: 'The github repo (owner/name), if any.' },
-                defaultBranch: { type: 'string', description: 'The project default branch, if any.' },
-                path: { type: 'string', description: 'The local main_repo_path, if any.' },
-              },
-              required: ['id'],
-            },
-          },
-        },
-        required: ['token', 'projects'],
-      },
-      handler: async (args) => {
-        const token = typeof args?.token === 'string' ? args.token : ''
-        const projects = Array.isArray(args?.projects) ? args.projects : []
-        if (token) projectsInbox.set(token, projects)
-        return `Recorded ${projects.length} project${projects.length === 1 ? '' : 's'}.`
-      },
-    },
-    {
       name: 'submit_tracking',
       description:
         'Submit the map of Sentry issue keys that already have a tracking GitHub issue/PR for the Sentry Triage canvas. Call this exactly once during a triage scan; pass back the token from the request unchanged.',
@@ -2003,11 +1904,11 @@ const session = await joinSession({
         // retargeting the canvas mid-flight can't reject a legitimate PR in the
         // original repo or admit an attacker one in a newly-set repo. Reject WITHOUT
         // consuming the single-use token so a genuine session can retry the URL.
-        // The authorized repo is '' for an explicitly selected project (authorized by
-        // host-resolved project_id, not a model-relayed repo) and for non-GitHub
-        // trackers; in those cases there is no trusted URL anchor, so the gate below
-        // is skipped and the reported number is shown as-is. When a concrete anchor
-        // IS present (cloud / current-project), '' from repoRefNumber fails closed.
+        // The authorized repo is '' for non-GitHub trackers or a local checkout with
+        // no detectable GitHub remote; in those cases there is no trusted URL anchor,
+        // so the gate below is skipped and the reported number is shown as-is. When a
+        // concrete anchor IS present (cloud / current-project), '' from repoRefNumber
+        // fails closed.
         const regRepo = registered.authorizedRepo || ''
         const regHost = registered.authorizedHost || ''
         // Derive the DISPLAYED PR number from the same validated URL, never from the

--- a/extensions/sentry-triage/extension.mjs
+++ b/extensions/sentry-triage/extension.mjs
@@ -116,6 +116,18 @@ function deriveRepoAnchors(prTargets, issueRepo, currentProjectRepo) {
   return { expectedRepo, prExpectedRepo, prProjectSelected }
 }
 
+// The TRUSTED current-checkout repo for the "Current project" PR anchor. Always
+// derived from the resolved session cwd (localPath), NEVER from runtimeDefaults.repo:
+// that value prefers GITHUB_REPOSITORY, which is the configured ISSUE target and may
+// point at a separate (cloud) repo. seedDefaultsFromSession() deliberately does not
+// overwrite an explicit GITHUB_REPOSITORY, so feeding runtimeDefaults.repo in as the
+// current-project anchor would gate PR validation/dedup on the issue repo and reject
+// legitimate PRs opened from the driving checkout. localPath is the resolved cwd, so
+// its git remote is the checkout actually being driven — the right, host-trusted anchor.
+function currentCheckoutRepo(defaults) {
+  return repoFromPath(defaults?.localPath || '')
+}
+
 // Every model turn (scan enrichment and each work item) runs on the ONE shared
 // `session`. The SDK drives a single conversation, so two overlapping
 // `sendAndWait` calls would interleave prompts and replies on the same thread —
@@ -539,7 +551,7 @@ function buildWorkPrompt({ key, issue, org, prTargets, model: modelOverride, ass
   // the trusted PR anchor when we have one, else the selected project's declared
   // repo (model-relayed — acceptable for a search hint), else the issue repo. Issue
   // lookup/creation stays on the issue repo (targetRepo).
-  const { prExpectedRepo } = deriveRepoAnchors(prTargets, issueRepo, defaults.repo)
+  const { prExpectedRepo } = deriveRepoAnchors(prTargets, issueRepo, currentCheckoutRepo(defaults))
   const prSearchRepo = prExpectedRepo || normalizeRepo(prTargets?.local?.repo) || targetRepo
   const plain = sanitizeForPrompt(issue.plainEnglish || issue.summary || 'User-visible failure in production', 200)
   const issueTitle = `[sentry-triage][${key}] ${plain}`.slice(0, 120)
@@ -901,7 +913,7 @@ Also, in the SAME turn, silently load the user's registered app projects for the
   // PR URL against that model-declared repo still pins the badge number to the URL it
   // links to and to the trusted host; it only accepts a model-asserted repo, which is
   // inherent to any model-reported tracking claim. Falls back to the issue repo last.
-  const { prExpectedRepo: trackPrExpectedRepo } = deriveRepoAnchors(trackPrTargets, trackRepo, runtimeDefaults.repo)
+  const { prExpectedRepo: trackPrExpectedRepo } = deriveRepoAnchors(trackPrTargets, trackRepo, currentCheckoutRepo(runtimeDefaults))
   const trackPrRepo = trackPrExpectedRepo || normalizeRepo(trackPrTargets?.local?.repo) || normalizeRepo(trackRepo)
   const needTracking = !!trackRepo
   const trackingToken = needTracking ? makeTrackingToken() : ''
@@ -1383,7 +1395,7 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
   // `prExpectedRepo` is the TRUSTED PR anchor when one exists, or '' for an
   // explicitly selected project — which authorizes by host-resolved project_id, not
   // a repo — signalled by `prProjectSelected` so the preflight below does NOT block.
-  const { expectedRepo, prExpectedRepo, prProjectSelected } = deriveRepoAnchors(prTargets, issueRepo, runtimeDefaults.repo)
+  const { expectedRepo, prExpectedRepo, prProjectSelected } = deriveRepoAnchors(prTargets, issueRepo, currentCheckoutRepo(runtimeDefaults))
   // Trusted host the authorized issue/PR links must live on, paired with
   // `expectedRepo`. Repo alone is not enough: a look-alike host would otherwise
   // let a model-reported link pass the repo check (see urlInRepo). Sourced from

--- a/extensions/sentry-triage/extension.mjs
+++ b/extensions/sentry-triage/extension.mjs
@@ -87,37 +87,33 @@ function normalizeRepo(value) {
   return raw.toLowerCase()
 }
 
-// Derive the two repo anchors the split-repo model enforces, from TRUSTED canvas
-// state only (Settings-configured prTargets / locally-detected defaults — never the
-// model or injected Sentry text):
+// Derive the two repo anchors the split-repo model enforces:
 //   - expectedRepo:   where the tracking ISSUE is filed (the issue/cloud repo).
-//   - prExpectedRepo: where the fix session opens its PR.
-// They can differ, and the PR anchor depends on WHERE the fix session runs:
-//   - Cloud mode: the session runs on the cloud repo, where the issue is also
-//     filed, so the PR anchor is the issue repo.
-//   - Local mode with an EXPLICITLY selected registered project (local.projectId
-//     set): the session runs in THAT project, so the PR lands in its config-time
-//     repo (local.repo, frozen when the user picked it in Settings — NOT re-read
-//     from the model-relayed project list at work time, which is refreshed inside
-//     the same turn that ingests untrusted Sentry data). If that repo is empty or
-//     malformed we FAIL CLOSED (prExpectedRepo='') rather than silently authorizing
-//     an unrelated repo; the caller's preflight then blocks.
-//   - Local mode with "Current project" (no explicit selection): the session runs
-//     in the canvas's OWN checkout, so the PR lands in the trusted current-project
-//     repo (`currentProjectRepo`, seeded from the session cwd's git remote) — NOT
-//     the issue repo, which Settings may point at a separate cloud repo. Using the
-//     issue repo here would make dedup search the wrong repo and reject the real
-//     PR callback.
-// Both values are '' unless a concrete "owner/repo" resolves.
+//   - prExpectedRepo: the TRUSTED repo a fix-session PR is gated against, or ''
+//     when no trusted anchor exists (in which case no URL gate is applied).
+// Only anchors from TRUSTED sources are used — never the model or injected Sentry
+// text:
+//   - Cloud mode: the fix session runs on the cloud repo (user-typed in Settings),
+//     where the issue is also filed, so the PR anchor is that issue repo.
+//   - Local mode, EXPLICITLY selected project (local.projectId set): the session is
+//     created by its host-resolved project_id — a trusted handle — so authorization
+//     rides on the project_id, NOT on a repo. The project's repo is only known via
+//     the model-relayed project list, which we do NOT treat as an authorization
+//     anchor, so we publish NO PR-repo gate here (prExpectedRepo='') and signal that
+//     via prProjectSelected. (The model list still feeds the Settings dropdown and a
+//     dedup search hint — display only, never authorization.)
+//   - Local mode, "Current project" (no explicit selection): the session runs in the
+//     canvas's OWN checkout, so the PR lands in the trusted current-project repo
+//     (`currentProjectRepo`, seeded from the session cwd's git remote) — NOT the
+//     issue repo, which Settings may point at a separate cloud repo.
+// Both repo values are '' unless a concrete "owner/repo" resolves.
 function deriveRepoAnchors(prTargets, issueRepo, currentProjectRepo) {
   const expectedRepo = normalizeRepo(issueRepo)
   const isCloudMode = prTargets?.mode === 'cloud'
-  if (isCloudMode) return { expectedRepo, prExpectedRepo: expectedRepo }
-  const localProjectSelected = Boolean(prTargets?.local?.projectId)
-  const prExpectedRepo = localProjectSelected
-    ? normalizeRepo(prTargets?.local?.repo)
-    : normalizeRepo(currentProjectRepo)
-  return { expectedRepo, prExpectedRepo }
+  if (isCloudMode) return { expectedRepo, prExpectedRepo: expectedRepo, prProjectSelected: false }
+  const prProjectSelected = Boolean(prTargets?.local?.projectId)
+  const prExpectedRepo = prProjectSelected ? '' : normalizeRepo(currentProjectRepo)
+  return { expectedRepo, prExpectedRepo, prProjectSelected }
 }
 
 // Every model turn (scan enrichment and each work item) runs on the ONE shared
@@ -538,12 +534,13 @@ function buildWorkPrompt({ key, issue, org, prTargets, model: modelOverride, ass
   const prMode = prTargets?.mode === 'cloud' ? 'cloud' : 'local'
   const model = modelOverride || prTargets?.model || ''
   const targetRepo = issueRepo || cloudRepo || defaults.repo || '(current repository)'
-  // The draft PR is opened where the fix session runs, which in local mode with an
-  // explicitly selected project is that project's repo — NOT the issue repo. Use
-  // this PR-repo anchor for the Step-0 open-PR dedup search; issue lookup/creation
-  // stays on the issue repo (targetRepo). Mirrors the enforcement in onWorkSelected.
+  // The draft PR is opened where the fix session runs. Use a best-effort PR-repo
+  // hint for the Step-0 open-PR dedup SEARCH only (never an authorization anchor):
+  // the trusted PR anchor when we have one, else the selected project's declared
+  // repo (model-relayed — acceptable for a search hint), else the issue repo. Issue
+  // lookup/creation stays on the issue repo (targetRepo).
   const { prExpectedRepo } = deriveRepoAnchors(prTargets, issueRepo, defaults.repo)
-  const prSearchRepo = prExpectedRepo || targetRepo
+  const prSearchRepo = prExpectedRepo || normalizeRepo(prTargets?.local?.repo) || targetRepo
   const plain = sanitizeForPrompt(issue.plainEnglish || issue.summary || 'User-visible failure in production', 200)
   const issueTitle = `[sentry-triage][${key}] ${plain}`.slice(0, 120)
   const markerLabel = 'sentry-triage'
@@ -868,14 +865,24 @@ async function enrichPlainEnglish(entry, categories, isCurrent) {
   const total = all.length
   const noun = total === 1 ? 'issue' : 'issues'
 
-  // Project enumeration is deliberately NOT folded into this triage turn. The
-  // projectId->repo mapping it produces is a security anchor (the saved repo is
-  // what onWorkSelected validates fix-session PRs against), and this prompt ingests
-  // untrusted Sentry titles below — a prompt injection could otherwise forge that
-  // mapping and steer PR validation at an attacker-chosen repo. It runs in its own
-  // Sentry-free turn (loadProjectOptions) after this one instead.
+  // Fold the one-time project enumeration into THIS triage round-trip. The list only
+  // populates the Settings dropdown (display + a dedup search hint); it is NOT an
+  // authorization anchor — fix-session PRs are authorized by the host-resolved
+  // project_id chosen at create_session time, never by this model-relayed repo (see
+  // deriveRepoAnchors). So even though this prompt ingests untrusted Sentry titles, a
+  // forged projectId->repo mapping can't steer PR authorization, and no separate
+  // Sentry-free turn is needed. Projects persist in state, so we only ask when we
+  // don't have them yet; the extra tool calls are silent.
   const loadedProjects = entry.state.getProjectOptions()
   const needProjects = !Array.isArray(loadedProjects) || loadedProjects.length === 0
+  const projectsToken = needProjects ? makeProjectsToken() : ''
+  const projectsBlock = needProjects
+    ? `
+
+Also, in the SAME turn, silently load the user's registered app projects for the canvas Settings dropdown (do not mention this in your reply):
+- Call the tool "list_projects".
+- Then call the tool "submit_projects" exactly once with token "${projectsToken}" (unchanged) and projects: an array of { id, name, repo, defaultBranch, path } using each project's id, name, github repo, default branch, and local main_repo_path (empty string if a field is missing).`
+    : ''
   // Fold tracking detection into the same round-trip: the canvas files tracking
   // issues with the "sentry-triage" label and the Sentry key in the title, so a
   // single label search of the target repo (matched by key) tells us which board
@@ -920,7 +927,7 @@ Do NOT use class names, exception type names, stack-trace terms, file paths, or 
 
 Do NOT print the summaries or any JSON in your reply. Instead call the tool "submit_issue_summaries" exactly once with:
 - token: "${token}" (pass it back unchanged)
-- summaries: an object mapping each issue key to its sentence, e.g. {"PROJ-123":"Shoppers cannot complete checkout after clicking pay."}${trackingBlock}${relatedBlock}
+- summaries: an object mapping each issue key to its sentence, e.g. {"PROJ-123":"Shoppers cannot complete checkout after clicking pay."}${projectsBlock}${trackingBlock}${relatedBlock}
 
 After the tool call(s), reply to the user with a confirmation sentence, then a blank line, then a clearly-labeled next-step note (no summaries, no JSON). Format it exactly like this (keep the blank line and the bold heading):
 
@@ -969,6 +976,9 @@ ${items.map((i) => `${i.key}: ${i.title}`).join('\n')}`
     // mutates this scan's own — now detached — category objects, which the caller
     // won't publish once isCurrent() is false.
     const current = typeof isCurrent !== 'function' || isCurrent()
+    if (current && projectsToken && projectsInbox.has(projectsToken)) {
+      entry.state.setProjectOptions(projectsInbox.get(projectsToken))
+    }
     // Only rewrite tracked badges when the model actually submitted tracking
     // (an empty {} still counts). If the turn died before submit_tracking ran,
     // leave any prior badges in place rather than wiping them.
@@ -1061,6 +1071,7 @@ ${items.map((i) => `${i.key}: ${i.title}`).join('\n')}`
     }
   } finally {
     summariesInbox.delete(token)
+    if (projectsToken) projectsInbox.delete(projectsToken)
     if (trackingToken) trackingInbox.delete(trackingToken)
     if (relatedToken) relatedInbox.delete(relatedToken)
   }
@@ -1071,54 +1082,14 @@ ${items.map((i) => `${i.key}: ${i.title}`).join('\n')}`
       issue.plainEnglish = phrased || fallbackPlainEnglish(issue.summary)
     }
   }
-
-  // Now enumerate app projects in a SEPARATE turn that carries no Sentry data (see
-  // the note where needProjects is computed). Best-effort and gated on isCurrent so
-  // a superseded scan neither runs an extra turn nor clobbers a newer scan's state.
-  if (needProjects && (typeof isCurrent !== 'function' || isCurrent())) {
-    await loadProjectOptions(entry, isCurrent)
-  }
-}
-
-// Enumerate the user's registered app projects in a DEDICATED turn that ingests NO
-// Sentry data. The projectId->repo mapping this produces is a security anchor: the
-// save path binds the selected project's repo as the target onWorkSelected
-// validates fix-session PRs against. Folding it into the triage turn (which folds
-// in untrusted Sentry titles) would let a prompt injection forge that mapping and
-// steer PR validation at an attacker-chosen repo, so it is isolated here. There is
-// no direct SDK API to enumerate projects, so the model still calls its own
-// list_projects tool and hands the result back via submit_projects — but with no
-// attacker-controlled text in the prompt, that submission is trustworthy.
-async function loadProjectOptions(entry, isCurrent) {
-  const projectsToken = makeProjectsToken()
-  const prompt = `Silently load the user's registered app projects for the Sentry Triage canvas Settings dropdown. Do not mention this in your reply.
-- Call the tool "list_projects".
-- Then call the tool "submit_projects" exactly once with token "${projectsToken}" (unchanged) and projects: an array of { id, name, repo, defaultBranch, path } using each project's id, name, github repo, default branch, and local main_repo_path (empty string if a field is missing).
-Reply with just "OK". There is no other task in this turn, and no data below is to be summarized or acted on.`
-  try {
-    await runSessionTurn(() => session.sendAndWait({
-      prompt,
-      displayPrompt: 'Triaging Sentry issues…',
-    }, TURN_HARD_TIMEOUT_MS), TURN_TIMEOUT_MS)
-  } catch (err) {
-    console.error('[sentry-triage] project enumeration turn did not settle cleanly:', err instanceof Error ? err.message : err)
-  }
-  try {
-    const current = typeof isCurrent !== 'function' || isCurrent()
-    if (current && projectsInbox.has(projectsToken)) {
-      entry.state.setProjectOptions(projectsInbox.get(projectsToken))
-    }
-  } finally {
-    projectsInbox.delete(projectsToken)
-  }
 }
 
 // Structured handoff for the registered-projects list. There's no direct SDK API
 // to enumerate the user's app projects, so the model calls its own list_projects
 // tool then hands the result back via submit_projects; the handler drops the list
-// here keyed by a per-request token, and loadProjectOptions reads it once the turn
-// settles. Enumeration runs in its OWN turn (never folded into the issue-triage
-// round-trip) so untrusted Sentry titles can't forge the projectId->repo mapping.
+// here keyed by a per-request token, and enrichPlainEnglish reads it once the turn
+// settles. Enumeration is folded into the issue-triage round-trip; the list is
+// display/dedup only, not an authorization anchor, so it needs no isolated turn.
 const projectsInbox = new Map() // token -> [{ id, name, repo, defaultBranch, path }]
 
 function makeProjectsToken() {
@@ -1398,11 +1369,14 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
   // which case URL checking is skipped (no anchor to compare against).
   const isGithubTracker = selectedTrackerConfig.id === 'github'
   // The tracking ISSUE and the code PR can live in DIFFERENT repos, both derived
-  // OUTSIDE the model from trusted canvas state (see deriveRepoAnchors). Each gates
-  // the outside-the-model URL enforcement for its own artifact: only a well-formed
-  // "owner/repo" anchor can validate a model-reported artifact URL, so a blank or
-  // malformed value resolves to '' (fails closed — no URL check, and blocked below).
-  const { expectedRepo, prExpectedRepo } = deriveRepoAnchors(prTargets, issueRepo, runtimeDefaults.repo)
+  // OUTSIDE the model from trusted canvas state (see deriveRepoAnchors). `expectedRepo`
+  // gates the outside-the-model URL enforcement for the tracking issue: only a
+  // well-formed "owner/repo" anchor can validate a model-reported issue URL, so a
+  // blank value resolves to '' (fails closed — no URL check, and blocked below).
+  // `prExpectedRepo` is the TRUSTED PR anchor when one exists, or '' for an
+  // explicitly selected project — which authorizes by host-resolved project_id, not
+  // a repo — signalled by `prProjectSelected` so the preflight below does NOT block.
+  const { expectedRepo, prExpectedRepo, prProjectSelected } = deriveRepoAnchors(prTargets, issueRepo, runtimeDefaults.repo)
   // Trusted host the authorized issue/PR links must live on, paired with
   // `expectedRepo`. Repo alone is not enough: a look-alike host would otherwise
   // let a model-reported link pass the repo check (see urlInRepo). Sourced from
@@ -1421,21 +1395,19 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
   // so it needs a concrete issue-repo anchor. Only a tracking-only run on a
   // non-GitHub tracker (Linear/Jira) performs no GitHub write, so it may proceed
   // without a repo anchor. Normal checkouts resolve a repo from the git remote;
-  // this trips only when detection fails or a target lacks a valid repo. The two
-  // failures have different fixes, so report the one that actually bit: a missing
-  // ISSUE anchor means no target repo is configured (fix in Settings), while a
-  // missing PR anchor with a VALID issue repo means the resolved PR project has
-  // empty/malformed repo metadata. That happens two ways: an explicitly selected
-  // local project whose config-time repo is blank/malformed (fix: pick a project
-  // with a valid owner/repo), or "Current project" running in a checkout with no
-  // detectable GitHub remote (fix: run from a repo-backed checkout). Both share a
-  // message that names either remedy.
+  // this trips only when detection fails. The two failures have different fixes, so
+  // report the one that actually bit: a missing ISSUE anchor means no target repo is
+  // configured (fix in Settings), while a missing PR anchor is "Current project"
+  // running in a checkout with no detectable GitHub remote — an explicitly selected
+  // project is authorized by its host-resolved project_id, needs no repo anchor, and
+  // is exempted here via prProjectSelected (fix: run from a repo-backed checkout, or
+  // pick a registered project).
   const missingIssueRepo = isGithubTracker && !expectedRepo
-  const missingPrRepo = wantsCopilot && !prExpectedRepo
+  const missingPrRepo = wantsCopilot && !prExpectedRepo && !prProjectSelected
   if (missingIssueRepo || missingPrRepo) {
     const error = missingIssueRepo
       ? 'No target repository is configured, so issue creation cannot be verified. Set a target repository in Settings before starting work.'
-      : 'The pull request destination has no valid repository (owner/repo), so it cannot be verified. Select a project with valid repository metadata, or open this canvas from a checkout with a GitHub remote, before starting work.'
+      : 'The pull request destination has no valid repository (owner/repo), so it cannot be verified. Open this canvas from a checkout with a GitHub remote, or select a registered project, before starting work.'
     for (const key of startableKeys) {
       entry.notifyWork(key, {
         phase: 'error',
@@ -1486,12 +1458,12 @@ async function onWorkSelected(entry, issueKeys, modelByKey, assignCopilot) {
 
     // Mint a token for THIS work item so the eventual PR callback can be routed
     // back to this exact instance+key even across canvases sharing a short key.
-    // Capture the repository authorized at hand-off time so a later PR callback is
-    // validated against THAT repo, not whatever the target settings happen to be
-    // when the callback lands — changing the target mid-flight must not cause a
-    // legitimate PR in the original repo to be rejected (or an attacker one in a
-    // newly-set repo to pass). The callback carries a PR, which lands in the PR
-    // repo (`prExpectedRepo`) — in local mode that can differ from the issue repo.
+    // Capture the repo the PR is authorized against AT hand-off time (frozen, not
+    // recomputed from live settings) so retargeting the canvas mid-flight can't
+    // reject a legitimate PR in the original repo or admit one in a newly-set repo.
+    // This anchor is '' for an explicitly selected project — such work is authorized
+    // by its host-resolved project_id, not a model-relayed repo — and submit_work_pr
+    // treats an empty anchor as "no URL gate" accordingly.
     const workToken = randomUUID()
     workRegistry.set(workToken, { entry, key, scopeGen, authorizedRepo: prExpectedRepo, authorizedHost: allowedHost })
 
@@ -2002,24 +1974,26 @@ const session = await joinSession({
         if (registered.key !== key) {
           return `Ignored: workToken does not match key ${key} (it was issued for ${registered.key}).`
         }
-        // Same outside-the-model enforcement as the success gate: this PR must live
-        // in the repository the work item was authorized against WHEN IT STARTED —
-        // captured in the token, not recomputed from current settings, so retargeting
-        // the canvas mid-flight can't reject a legitimate PR in the original repo (or
-        // admit an attacker one in a newly-set repo). A code PR is always on GitHub,
-        // so this applies regardless of the issue tracker. Reject WITHOUT consuming
-        // the single-use token so a genuine session can retry with the correct URL.
-        // '' ("cannot confirm") fails closed; the authorized repo is always concrete
-        // here because onWorkSelected refuses to start GitHub work without one.
+        // Same outside-the-model enforcement as the success gate: when the work item
+        // was authorized against a concrete repo WHEN IT STARTED (captured in the
+        // token, not recomputed from current settings), this PR must live there, so
+        // retargeting the canvas mid-flight can't reject a legitimate PR in the
+        // original repo or admit an attacker one in a newly-set repo. Reject WITHOUT
+        // consuming the single-use token so a genuine session can retry the URL.
+        // The authorized repo is '' for an explicitly selected project (authorized by
+        // host-resolved project_id, not a model-relayed repo) and for non-GitHub
+        // trackers; in those cases there is no trusted URL anchor, so the gate below
+        // is skipped and the reported number is shown as-is. When a concrete anchor
+        // IS present (cloud / current-project), '' from repoRefNumber fails closed.
         const regRepo = registered.authorizedRepo || ''
         const regHost = registered.authorizedHost || ''
         // Derive the DISPLAYED PR number from the same validated URL, never from the
         // model-reported prNumber: a session could pair /pull/1 with prNumber 999 and
         // render "PR #999" linking to PR 1. repoRefNumber returns null on any
         // host/repo/shape mismatch (the reject below, equivalent to the old urlInRepo
-        // guard) and otherwise the number parsed from the URL. '' ("cannot confirm")
-        // fails closed, but if the authorized repo somehow weren't concrete there's
-        // nothing to validate against, so fall back to the reported number.
+        // guard) and otherwise the number parsed from the URL. When there is no
+        // concrete authorized repo there's nothing to validate against, so fall back
+        // to the reported number (display only — no authorization rides on it).
         const verifiedPrNumber = regRepo
           ? repoRefNumber(prUrl, regRepo, regHost, 'pull')
           : (reportedPrNumber ?? null)

--- a/extensions/sentry-triage/server.mjs
+++ b/extensions/sentry-triage/server.mjs
@@ -370,6 +370,7 @@ export function startServer({ port = 0, onRefresh, onAction, onWorkSelected, onR
             baseBranch: pick(payload.localBranch, current.local.baseBranch),
             projectId: pick(payload.localProjectId, current.local.projectId),
             projectName: pick(payload.localProjectName, current.local.projectName),
+            repo: pick(payload.localProjectRepo, current.local.repo),
           },
           cloud: {
             repo: pick(payload.cloudRepo, current.cloud.repo),
@@ -384,7 +385,9 @@ export function startServer({ port = 0, onRefresh, onAction, onWorkSelected, onR
         // the stale annotations now, invalidate any pending enrichment, and
         // re-derive against the new repo. Model/base-branch-only edits keep them.
         const repoId = (t) =>
-          [t.cloud.repo, t.local.path, t.local.projectId].map((v) => (v || '').trim()).join('\u0000')
+          [t.mode, t.cloud.repo, t.local.path, t.local.projectId, t.local.repo]
+            .map((v) => (v || '').trim())
+            .join('\u0000')
         const repoChanged = repoId(next) !== repoId(current)
         state.setPrTargets(next)
         if (repoChanged) {

--- a/extensions/sentry-triage/server.mjs
+++ b/extensions/sentry-triage/server.mjs
@@ -362,14 +362,19 @@ export function startServer({ port = 0, onRefresh, onAction, onWorkSelected, onR
         const payload = parseJson(body)
         const current = state.getPrTargets()
         const pick = (value, fallback) => (typeof value === 'string' ? value : fallback)
-        // The PR-authorization repo (and its display name) must NOT be taken from
-        // the browser payload. The Settings dropdown is populated by the model via
-        // submit_projects, so accepting its repo here would let a forged
-        // projectId->repo mapping choose where fix-session PRs may land. Re-bind both
-        // from the selected projectId against our own trusted project options (loaded
-        // in a Sentry-free turn — see loadProjectOptions), failing closed to '' when
-        // the id isn't in the list. localProjectRepo/localProjectName in the payload
-        // are ignored on purpose.
+        // repo/name here are DISPLAY + dedup-search metadata only — they do NOT
+        // authorize where fix-session PRs land (an explicitly selected project is
+        // authorized by its host-resolved project_id at create_session time; see
+        // deriveRepoAnchors). Still, don't take them from the browser payload: the
+        // Settings dropdown is populated by the model via submit_projects, so re-bind
+        // repo/name from the selected projectId against our own project options to
+        // keep the browser from injecting arbitrary display/search strings. Crucially,
+        // ALSO reject a projectId that doesn't resolve to a known project (stale or
+        // forged): storing an unknown non-empty id would make deriveRepoAnchors treat
+        // it as an explicit selection and skip the missing-repo/PR-URL preflight, so
+        // an unresolvable id must fail closed to '' (→ Current-project mode, which
+        // requires a trusted git remote). localProjectRepo/localProjectName in the
+        // payload are ignored on purpose.
         const nextProjectId = pick(payload.localProjectId, current.local.projectId)
         const trustedProjects = state.getProjectOptions()
         const boundProject = nextProjectId && Array.isArray(trustedProjects)
@@ -383,7 +388,7 @@ export function startServer({ port = 0, onRefresh, onAction, onWorkSelected, onR
           local: {
             path: pick(payload.localPath, current.local.path),
             baseBranch: pick(payload.localBranch, current.local.baseBranch),
-            projectId: nextProjectId,
+            projectId: boundProject ? nextProjectId : '',
             projectName: boundName,
             repo: boundRepo,
           },

--- a/extensions/sentry-triage/server.mjs
+++ b/extensions/sentry-triage/server.mjs
@@ -104,7 +104,6 @@ export function startServer({ port = 0, onRefresh, onAction, onWorkSelected, onR
       orgDefault: state.getOrgDefault(),
       savedDefaultOrg: state.getSavedDefaultOrg(),
       project: state.getProject(),
-      projectOptions: state.getProjectOptions(),
       period: state.getPeriod(),
       periods: PERIODS,
       projects: state.getProjects(),
@@ -362,35 +361,17 @@ export function startServer({ port = 0, onRefresh, onAction, onWorkSelected, onR
         const payload = parseJson(body)
         const current = state.getPrTargets()
         const pick = (value, fallback) => (typeof value === 'string' ? value : fallback)
-        // repo/name here are DISPLAY + dedup-search metadata only — they do NOT
-        // authorize where fix-session PRs land (an explicitly selected project is
-        // authorized by its host-resolved project_id at create_session time; see
-        // deriveRepoAnchors). Still, don't take them from the browser payload: the
-        // Settings dropdown is populated by the model via submit_projects, so re-bind
-        // repo/name from the selected projectId against our own project options to
-        // keep the browser from injecting arbitrary display/search strings. Crucially,
-        // ALSO reject a projectId that doesn't resolve to a known project (stale or
-        // forged): storing an unknown non-empty id would make deriveRepoAnchors treat
-        // it as an explicit selection and skip the missing-repo/PR-URL preflight, so
-        // an unresolvable id must fail closed to '' (→ Current-project mode, which
-        // requires a trusted git remote). localProjectRepo/localProjectName in the
-        // payload are ignored on purpose.
-        const nextProjectId = pick(payload.localProjectId, current.local.projectId)
-        const trustedProjects = state.getProjectOptions()
-        const boundProject = nextProjectId && Array.isArray(trustedProjects)
-          ? trustedProjects.find((p) => p && p.id === nextProjectId)
-          : null
-        const boundRepo = boundProject && typeof boundProject.repo === 'string' ? boundProject.repo : ''
-        const boundName = boundProject && typeof boundProject.name === 'string' ? boundProject.name : ''
+        // The local fix-session hand-off always runs in the CURRENT project (the
+        // canvas's own checkout, host-trusted from its git remote), so there is no
+        // model-relayed project selection to bind here. Cross-repo work uses Cloud
+        // mode, whose repo the user types directly in Settings (also trusted). Only
+        // the local path/branch and cloud repo/branch are accepted from the payload.
         const next = {
           mode: pick(payload.mode, current.mode),
           model: pick(payload.model, current.model),
           local: {
             path: pick(payload.localPath, current.local.path),
             baseBranch: pick(payload.localBranch, current.local.baseBranch),
-            projectId: boundProject ? nextProjectId : '',
-            projectName: boundName,
-            repo: boundRepo,
           },
           cloud: {
             repo: pick(payload.cloudRepo, current.cloud.repo),
@@ -405,7 +386,7 @@ export function startServer({ port = 0, onRefresh, onAction, onWorkSelected, onR
         // the stale annotations now, invalidate any pending enrichment, and
         // re-derive against the new repo. Model/base-branch-only edits keep them.
         const repoId = (t) =>
-          [t.mode, t.cloud.repo, t.local.path, t.local.projectId, t.local.repo]
+          [t.mode, t.cloud.repo, t.local.path]
             .map((v) => (v || '').trim())
             .join('\u0000')
         const repoChanged = repoId(next) !== repoId(current)

--- a/extensions/sentry-triage/server.mjs
+++ b/extensions/sentry-triage/server.mjs
@@ -362,15 +362,30 @@ export function startServer({ port = 0, onRefresh, onAction, onWorkSelected, onR
         const payload = parseJson(body)
         const current = state.getPrTargets()
         const pick = (value, fallback) => (typeof value === 'string' ? value : fallback)
+        // The PR-authorization repo (and its display name) must NOT be taken from
+        // the browser payload. The Settings dropdown is populated by the model via
+        // submit_projects, so accepting its repo here would let a forged
+        // projectId->repo mapping choose where fix-session PRs may land. Re-bind both
+        // from the selected projectId against our own trusted project options (loaded
+        // in a Sentry-free turn — see loadProjectOptions), failing closed to '' when
+        // the id isn't in the list. localProjectRepo/localProjectName in the payload
+        // are ignored on purpose.
+        const nextProjectId = pick(payload.localProjectId, current.local.projectId)
+        const trustedProjects = state.getProjectOptions()
+        const boundProject = nextProjectId && Array.isArray(trustedProjects)
+          ? trustedProjects.find((p) => p && p.id === nextProjectId)
+          : null
+        const boundRepo = boundProject && typeof boundProject.repo === 'string' ? boundProject.repo : ''
+        const boundName = boundProject && typeof boundProject.name === 'string' ? boundProject.name : ''
         const next = {
           mode: pick(payload.mode, current.mode),
           model: pick(payload.model, current.model),
           local: {
             path: pick(payload.localPath, current.local.path),
             baseBranch: pick(payload.localBranch, current.local.baseBranch),
-            projectId: pick(payload.localProjectId, current.local.projectId),
-            projectName: pick(payload.localProjectName, current.local.projectName),
-            repo: pick(payload.localProjectRepo, current.local.repo),
+            projectId: nextProjectId,
+            projectName: boundName,
+            repo: boundRepo,
           },
           cloud: {
             repo: pick(payload.cloudRepo, current.cloud.repo),

--- a/extensions/sentry-triage/state.mjs
+++ b/extensions/sentry-triage/state.mjs
@@ -99,7 +99,7 @@ export function createState() {
   const prTargets = {
     mode: 'local',
     model: '',
-    local: { path: '', baseBranch: '', projectId: '', projectName: '' },
+    local: { path: '', baseBranch: '', projectId: '', projectName: '', repo: '' },
     cloud: { repo: '', baseBranch: '' },
   }
 
@@ -116,6 +116,7 @@ export function createState() {
         baseBranch: str(local.baseBranch),
         projectId: str(local.projectId),
         projectName: str(local.projectName),
+        repo: str(local.repo),
       },
       cloud: {
         repo: str(cloud.repo),
@@ -337,6 +338,7 @@ export function createState() {
       prTargets.local.baseBranch = normalized.local.baseBranch
       prTargets.local.projectId = normalized.local.projectId
       prTargets.local.projectName = normalized.local.projectName
+      prTargets.local.repo = normalized.local.repo
       prTargets.cloud.repo = normalized.cloud.repo
       prTargets.cloud.baseBranch = normalized.cloud.baseBranch
       return prTargets

--- a/extensions/sentry-triage/state.mjs
+++ b/extensions/sentry-triage/state.mjs
@@ -52,11 +52,6 @@ export function createState() {
   // SSE project broadcast to the right org (setup screen switches org before any
   // scan, so the panel's own org isn't a reliable signal).
   let projectsOrg = ''
-  // Registered app projects the "Work on selected" local hand-off can spawn the
-  // fix session in. Enumerated eagerly on canvas open via the agent's
-  // list_projects tool (there is no direct SDK API), each entry is
-  // { id, name, repo, defaultBranch, path }.
-  let projectOptions = []
   // Sentry search window. Defaults to the last day; the user can widen it from
   // the issues list to look further back. Only Sentry's supported periods are
   // accepted (see PERIODS below).
@@ -99,7 +94,7 @@ export function createState() {
   const prTargets = {
     mode: 'local',
     model: '',
-    local: { path: '', baseBranch: '', projectId: '', projectName: '', repo: '' },
+    local: { path: '', baseBranch: '' },
     cloud: { repo: '', baseBranch: '' },
   }
 
@@ -114,9 +109,6 @@ export function createState() {
       local: {
         path: str(local.path),
         baseBranch: str(local.baseBranch),
-        projectId: str(local.projectId),
-        projectName: str(local.projectName),
-        repo: str(local.repo),
       },
       cloud: {
         repo: str(cloud.repo),
@@ -253,25 +245,6 @@ export function createState() {
       return projectsOrg
     },
 
-    getProjectOptions() {
-      return projectOptions
-    },
-
-    setProjectOptions(list) {
-      projectOptions = Array.isArray(list)
-        ? list
-            .filter((p) => p && typeof p === 'object' && typeof p.id === 'string' && p.id)
-            .map((p) => ({
-              id: p.id,
-              name: typeof p.name === 'string' && p.name ? p.name : p.id,
-              repo: typeof p.repo === 'string' ? p.repo : '',
-              defaultBranch: typeof p.defaultBranch === 'string' ? p.defaultBranch : '',
-              path: typeof p.path === 'string' ? p.path : '',
-            }))
-        : []
-      return projectOptions
-    },
-
     getConnections() {
       return connections
     },
@@ -336,9 +309,6 @@ export function createState() {
       prTargets.model = normalized.model
       prTargets.local.path = normalized.local.path
       prTargets.local.baseBranch = normalized.local.baseBranch
-      prTargets.local.projectId = normalized.local.projectId
-      prTargets.local.projectName = normalized.local.projectName
-      prTargets.local.repo = normalized.local.repo
       prTargets.cloud.repo = normalized.cloud.repo
       prTargets.cloud.baseBranch = normalized.cloud.baseBranch
       return prTargets


### PR DESCRIPTION
## What & why

Follow-up hardening for the merged Sentry Triage canvas (#2802). The canvas relays model-reported GitHub artifact URLs and numbers — produced in the same turn that ingests **untrusted Sentry text** — into tracking badges and the "Fix with Copilot" flow. This PR validates that data against trusted, outside-the-model anchors so injected text can't mint misleading badges or steer a GitHub write to the wrong repo, and adds first-class support for issue and PR repos that legitimately differ.

## Changes

- **Path-type-aware URL validation** (`repoRefNumber`/`urlInRepo`): a URL is only trusted when it is http(s), on the trusted host, in the expected `owner/repo`, and matches the exact artifact kind (`/issues/<n>` vs `/pull/<n>`) with a path-segment boundary after the id. The id must be a positive safe integer. Rejects look-alikes like `/pull/123evil`, cross-kind spoofs (an issue URL minting a "PR #N" badge), and overflow/zero ids.
- **Split issue anchor from PR anchor** (`deriveRepoAnchors`): the tracking issue and the fix PR can live in different repos. Cloud mode anchors the PR on the issue/cloud repo; an explicitly selected local project anchors it on that project's config-time repo (frozen at save time); "Current project" anchors it on the trusted current-project repo from the git remote — never the issue repo. A missing/malformed PR repo **fails closed** with a clear, actionable error.
- **Derive tracking numbers from the validated URLs** (not the model), and strip every `pr*` field when no concrete `/pull/<n>` in the PR repo is present, so a badge can't point at a different artifact than the one verified.
- **Roll the optimistic rescan overlay back on a failed `/api/refresh` POST** instead of leaving a blocking overlay up until the fallback timer expires.

## Testing

- `node --check` on all four changed modules.
- Ad-hoc unit tests (15 cases) covering the id boundary/safe-integer guards and all three `deriveRepoAnchors` branches.
- Line endings normalized via `eng/fix-line-endings.sh`.

Opening as **draft** for a Copilot review pass before marking ready.
