### PR TITLE
Add an exact-slug Sentry project resolver to the sentry-triage canvas

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1349,7 +1349,7 @@
       "name": "sentry-triage",
       "source": "plugins/sentry-triage",
       "description": "Scan live Sentry issues in a Copilot canvas, group them by urgency, and hand issues off for tracking or a fix PR.",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "name": "signals-dashboard",

--- a/extensions/sentry-triage/README.md
+++ b/extensions/sentry-triage/README.md
@@ -42,10 +42,11 @@ that drafts a fix pull request.
 - The GitHub Copilot app canvas / UI-extensions experiment enabled.
 - A Sentry sign-in. This canvas reads issues through the
   [Sentry CLI](https://cli.sentry.dev) in library mode — there is no MCP server
-  to configure. Sign in once from your terminal:
+  to configure. After installing the dependency (see **Install** below), sign in
+  once with the package-local CLI, run from the extension folder:
 
   ```sh
-  sentry auth login
+  npx sentry auth login
   ```
 
   This stores an OAuth credential the canvas auto-detects. For non-interactive
@@ -61,10 +62,35 @@ that drafts a fix pull request.
 
 ## Install
 
-Drop this folder at `~/.copilot/extensions/sentry-triage/` for user scope, or in
-a repository at `.github/extensions/sentry-triage/` for project scope. Then
-install dependencies from inside the copied folder (this canvas depends on the
-`sentry` npm package at runtime):
+Drop this folder at `~/.copilot/extensions/sentry-triage/` for user scope, or in a
+repository at `.github/extensions/sentry-triage/` for project scope.
+
+This canvas depends on the [`sentry`](https://cli.sentry.dev) npm package at
+runtime, which isn't bundled with the extension source. If it's missing, the canvas
+still **opens** and shows a setup gate explaining what to do instead of crashing.
+
+### Let Copilot set it up (recommended)
+
+Because the canvas runs inside GitHub Copilot, the agent can install the dependency
+for you. Paste this into Copilot:
+
+> Locate the loaded `sentry-triage` canvas extension folder — the directory that
+> contains its `package.json` — run `npm install` there, then reload extensions.
+
+(That folder is `~/.copilot/extensions/sentry-triage/` for user scope,
+`.github/extensions/sentry-triage/` for project scope, or, if you installed the
+published plugin, `com.github.copilot/extensions/sentry-triage` inside the
+installed plugin.)
+
+Then finish the one interactive step yourself — sign in so Copilot never handles a
+raw secret. Run this from the same extension folder (`npx` resolves the CLI the
+local `npm install` just placed in `node_modules`):
+
+```sh
+npx sentry auth login
+```
+
+### Or install it manually
 
 ```sh
 # User scope
@@ -73,11 +99,15 @@ cd ~/.copilot/extensions/sentry-triage
 # Or project scope, from the repository root
 cd .github/extensions/sentry-triage
 
+# Or, if you installed the published plugin (`copilot plugin install`), the source
+# lives inside the installed plugin — cd into its extension folder:
+cd <installed-plugin-path>/com.github.copilot/extensions/sentry-triage
+
 npm install
+npx sentry auth login
 ```
 
-Reload extensions in the GitHub Copilot app, then open the `sentry-triage`
-canvas.
+Reload extensions in the GitHub Copilot app, then open the `sentry-triage` canvas.
 
 ## Open the canvas in the correct repository scope
 

--- a/extensions/sentry-triage/components/page.mjs
+++ b/extensions/sentry-triage/components/page.mjs
@@ -66,6 +66,10 @@ export function Page({
   // required, …). Shown in the gate so users see the real reason instead of a
   // generic "connect" message for problems reconnecting won't fix.
   const gateError = (conn.sentry && conn.sentry.error) || ''
+  // A dedicated setup reason (currently only the optional `sentry` package being
+  // absent) that takes precedence over the auth/connectivity gate variants, so the
+  // install prompt is never shown beneath contradictory "sign in" guidance.
+  const packageMissing = (conn.sentry && conn.sentry.setup) === 'package-missing'
   // Distinguish "not signed in" (needs `sentry auth login`) from a transient
   // connectivity failure where a credential likely exists. probeSentry() reports
   // configured:false only for auth failures, so a gated-but-configured state means
@@ -184,20 +188,24 @@ export function Page({
     <section class="sentry-gate" role="alert">
       <div class="gate-card">
         <div class="gate-icon">⚠️</div>
-        <h2 id="gate-title">${signedOut ? 'Connect Sentry to start triaging' : 'Can’t reach Sentry right now'}</h2>
-        <div class="gate-body gate-body-auth" id="gate-body-auth"${signedOut ? '' : ' style="display:none;"'}>
-          <p class="gate-lead">This canvas reads your live Sentry issues through the Sentry CLI, but it isn't signed in yet.</p>
-          <p class="gate-steps">Run <code>sentry auth login</code> in your terminal to sign in, then re-open this canvas.</p>
+        <h2 id="gate-title">${packageMissing ? 'Set up the Sentry CLI' : (signedOut ? 'Connect Sentry to start triaging' : 'Can’t reach Sentry right now')}</h2>
+        <div class="gate-body gate-body-setup" id="gate-body-setup"${packageMissing ? '' : ' style="display:none;"'}>
+          <p class="gate-lead">This canvas reads your live Sentry issues through the Sentry CLI, but its <code>sentry</code> package isn’t installed for this extension yet.</p>
+          <p class="gate-steps">Ask Copilot to “install the sentry-triage dependencies and reload extensions,” then run <code>npx sentry auth login</code> from the extension folder to sign in and re-open this canvas.</p>
         </div>
-        <div class="gate-body gate-body-conn" id="gate-body-conn"${signedOut || !transientConn ? ' style="display:none;"' : ''}>
+        <div class="gate-body gate-body-auth" id="gate-body-auth"${signedOut && !packageMissing ? '' : ' style="display:none;"'}>
+          <p class="gate-lead">This canvas reads your live Sentry issues through the Sentry CLI, but it isn't signed in yet.</p>
+          <p class="gate-steps">Run <code>npx sentry auth login</code> from the extension folder to sign in, then re-open this canvas.</p>
+        </div>
+        <div class="gate-body gate-body-conn" id="gate-body-conn"${signedOut || !transientConn || packageMissing ? ' style="display:none;"' : ''}>
           <p class="gate-lead">You’re signed in, but this canvas couldn’t reach Sentry — usually a temporary network blip.</p>
           <p class="gate-steps">It should recover on the next check. If it persists, check your network or VPN, then re-open this canvas.</p>
         </div>
-        <div class="gate-body gate-body-unknown" id="gate-body-unknown"${signedOut || transientConn ? ' style="display:none;"' : ''}>
+        <div class="gate-body gate-body-unknown" id="gate-body-unknown"${signedOut || transientConn || packageMissing ? ' style="display:none;"' : ''}>
           <p class="gate-lead">You’re signed in, but this canvas couldn’t reach Sentry.</p>
           <p class="gate-steps">See the details below, then re-open this canvas to try again.</p>
         </div>
-        <p class="gate-error" id="gate-error" ${sentryReady || !gateError ? 'style="display:none;"' : ''}>${escapeHtml(gateError || '')}</p>
+        <p class="gate-error" id="gate-error" ${sentryReady || !gateError || packageMissing ? 'style="display:none;"' : ''}>${escapeHtml(gateError || '')}</p>
       </div>
     </section>
 
@@ -1108,25 +1116,30 @@ export function Page({
         // sentry auth login command, nor promise recovery for what won't self-heal.
         const signedOut = !(c.sentry && c.sentry.configured);
         const transientConn = Boolean(c.sentry && c.sentry.transient);
+        const packageMissing = (c.sentry && c.sentry.setup) === "package-missing";
         const gateTitleEl = document.getElementById("gate-title");
         if (gateTitleEl) {
-          gateTitleEl.textContent = signedOut
+          gateTitleEl.textContent = packageMissing
+            ? "Set up the Sentry CLI"
+            : signedOut
             ? "Connect Sentry to start triaging"
             : "Can’t reach Sentry right now";
         }
+        const setupBody = document.getElementById("gate-body-setup");
         const authBody = document.getElementById("gate-body-auth");
         const connBody = document.getElementById("gate-body-conn");
         const unknownBody = document.getElementById("gate-body-unknown");
-        if (authBody) authBody.style.display = signedOut ? "" : "none";
-        if (connBody) connBody.style.display = !signedOut && transientConn ? "" : "none";
-        if (unknownBody) unknownBody.style.display = !signedOut && !transientConn ? "" : "none";
+        if (setupBody) setupBody.style.display = packageMissing ? "" : "none";
+        if (authBody) authBody.style.display = signedOut && !packageMissing ? "" : "none";
+        if (connBody) connBody.style.display = !signedOut && !packageMissing && transientConn ? "" : "none";
+        if (unknownBody) unknownBody.style.display = !signedOut && !packageMissing && !transientConn ? "" : "none";
 
         // Surface the specific preflight failure in the gate (or hide it when the
         // error clears / there's nothing actionable beyond the sign-in steps).
         const gateErrEl = document.getElementById("gate-error");
         if (gateErrEl) {
           const err = (c.sentry && c.sentry.error) || "";
-          if (gatedNow && err) {
+          if (gatedNow && err && !packageMissing) {
             gateErrEl.textContent = err;
             gateErrEl.style.display = "";
           } else {

--- a/extensions/sentry-triage/components/page.mjs
+++ b/extensions/sentry-triage/components/page.mjs
@@ -410,6 +410,21 @@ export function Page({
       // requestProjectsForOrg while seeding the org select. Seeded at init.
       const projectsByOrg = {};
 
+      // Cache of exact-slug resolutions (org "/" slug -> "checking" | "found" |
+      // "missing" | "error", plus the canonical slug when found). The paged
+      // project list can't reach every project in a mega-org, so a valid typed
+      // slug may show "No matching projects"; a live project.view lookup (via
+      // /api/resolve-project) confirms it exists and lets the user select it.
+      const projectResolveCache = {};
+      // Callbacks waiting on an in-flight lookup, keyed the same way. When a check
+      // is already running for a slug, later callers (e.g. the Scan/Fetch gate)
+      // queue here and are flushed when it settles, instead of being dropped.
+      const projectResolveWaiters = {};
+      function projectResolveKey(org, slug) {
+        return String(org || "").trim().toLowerCase() + "/" + String(slug || "").trim().toLowerCase();
+      }
+
+
       function submitScan() {
         const input = document.getElementById("org-input");
         const projectInput = document.getElementById("project-input");
@@ -424,29 +439,44 @@ export function Page({
         const project = projectInput ? projectInput.value.trim() : "";
         const repo = repoInput ? repoInput.value.trim() : "";
         if (!org) { if (input) input.focus(); return; }
-        if (input) { input.value = org; input.disabled = true; }
-        if (projectInput) projectInput.disabled = true;
-        const scanBtn = document.getElementById("scan-btn");
-        if (scanBtn) { scanBtn.disabled = true; scanBtn.textContent = "Scanning…"; }
-        showScanOverlay(project ? "Scanning " + project + "…" : "Scanning all projects…");
-        fetch("/api/set-org", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ org, project, repo })
-        }).then((res) => {
-          if (!res.ok) throw new Error("set-org " + res.status);
-        }).catch(() => {
-          // The loopback POST failed (server stopped, rejected, or a transport
-          // blip). Without this, the overlay would linger until its 250s safety
-          // timer while the form stayed disabled — a dead end with no retry path
-          // short of reopening the canvas. Restore the controls and tell the user
-          // so they can try again.
-          hideScanOverlay();
-          if (input) input.disabled = false;
-          if (projectInput) projectInput.disabled = false;
-          if (scanBtn) { scanBtn.disabled = false; scanBtn.textContent = "Scan"; }
-          syncScanButtonState();
-          window.alert("Couldn't start the scan — the triage server may have stopped responding. Please try again.");
+        // Gate: a typed project must be verified against Sentry before the scan
+        // starts, so clicking Scan (or submitting the form) can't start a scan on
+        // an unverified slug the way Enter in the autocomplete already prevents.
+        // An empty project scans all projects and needs no lookup.
+        verifyProjectForScan(org, project).then((v) => {
+          if (!v.ok) {
+            showToast(v.reason === "missing"
+              ? "No project \u201C" + project + "\u201D in " + org + " — check the slug."
+              : "Couldn't verify that project with Sentry — try again.");
+            if (projectInput) projectInput.focus();
+            return;
+          }
+          const proj = v.slug;
+          if (projectInput && proj !== project) projectInput.value = proj;
+          if (input) { input.value = org; input.disabled = true; }
+          if (projectInput) projectInput.disabled = true;
+          const scanBtn = document.getElementById("scan-btn");
+          if (scanBtn) { scanBtn.disabled = true; scanBtn.textContent = "Scanning…"; }
+          showScanOverlay(proj ? "Scanning " + proj + "…" : "Scanning all projects…");
+          fetch("/api/set-org", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ org, project: proj, repo })
+          }).then((res) => {
+            if (!res.ok) throw new Error("set-org " + res.status);
+          }).catch(() => {
+            // The loopback POST failed (server stopped, rejected, or a transport
+            // blip). Without this, the overlay would linger until its 250s safety
+            // timer while the form stayed disabled — a dead end with no retry path
+            // short of reopening the canvas. Restore the controls and tell the user
+            // so they can try again.
+            hideScanOverlay();
+            if (input) input.disabled = false;
+            if (projectInput) projectInput.disabled = false;
+            if (scanBtn) { scanBtn.disabled = false; scanBtn.textContent = "Scan"; }
+            syncScanButtonState();
+            window.alert("Couldn't start the scan — the triage server may have stopped responding. Please try again.");
+          });
         });
       }
 
@@ -1211,6 +1241,22 @@ export function Page({
         return currentProject && !list.includes(currentProject) ? [currentProject, ...list] : list;
       }
 
+      // The project slugs known to belong to a specific org. Always read from the
+      // org-keyed cache (populated by the initial seed and every SSE broadcast under
+      // the list's own org), never from the painted currentSentryProjects list: on a
+      // free-text header org switch, fetchScoped() sets currentOrg to the new org
+      // before its project-list broadcast arrives, so the painted list still holds
+      // the previous org's slugs. Trusting currentOrg === slug there would treat
+      // those stale slugs as local and let Enter bypass the exact-slug resolver. The
+      // cache only ever holds each org's own list, so an org with no entry yet
+      // returns [] and every typed slug is verified — the safe direction.
+      function localProjectChoicesForOrg(org) {
+        const slug = String(org || "").trim().toLowerCase();
+        if (!slug) return [];
+        const cached = projectsByOrg[slug];
+        return Array.isArray(cached) ? cached.filter(Boolean) : [];
+      }
+
       // The project input on screen — the header switcher in triage chrome, else
       // the setup-screen field.
       function activeProjectInput() {
@@ -1268,13 +1314,95 @@ export function Page({
         }).catch(() => setProjectLoading(false));
       }
 
-      // Wire a text input as a project autocomplete: a filtered suggestion menu.
+      // Resolve one exact typed slug against Sentry (project.view) and cache the
+      // outcome. Called ONLY from an explicit commit (Enter), never on keystroke,
+      // so at most one lookup per committed slug is ever issued — no per-prefix
+      // queue of stale lookups. onDone runs after the cache is updated
+      // (found/missing/error) so the caller can commit the canonical slug or
+      // repaint an open menu. In-flight and settled lookups are not repeated; a
+      // prior "error" is cleared by the caller before an explicit retry.
+      function resolveProjectSlug(org, slug, onDone) {
+        const o = String(org || "").trim().toLowerCase();
+        const s = String(slug || "").trim();
+        if (!o || !s) return;
+        const key = projectResolveKey(o, s);
+        const cached = projectResolveCache[key];
+        // A settled entry (found/missing/error) fires immediately. A check that's
+        // already in flight can't fire yet, so queue this callback to be flushed
+        // when it settles — otherwise a second caller during "checking" is dropped.
+        if (cached) {
+          if (cached.status === "checking") {
+            if (onDone) (projectResolveWaiters[key] || (projectResolveWaiters[key] = [])).push(onDone);
+          } else if (onDone) {
+            onDone(cached);
+          }
+          return;
+        }
+        projectResolveCache[key] = { status: "checking", slug: "" };
+        // Record the settled entry, notify this caller, then flush anyone who
+        // queued while the request was in flight.
+        const settle = (entry) => {
+          projectResolveCache[key] = entry;
+          if (onDone) onDone(entry);
+          const waiters = projectResolveWaiters[key];
+          if (waiters) {
+            delete projectResolveWaiters[key];
+            for (const fn of waiters) { try { fn(entry); } catch (_) {} }
+          }
+        };
+        fetch("/api/resolve-project", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ org: o, slug: s })
+        })
+          .then((r) => r.json())
+          .then((d) => {
+            if (!d || d.ok === false) settle({ status: "error", slug: "" });
+            else if (d.found) settle({ status: "found", slug: String(d.slug || s) });
+            else settle({ status: "missing", slug: "" });
+          })
+          .catch(() => {
+            settle({ status: "error", slug: "" });
+          });
+      }
+
+      // Ensure a typed project is a real project in the org before any scan starts,
+      // so the "scans never run against an unverified project" invariant holds for
+      // pointer users too — the setup Scan button/form and the header Fetch button,
+      // not just Enter in the autocomplete. Resolves to the canonical slug. An empty
+      // project is an all-projects scan (always allowed); a locally-known project
+      // needs no lookup; anything else is verified via the shared resolver, reusing
+      // its cache and in-flight de-duplication.
+      function verifyProjectForScan(org, project) {
+        return new Promise((resolve) => {
+          const o = String(org || "").trim().toLowerCase();
+          const raw = String(project || "").trim();
+          if (!raw) { resolve({ ok: true, slug: "" }); return; }
+          if (!o) { resolve({ ok: true, slug: raw }); return; }
+          const p = raw.toLowerCase();
+          if (localProjectChoicesForOrg(o).some((s) => s.toLowerCase() === p)) {
+            resolve({ ok: true, slug: raw });
+            return;
+          }
+          const key = projectResolveKey(o, p);
+          const rc = projectResolveCache[key];
+          if (rc && rc.status === "found") { resolve({ ok: true, slug: rc.slug || raw }); return; }
+          if (rc && rc.status === "missing") { resolve({ ok: false, reason: "missing", slug: raw }); return; }
+          if (rc && rc.status === "error") delete projectResolveCache[key];
+          resolveProjectSlug(o, p, (res) => {
+            if (res && res.status === "found") resolve({ ok: true, slug: res.slug || raw });
+            else resolve({ ok: false, reason: (res && res.status) || "error", slug: raw });
+          });
+        });
+      }
+
+
       // (A <select> is unwieldy for orgs with many projects, and a <datalist>
       // does not repaint in this webview.) onCommit(value) runs when the user
       // picks a suggestion; an empty value means "all projects". The project list
       // is read live on each open, so newly-discovered projects appear without a
       // rebuild. Idempotent per input.
-      function attachProjectAutocomplete(input, onCommit) {
+      function attachProjectAutocomplete(input, onCommit, onVerifiedCommit) {
         if (!input || input.dataset.acWired) return;
         input.dataset.acWired = "1";
         // Ensure the input sits in a positioned wrapper with a menu container.
@@ -1297,6 +1425,22 @@ export function Page({
         // readers announce the popup and can follow the active option.
         if (!menu.id) menu.id = (input.id ? input.id : "project-ac") + "-listbox";
         input.setAttribute("aria-controls", menu.id);
+        // A visually-hidden live region announces exact-slug resolution state
+        // (checking / verified / not found / couldn't check) to screen readers,
+        // because the listbox itself is not a live region and its contents are
+        // replaced silently. Associated with the combobox via aria-describedby.
+        let statusEl = wrap.querySelector(".project-ac-status");
+        if (!statusEl) {
+          statusEl = document.createElement("div");
+          statusEl.className = "project-ac-status";
+          statusEl.setAttribute("aria-live", "polite");
+          statusEl.setAttribute("role", "status");
+          statusEl.style.cssText = "position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0;";
+          wrap.appendChild(statusEl);
+        }
+        if (!statusEl.id) statusEl.id = menu.id + "-status";
+        const describedBy = (input.getAttribute("aria-describedby") || "").split(/\s+/).filter(Boolean);
+        if (!describedBy.includes(statusEl.id)) { describedBy.push(statusEl.id); input.setAttribute("aria-describedby", describedBy.join(" ")); }
         const optionId = (i) => menu.id + "-opt-" + i;
         function syncActiveDescendant() {
           if (active >= 0 && items[active]) input.setAttribute("aria-activedescendant", optionId(active));
@@ -1307,7 +1451,8 @@ export function Page({
         const CAP = 50;
         function render() {
           const q = input.value.trim().toLowerCase();
-          const source = sentryProjectChoices();
+          const org = selectedOrgSlug();
+          const source = localProjectChoicesForOrg(org);
           let matches = q ? source.filter((s) => s.toLowerCase().includes(q)) : source.slice();
           const truncated = matches.length > CAP;
           matches = matches.slice(0, CAP);
@@ -1315,8 +1460,55 @@ export function Page({
           // Offer an explicit "all projects" reset only when the box is empty.
           if (!q) items.push({ value: "", label: "All projects", all: true });
           matches.forEach((s) => items.push({ value: s, label: s }));
+
+          // Exact-slug resolution: when the user has typed something with no
+          // exact local match, an explicit commit (Enter) asks Sentry directly
+          // whether that project exists (the paged list can't reach every project
+          // in a mega-org). This turns a misleading "No matching projects" into a
+          // selectable verified option — or an honest "not found" — without paging
+          // thousands of projects.
+          let resolveHint = "";
+          let statusText = "";
+          const hasExactLocal = source.some((s) => s.toLowerCase() === q);
+          if (q && org && !hasExactLocal) {
+            const key = projectResolveKey(org, q);
+            const rc = projectResolveCache[key];
+            // Resolution is triggered ONLY on an explicit commit (Enter / click),
+            // never as a side effect of typing. So render() just REFLECTS whatever
+            // the cache already holds: it neither schedules a lookup nor cancels
+            // one. That removes the per-prefix queue of stale lookups AND the
+            // completion-repaint retry loop the earlier keystroke-debounced version
+            // could spin during an outage.
+            if (!rc) {
+              resolveHint = "prompt"; // offer an explicit check on Enter
+            } else if (rc.status === "checking") {
+              resolveHint = "checking";
+              statusText = "Checking Sentry for \u201C" + q + "\u201D\u2026";
+            } else if (rc.status === "found") {
+              // Surface the canonical slug as a verified, selectable option at the
+              // top — deduped against any local match with the same slug.
+              const canon = rc.slug || q;
+              const dup = items.some((it) => it.value && it.value.toLowerCase() === canon.toLowerCase());
+              if (!dup) items.unshift({ value: canon, label: canon, verified: true });
+              statusText = "Verified project \u201C" + canon + "\u201D in " + org;
+            } else if (rc.status === "missing") {
+              resolveHint = "missing";
+              statusText = "No project \u201C" + q + "\u201D in " + org;
+            } else if (rc.status === "error") {
+              resolveHint = "error";
+              statusText = "Couldn't check Sentry for \u201C" + q + "\u201D";
+            }
+          }
+          if (statusEl && statusEl.textContent !== statusText) statusEl.textContent = statusText;
+
           if (!items.length) {
-            menu.innerHTML = '<div class="project-ac-empty">No matching projects</div>';
+            const empty =
+              resolveHint === "checking" ? "Checking Sentry…"
+              : resolveHint === "prompt" ? "Press Enter to check Sentry for \u201C" + escapeHtml(q) + "\u201D"
+              : resolveHint === "missing" ? "No project \u201C" + escapeHtml(q) + "\u201D in " + escapeHtml(org)
+              : resolveHint === "error" ? "Couldn't check Sentry — press Enter to retry"
+              : "No matching projects";
+            menu.innerHTML = '<div class="project-ac-empty">' + empty + '</div>';
             syncActiveDescendant();
             return;
           }
@@ -1326,31 +1518,93 @@ export function Page({
               .map((it, i) =>
                 '<div id="' + optionId(i) + '" class="project-ac-item' + (i === active ? ' active' : '') + '" role="option" aria-selected="' + (i === active) + '" data-idx="' + i + '">' +
                 (it.all ? '<span class="project-ac-all">' + escapeHtml(it.label) + '</span>' : escapeHtml(it.label)) +
+                (it.verified ? '<span class="project-ac-verified" title="Verified in Sentry">\u2713</span>' : '') +
                 '</div>')
               .join('') +
-            (truncated ? '<div class="project-ac-more">Keep typing to narrow…</div>' : '');
+            (resolveHint === "checking" ? '<div class="project-ac-more">Checking Sentry…</div>'
+              : resolveHint === "prompt" ? '<div class="project-ac-more">Press Enter to check Sentry for \u201C' + escapeHtml(q) + '\u201D</div>'
+              : resolveHint === "error" ? "<div class='project-ac-more'>Couldn't check Sentry — press Enter to retry</div>"
+              : resolveHint === "missing" ? '<div class="project-ac-more">No project \u201C' + escapeHtml(q) + '\u201D in ' + escapeHtml(org) + '</div>'
+              : truncated ? '<div class="project-ac-more">Keep typing to narrow…</div>' : '');
           syncActiveDescendant();
         }
         function open() { render(); menu.hidden = false; input.setAttribute("aria-expanded", "true"); }
         function close() { menu.hidden = true; active = -1; input.setAttribute("aria-expanded", "false"); input.removeAttribute("aria-activedescendant"); }
-        function commit(value) {
+        function commit(value, opts) {
           input.value = value;
           close();
-          if (onCommit) onCommit(value);
+          // Committing the exact-slug *verified* option (an off-list project Sentry
+          // confirmed) uses onVerifiedCommit when provided, so the setup field can
+          // start the scan on it even though its onCommit is null (plain local list
+          // picks there just fill the box). Every other commit uses onCommit. On the
+          // header both callbacks are the same fetchScoped, so behavior is unchanged.
+          const cb = (opts && opts.verified && onVerifiedCommit) ? onVerifiedCommit : onCommit;
+          if (cb) cb(value);
         }
         input.addEventListener("focus", open);
-        input.addEventListener("input", () => { active = -1; open(); });
+        input.addEventListener("input", () => {
+          active = -1;
+          // Editing the query clears a stale transient-failure marker for exactly
+          // this slug, so the menu drops back to the "Press Enter to check" prompt
+          // instead of showing a leftover error. The actual (re)check happens only
+          // when the user presses Enter — never as a side effect of typing.
+          const q = input.value.trim().toLowerCase();
+          const org = selectedOrgSlug();
+          if (q && org) {
+            const key = projectResolveKey(org, q);
+            const rc = projectResolveCache[key];
+            if (rc && rc.status === "error") delete projectResolveCache[key];
+          }
+          open();
+        });
         input.addEventListener("keydown", (e) => {
           if (menu.hidden) {
-            if (e.key === "ArrowDown") { e.preventDefault(); open(); }
-            return;
+            if (e.key === "ArrowDown") { e.preventDefault(); open(); return; }
+            // Enter still needs the exact-slug lookup below even when the menu is
+            // closed (e.g. after Escape); otherwise a typed slug bubbles to the scan
+            // handler and is sent to /api/set-org unverified. Short-circuit the rest.
+            if (e.key !== "Enter") return;
           }
           if (e.key === "ArrowDown") { e.preventDefault(); active = Math.min(active + 1, items.length - 1); render(); }
           else if (e.key === "ArrowUp") { e.preventDefault(); active = Math.max(active - 1, 0); render(); }
           else if (e.key === "Enter") {
-            // Only intercept Enter when a suggestion is highlighted; otherwise let
-            // it bubble to the header handler that applies a typed value.
-            if (active >= 0 && items[active]) { e.preventDefault(); e.stopPropagation(); commit(items[active].value); }
+            // A highlighted suggestion commits directly.
+            if (active >= 0 && items[active]) { e.preventDefault(); e.stopPropagation(); commit(items[active].value, { verified: !!items[active].verified }); return; }
+            // Otherwise, if the user typed a slug with no exact local match, Enter is
+            // the EXPLICIT commit that triggers exact-slug resolution — we never look
+            // up as they type. Verify it once, then commit the canonical slug on
+            // success, or surface an honest "not found" / "couldn't check" in place.
+            const q = input.value.trim().toLowerCase();
+            const org = selectedOrgSlug();
+            if (q && org && !localProjectChoicesForOrg(org).some((s) => s.toLowerCase() === q)) {
+              e.preventDefault(); e.stopPropagation();
+              const key = projectResolveKey(org, q);
+              const rc = projectResolveCache[key];
+              if (rc && rc.status === "found") { commit(rc.slug || q, { verified: true }); return; }
+              if (rc && rc.status === "checking") { open(); return; }
+              // Fresh check, or an explicit retry after a prior transient error.
+              if (rc && rc.status === "error") delete projectResolveCache[key];
+              resolveProjectSlug(org, q, (res) => {
+                // Ignore a stale completion if the box has since moved on — either
+                // the project text changed, or the org was edited while the lookup
+                // was pending (a result verified for the old org must not commit and
+                // let fetchScoped() scan a different, unverified org).
+                if (input.value.trim().toLowerCase() !== q || selectedOrgSlug() !== org) return;
+                // Render the resolved state before acting so the aria-live region
+                // publishes the completion (found/missing/error) to screen readers.
+                // commit() closes the menu without rendering, so a "found" result
+                // would otherwise leave the live region stuck at "Checking Sentry…";
+                // render() first sets it to "Verified project …", then commit closes.
+                render();
+                if (res && res.status === "found") commit(res.slug || q, { verified: true });
+              });
+              // open() (not render()) so the "Checking Sentry…" hint is visible even
+              // when this commit came from a closed menu (e.g. Enter after Escape).
+              open();
+              return;
+            }
+            // Exact local match or empty box: let Enter bubble to the header handler
+            // that applies the typed value.
           } else if (e.key === "Escape") { e.stopPropagation(); close(); }
         });
         // mousedown (not click) so the selection beats the input's blur.
@@ -1359,18 +1613,21 @@ export function Page({
           if (!el) return;
           e.preventDefault();
           const idx = Number(el.dataset.idx);
-          if (items[idx]) commit(items[idx].value);
+          if (items[idx]) commit(items[idx].value, { verified: !!items[idx].verified });
         });
         input.addEventListener("blur", () => { setTimeout(close, 120); });
       }
 
       // Ensure the setup-screen project field behaves as an autocomplete. The
       // suggestion list is read live on each open, so no rebuild is needed when
-      // the org's projects arrive. Picking here just fills the box; the Scan
-      // button reads #project-input on submit.
+      // the org's projects arrive. Picking a local suggestion just fills the box
+      // (the Scan button reads #project-input on submit) — but committing a
+      // Sentry-verified off-list slug starts the scan directly, so keyboard-only
+      // users aren't trapped re-verifying a project that never joins the local
+      // list. submitScan re-reads #project-input, so the committed slug is used.
       function renderSetupProjectField() {
         const el = document.getElementById("project-input");
-        if (el) attachProjectAutocomplete(el, null);
+        if (el) attachProjectAutocomplete(el, null, () => submitScan());
       }
 
       // Ensure the project control exists in the header and reflects the current
@@ -1428,7 +1685,13 @@ export function Page({
           label.appendChild(fetchBtn);
           scope.insertBefore(label, scope.firstChild);
         }
-        input.value = currentProject || "";
+        // Reflect the current project, but never while the user is editing this
+        // field: a streamed project page repaints the switcher (renderProjectSwitcher
+        // runs per SSE page), and clobbering the value mid-type would erase an
+        // in-progress slug — and with it the query captured for exact-slug
+        // resolution, so the first Enter's lookup would be silently dropped by the
+        // stale-completion guard. Only sync when the field isn't focused.
+        if (document.activeElement !== input) input.value = currentProject || "";
         attachProjectAutocomplete(input, () => fetchScoped());
 
         // Org control, injected before the project switcher so the header reads
@@ -1551,40 +1814,56 @@ export function Page({
         const org = orgInput ? orgInput.value.trim() : currentOrg;
         const project = projectInput ? projectInput.value.trim() : "";
         if (!org) { if (orgInput) orgInput.focus(); return; }
-        if (org !== currentOrg || project !== currentProject) resetPerCardState();
-        // Snapshot the last-scanned scope BEFORE the optimistic update so a failed
-        // rescan can roll back. Without this, a network/server failure leaves the
-        // switchers showing the new org/project while the still-rendered cards
-        // belong to the old scope — stale data under a selection we never scanned.
-        const prevOrg = currentOrg;
-        const prevProject = currentProject;
-        const subtitle = document.querySelector(".page-subtitle");
-        const prevSubtitle = subtitle ? subtitle.textContent : "";
-        currentOrg = org;
-        currentProject = project;
-        updateTriageDesc();
-        if (subtitle) subtitle.textContent = "Scanning " + (project || "all projects") + "...";
-        showScanOverlay("Scanning " + (project || "all projects") + "…");
-        fetch("/api/set-org", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ org, project })
-        }).then((res) => {
-          if (!res.ok) throw new Error("set-org " + res.status);
-        }).catch(() => {
-          // Loopback POST failed (server stopped/rejected, or a transport blip).
-          // Roll the optimistic selection back to the last-scanned scope so the
-          // switchers stay consistent with the cards still on screen, clear the
-          // overlay (which would otherwise linger until its safety timer), and
-          // tell the user so they can retry.
-          hideScanOverlay();
-          currentOrg = prevOrg;
-          currentProject = prevProject;
-          if (orgInput) orgInput.value = prevOrg;
-          if (projectInput) projectInput.value = prevProject;
+        // Gate: verify a typed project against Sentry before any optimistic update
+        // or scan, so the Fetch button and header-Enter can't scan an unverified
+        // slug. (The autocomplete's own Enter resolves before committing; this
+        // covers the pointer path and Enter on the raw org/project inputs.) An
+        // empty project scans all projects and needs no lookup.
+        verifyProjectForScan(org, project).then((v) => {
+          if (!v.ok) {
+            showToast(v.reason === "missing"
+              ? "No project \u201C" + project + "\u201D in " + org + " — check the slug."
+              : "Couldn't verify that project with Sentry — try again.");
+            if (projectInput) projectInput.focus();
+            return;
+          }
+          const proj = v.slug;
+          if (projectInput && proj !== project) projectInput.value = proj;
+          if (org !== currentOrg || proj !== currentProject) resetPerCardState();
+          // Snapshot the last-scanned scope BEFORE the optimistic update so a failed
+          // rescan can roll back. Without this, a network/server failure leaves the
+          // switchers showing the new org/project while the still-rendered cards
+          // belong to the old scope — stale data under a selection we never scanned.
+          const prevOrg = currentOrg;
+          const prevProject = currentProject;
+          const subtitle = document.querySelector(".page-subtitle");
+          const prevSubtitle = subtitle ? subtitle.textContent : "";
+          currentOrg = org;
+          currentProject = proj;
           updateTriageDesc();
-          if (subtitle) subtitle.textContent = prevSubtitle;
-          window.alert("Couldn't start the scan — the triage server may have stopped responding. Please try again.");
+          if (subtitle) subtitle.textContent = "Scanning " + (proj || "all projects") + "...";
+          showScanOverlay("Scanning " + (proj || "all projects") + "…");
+          fetch("/api/set-org", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ org, project: proj })
+          }).then((res) => {
+            if (!res.ok) throw new Error("set-org " + res.status);
+          }).catch(() => {
+            // Loopback POST failed (server stopped/rejected, or a transport blip).
+            // Roll the optimistic selection back to the last-scanned scope so the
+            // switchers stay consistent with the cards still on screen, clear the
+            // overlay (which would otherwise linger until its safety timer), and
+            // tell the user so they can retry.
+            hideScanOverlay();
+            currentOrg = prevOrg;
+            currentProject = prevProject;
+            if (orgInput) orgInput.value = prevOrg;
+            if (projectInput) projectInput.value = prevProject;
+            updateTriageDesc();
+            if (subtitle) subtitle.textContent = prevSubtitle;
+            window.alert("Couldn't start the scan — the triage server may have stopped responding. Please try again.");
+          });
         });
       }
 

--- a/extensions/sentry-triage/extension.mjs
+++ b/extensions/sentry-triage/extension.mjs
@@ -2,7 +2,7 @@ import { joinSession, createCanvas } from '@github/copilot-sdk/extension'
 import { execSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { startServer } from './server.mjs'
-import { scanIssues, listOrgs, listProjects } from './sentry.mjs'
+import { scanIssues, listOrgs, listProjects, findProject } from './sentry.mjs'
 import { checkConnections, checkConnectionsOnce } from './preflight.mjs'
 import { sanitizeForPrompt } from './escape.mjs'
 
@@ -1089,6 +1089,27 @@ async function discoverProjects(entry, org, { force = false } = {}) {
   }
 }
 
+// Resolve a single exact project slug the user typed, via the SDK's O(1)
+// project.view (findProject) — the counterpart to discoverProjects's paged,
+// budget-capped list. For a mega-org the list can't reach every project, so a
+// valid typed slug may never appear as a suggestion; this confirms it directly.
+// Returns { found, slug } where slug is the canonical spelling. Throws on a
+// genuine lookup failure so the server route can answer "could not check"
+// (ok:false) rather than a misleading "not found".
+async function resolveProject(entry, org, slug) {
+  if (entry.closed) return { found: false, slug: '' }
+  const orgSlug = String(org || entry.state.getOrg() || entry.state.getOrgDefault() || '').trim().toLowerCase()
+  const wanted = String(slug || '').trim()
+  if (!orgSlug || !wanted) return { found: false, slug: '' }
+  const conn = entry.state.getConnections()
+  // Not reachable means we CANNOT check right now — it is not evidence the project
+  // is missing. Throw so the server route answers "couldn't check" (ok:false)
+  // rather than a false "no such project".
+  if (!conn || !conn.sentry || !conn.sentry.reachable) throw new Error('sentry-unreachable')
+  const resolved = await findProject(orgSlug, wanted)
+  return { found: !!resolved, slug: resolved || '' }
+}
+
 async function runConnectionCheck(entry, isCurrent) {
   try {
     const connections = await checkConnections()
@@ -1865,6 +1886,7 @@ const session = await joinSession({
             onWorkSelected: (keys, modelByKey, assignCopilot) => onWorkSelected(entry, keys, modelByKey, assignCopilot),
             onRecheck: () => onRecheckConnections(entry),
             onListProjects: (org) => discoverProjects(entry, org, { force: true }),
+            onResolveProject: (org, slug) => resolveProject(entry, org, slug),
             onInvalidateEnrichment: () => {
               // Bump the scan generation so any enrichment turn still in flight
               // from the previous repo fails its isCurrent() guard and applies

--- a/extensions/sentry-triage/package.json
+++ b/extensions/sentry-triage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-triage",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "extension.mjs",
   "author": "Liz Tom",
   "license": "MIT",

--- a/extensions/sentry-triage/preflight.mjs
+++ b/extensions/sentry-triage/preflight.mjs
@@ -23,6 +23,7 @@ export function buildConnections({
   sentryReachable = false,
   sentryError = '',
   sentryTransient = false,
+  sentrySetup = '',
 } = {}) {
   return {
     checked: true,
@@ -34,6 +35,10 @@ export function buildConnections({
       // recovery for blips but show neutral guidance for unknown failures that
       // won't self-heal, instead of routing every failure to a "network" message.
       transient: sentryReachable ? false : Boolean(sentryTransient),
+      // Explicit setup reason (currently only 'package-missing') for gate variants
+      // that must NOT be inferred from the auth boolean. Keeps a missing-dependency
+      // install prompt from rendering beneath contradictory "sign in" guidance.
+      setup: sentryReachable ? '' : String(sentrySetup || ''),
       error: sentryReachable ? '' : String(sentryError || ''),
     },
   }
@@ -44,11 +49,16 @@ export function buildConnections({
 export function unknownConnections() {
   return {
     checked: false,
-    sentry: { configured: false, reachable: false, transient: false, error: '' },
+    sentry: { configured: false, reachable: false, transient: false, setup: '', error: '' },
   }
 }
 
 const msg = (err) => (err instanceof Error ? err.message : String(err))
+
+// The optional `sentry` package isn't installed for this extension (a published
+// awesome-copilot plugin ships source only). This is a one-time setup step, not a
+// network blip and not an auth failure, so it gets its own gate branch.
+const isPackageMissing = (err) => Boolean(err) && err.code === 'SENTRY_PACKAGE_MISSING'
 
 // Text used for classification: the message plus any CLI stderr, since a rejected
 // credential (HTTP 401/403) often surfaces its status in stderr rather than the
@@ -82,11 +92,14 @@ const isTransient = (err) =>
 // Turn the raw error into something a human can act on.
 const humanizeSentryError = (err) => {
   const t = msg(err)
+  if (isPackageMissing(err)) {
+    return 'The Sentry CLI isn’t installed for this canvas yet. Ask Copilot to “install the sentry-triage dependencies and reload extensions,” then run `npx sentry auth login` from the extension folder and re-open this canvas.'
+  }
   if (isNotAuthenticated(err)) {
-    return 'Sentry isn’t connected yet. Run `sentry auth login` in your terminal, then re-open this canvas.'
+    return 'Sentry isn’t connected yet. Run `npx sentry auth login` from the extension folder, then re-open this canvas.'
   }
   if (isAuthFailure(err)) {
-    return 'Sentry rejected your credential (expired or invalid). Run `sentry auth login` in your terminal, then re-open this canvas.'
+    return 'Sentry rejected your credential (expired or invalid). Run `npx sentry auth login` from the extension folder, then re-open this canvas.'
   }
   if (isTransient(err)) {
     return 'Couldn’t reach Sentry just now (network). It should recover on the next check.'
@@ -97,14 +110,16 @@ const humanizeSentryError = (err) => {
 // Classify a failed Sentry probe into the two decisions the caller cares about,
 // plus a human message. Pure and exported so the gate/retry branching can be
 // unit-tested without mocking the SDK:
-//   - configured: does a usable credential exist? Auth failures (no login OR a
-//     rejected/expired credential) clear it so the gate shows sign-in guidance;
+//   - configured: is the canvas actually set up to reach Sentry? Auth failures
+//     (no login OR a rejected/expired credential) clear it so the gate shows
+//     sign-in guidance, and a missing `sentry` package clears it too so the gate
+//     shows install guidance instead of a contradictory configured:true state;
 //     everything else keeps it so the gate shows connectivity guidance.
 //   - transient: worth retrying? Only network blips — never auth failures, even
 //     when their text happens to mention a network keyword.
 export function classifySentryError(err) {
   return {
-    configured: !isAuthFailure(err),
+    configured: !isAuthFailure(err) && !isPackageMissing(err),
     transient: isTransient(err),
     message: humanizeSentryError(err),
   }
@@ -135,6 +150,7 @@ const shape = (result) =>
     sentryConfigured: result.configured,
     sentryReachable: result.reachable,
     sentryTransient: result.transient,
+    sentrySetup: !result.reachable && isPackageMissing(result.error) ? 'package-missing' : '',
     sentryError: result.reachable ? '' : humanizeSentryError(result.error),
   })
 

--- a/extensions/sentry-triage/sentry.mjs
+++ b/extensions/sentry-triage/sentry.mjs
@@ -284,8 +284,13 @@ async function listProjectsPaged(org, onPage) {
 
 // Verify a specific project slug exists / is accessible. The org's project list
 // is capped, so a valid slug may not appear in it; project view resolves any
-// slug directly. Returns the canonical slug, or '' if it doesn't exist / isn't
-// accessible.
+// slug directly. Returns the canonical slug on success, or '' ONLY when the
+// project is confirmed not to exist. A transient/permission failure (network,
+// rate limit, 403, 5xx) is NOT a "not found": it re-throws so the caller can
+// report "couldn't check" instead of a false "no such project" that would train
+// the user to distrust a correct slug. Runs on the shared serial SDK chain
+// (projectView); interactive callers invoke it only on an explicit commit, so it
+// never floods that queue.
 export async function findProject(org, slug) {
   const wanted = String(slug || '').trim()
   if (!wanted) return ''
@@ -294,9 +299,21 @@ export async function findProject(org, slug) {
     const resolved = String(project?.slug || '').trim()
     return resolved || wanted
   } catch (err) {
-    if (err instanceof SentryError) return ''
+    if (err instanceof SentryError && isProjectNotFound(err)) return ''
     throw err
   }
+}
+
+// Decide whether a failed project.view means the project genuinely does not
+// exist (a confirmed 404 / "not found"), as opposed to a failure that merely
+// prevented the check. A definite non-404 HTTP status (403/429/5xx) is never a
+// not-found; only an explicit 404 or an unambiguous not-found message counts.
+function isProjectNotFound(err) {
+  const info = sentryErrorInfo(err)
+  if (info && info.code) return info.code === 404
+  const t = `${err?.message || ''}\n${err?.stderr || ''}`
+  if (/permission|forbidden|not authorized|unauthorized/i.test(t)) return false
+  return /\bnot found\b|no such project|does(?:n't| not) exist|unknown project/i.test(t)
 }
 
 // Per-query issue search. `limit` bounds a single call; the SDK auto-pages up to

--- a/extensions/sentry-triage/sentryClient.mjs
+++ b/extensions/sentry-triage/sentryClient.mjs
@@ -13,16 +13,71 @@
 // canvas's internal issue model lives in sentry.mjs so this file stays a thin,
 // swappable transport.
 
-import createSentrySDK, { SentryError } from 'sentry'
+// The heavyweight `sentry` CLI package is an OPTIONAL, lazily-loaded dependency.
+// awesome-copilot ships extension *source* only (no node_modules), so an installed
+// plugin may not have it. A top-level `import ... from 'sentry'` would throw
+// `Cannot find package 'sentry'` at module load and take the whole canvas down
+// before any UI renders. Instead we import it dynamically on first use and, when
+// it's absent, throw a clear SentryError (tagged SENTRY_PACKAGE_MISSING) that the
+// setup gate turns into actionable guidance — Copilot can install it for you.
+
+// A stand-in SentryError so callers can `import { SentryError }` at load time and
+// `instanceof`-check even when the package never loads. When the real package IS
+// present we replace this binding (a live ESM export) with the SDK's own
+// SentryError class, so existing `instanceof` + `.exitCode` checks keep matching
+// the errors the SDK actually throws.
+let SentryError = class SentryError extends Error {
+  constructor(message, opts = {}) {
+    super(message)
+    this.name = 'SentryError'
+    if (opts.code) this.code = opts.code
+  }
+}
 
 export { SentryError }
 
+// Fallback message when the optional `sentry` package can't be resolved. The
+// setup gate (preflight.mjs) rewrites this into fuller guidance; this is what
+// surfaces anywhere the raw error is shown.
+const PACKAGE_MISSING_MESSAGE =
+  'The Sentry CLI (the `sentry` npm package) is not installed for this extension. ' +
+  'Ask Copilot to set it up, or run `npm install` in the extension folder.'
+
 let sdk = null
+let sdkFactory = null
+
+// Import the optional `sentry` package exactly once. Throws a SentryError tagged
+// SENTRY_PACKAGE_MISSING when it can't be resolved, and swaps in the SDK's real
+// SentryError class (live ESM binding) when it can.
+async function loadFactory() {
+  if (sdkFactory) return sdkFactory
+  let mod
+  try {
+    mod = await import('sentry')
+  } catch (err) {
+    // Only translate "the `sentry` package itself isn't installed" into the setup
+    // gate. Node reports that as ERR_MODULE_NOT_FOUND naming the `sentry` package.
+    // Any OTHER failure — a missing TRANSITIVE dependency, or the package's own
+    // entrypoint throwing at import — is a real defect we must surface, not mask
+    // behind a misleading "reinstall sentry" message. Rethrow those unchanged.
+    const message = String((err && err.message) || '')
+    const sentryPackageMissing =
+      err && err.code === 'ERR_MODULE_NOT_FOUND' && /Cannot find (?:package|module) 'sentry'/.test(message)
+    if (!sentryPackageMissing) throw err
+    throw new SentryError(PACKAGE_MISSING_MESSAGE, { code: 'SENTRY_PACKAGE_MISSING' })
+  }
+  if (mod.SentryError) SentryError = mod.SentryError
+  sdkFactory = mod.default
+  return sdkFactory
+}
 
 // Lazily construct the SDK once. cwd affects the CLI's project-root / DSN
 // detection; we anchor it to the extension's cwd for determinism.
-function getSdk() {
-  if (!sdk) sdk = createSentrySDK({ cwd: process.cwd() })
+async function getSdk() {
+  if (!sdk) {
+    const create = await loadFactory()
+    sdk = create({ cwd: process.cwd() })
+  }
   return sdk
 }
 
@@ -77,13 +132,13 @@ function asArray(res) {
 // credential is present and valid; throws SentryError ("Not authenticated…")
 // otherwise. Used by preflight to gate the board.
 export async function whoami() {
-  return runSerial(() => getSdk().auth.whoami())
+  return runSerial(async () => (await getSdk()).auth.whoami())
 }
 
 // All organizations the stored credential can see. Raw org objects (each has a
 // `slug`).
 export async function orgList(limit = 100) {
-  return runSerial(async () => asArray(await getSdk().org.list({ limit })))
+  return runSerial(async () => asArray(await (await getSdk()).org.list({ limit })))
 }
 
 // Single-page project fetch within an org. Deliberately NOT wrapped in
@@ -96,13 +151,13 @@ export async function orgList(limit = 100) {
 // (see listProjects in sentry.mjs).
 export async function projectListRaw(org, limit = 100, cursor) {
   const orgProject = `${String(org || '').replace(/\/+$/, '')}/`
-  return asArray(await getSdk().project.list({ orgProject, limit, ...(cursor ? { cursor } : {}) }))
+  return asArray(await (await getSdk()).project.list({ orgProject, limit, ...(cursor ? { cursor } : {}) }))
 }
 
 // Verify a specific project exists / is accessible. Returns the raw project
 // object on success; throws SentryError when the slug is unknown or forbidden.
 export async function projectView(org, slug) {
-  return runSerial(() => getSdk().project.view({ orgProject: `${org}/${slug}` }))
+  return runSerial(async () => (await getSdk()).project.view({ orgProject: `${org}/${slug}` }))
 }
 
 // Search issues. `orgProject` is "org/project" (or the trailing-slash "org/" form
@@ -113,7 +168,7 @@ export async function projectView(org, slug) {
 export async function issueList({ orgProject, query, sort = 'date', limit = 100, period } = {}) {
   return runSerial(async () =>
     asArray(
-      await getSdk().issue.list({
+      await (await getSdk()).issue.list({
         ...(orgProject ? { orgProject } : {}),
         ...(query ? { query } : {}),
         ...(period ? { period } : {}),

--- a/extensions/sentry-triage/sentryClient.mjs
+++ b/extensions/sentry-triage/sentryClient.mjs
@@ -154,8 +154,18 @@ export async function projectListRaw(org, limit = 100, cursor) {
   return asArray(await (await getSdk()).project.list({ orgProject, limit, ...(cursor ? { cursor } : {}) }))
 }
 
-// Verify a specific project exists / is accessible. Returns the raw project
-// object on success; throws SentryError when the slug is unknown or forbidden.
+// Verify a specific project exists / is accessible via the SDK's O(1)
+// `project.view`. Returns the raw project object on success; throws SentryError
+// when the slug is unknown or forbidden.
+//
+// This runs on the SAME shared `runSerial` chain as every other SDK call — there
+// is deliberately NO separate "fast lane". `sentry@0.42.2` keeps its per-command
+// and pagination state in MODULE-GLOBAL SDK state (see the runSerial note above),
+// so a second SDK instance would NOT be a concurrency-isolation boundary: it would
+// still race the paged list / scan and corrupt that shared state. `project.view`
+// is a single, cursor-free call, so funneling it through the one FIFO chain is
+// both correct and cheap. Interactive callers trigger it only on an explicit
+// commit (not per keystroke), so a real user never floods this queue.
 export async function projectView(org, slug) {
   return runSerial(async () => (await getSdk()).project.view({ orgProject: `${org}/${slug}` }))
 }

--- a/extensions/sentry-triage/server.mjs
+++ b/extensions/sentry-triage/server.mjs
@@ -77,7 +77,7 @@ function hasValidToken(req, token) {
   return value === token
 }
 
-export function startServer({ port = 0, onRefresh, onAction, onWorkSelected, onRecheck, onListProjects, onInvalidateEnrichment, defaults } = {}) {
+export function startServer({ port = 0, onRefresh, onAction, onWorkSelected, onRecheck, onListProjects, onResolveProject, onInvalidateEnrichment, defaults } = {}) {
   // Per-instance state + SSE clients — never shared across canvas instances.
   const state = createState()
   state.applyRepoDefaults(defaults)
@@ -238,6 +238,40 @@ export function startServer({ port = 0, onRefresh, onAction, onWorkSelected, onR
           .catch((err) => console.error('[sentry-triage] list-projects failed:', err instanceof Error ? err.message : err))
         res.writeHead(200, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({ ok: true }))
+      })
+      return
+    }
+
+    // Resolve a single exact "org/slug" via the SDK's project.view — an O(1)
+    // lookup that confirms a project the paged list may never reach. For a
+    // mega-org (e.g. "github" has thousands of projects) list discovery is
+    // budget-capped, so a valid slug the user types can be absent from the
+    // autocomplete; this endpoint tells the client "yes, that project exists"
+    // (with its canonical slug) without paging. Distinguishes three outcomes so
+    // the UI never shows a false negative: found, genuinely-missing, and
+    // could-not-check (network/permission) — the latter returns ok:false.
+    if (req.method === 'POST' && req.url === '/api/resolve-project') {
+      readBody(req, res).then(async (body) => {
+        if (body === null) return
+        const { org, slug } = parseJson(body)
+        const wantedOrg = typeof org === 'string' ? org : ''
+        const wantedSlug = typeof slug === 'string' ? slug.trim() : ''
+        let result = { ok: true, found: false, slug: '' }
+        try {
+          if (onResolveProject && wantedSlug) {
+            const r = await onResolveProject(wantedOrg, wantedSlug)
+            const resolved = r && typeof r.slug === 'string' ? r.slug : ''
+            result = { ok: true, found: !!(r && r.found && resolved), slug: resolved }
+          }
+        } catch (err) {
+          // A lookup failure (transient network / rate limit / permission) must
+          // NOT be reported as "project doesn't exist" — that would train the
+          // user to distrust a correct slug. Signal indeterminate with ok:false.
+          console.error('[sentry-triage] resolve-project failed:', err instanceof Error ? err.message : err)
+          result = { ok: false, found: false, slug: '' }
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify(result))
       })
       return
     }

--- a/extensions/sentry-triage/styles.mjs
+++ b/extensions/sentry-triage/styles.mjs
@@ -236,6 +236,15 @@ export function styles() {
     .project-ac-item .project-ac-all { color: var(--text-color-muted, #8b949e); font-style: italic; }
     .project-ac-item.active .project-ac-all,
     .project-ac-item:hover .project-ac-all { color: var(--color-fg-on-emphasis, #ffffff); }
+    /* Checkmark on a slug confirmed to exist via a live project.view lookup
+       (a project the paged autocomplete list never reached). */
+    .project-ac-item .project-ac-verified {
+      margin-left: 6px;
+      color: var(--color-success-fg, #3fb950);
+      font-weight: 600;
+    }
+    .project-ac-item.active .project-ac-verified,
+    .project-ac-item:hover .project-ac-verified { color: var(--color-fg-on-emphasis, #ffffff); }
     .project-ac-empty,
     .project-ac-more {
       padding: 6px 8px;

--- a/plugins/sentry-triage/plugin.json
+++ b/plugins/sentry-triage/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "sentry-triage",
   "description": "Scan live Sentry issues in a Copilot canvas, group them by urgency, and hand issues off for tracking or a fix PR.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Liz Tom",
     "url": "https://github.com/liztom"


### PR DESCRIPTION
> **Stacked on #2810.** This PR is built on top of `fix-sentry-triage-sdk-bundling` (#2810). Because #2810 is a fork→upstream PR, GitHub can't natively base this on that branch, so it targets `main` and temporarily includes #2810's single commit (`Fix sentry-triage canvas crash when the sentry package isn't bundled`). That shared commit will drop out of this diff automatically once #2810 merges, leaving only the resolver commit. Please merge #2810 first.

## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [x] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `main` branch for this pull request.

---

## Description

Adds an **exact-slug Sentry project resolver** to the existing `sentry-triage` canvas extension. The project picker previously only offered projects from the page the canvas had already loaded, so teams with many projects (or a project outside the first page) couldn't target one by slug.

This adds a **verify-on-commit** flow: when a user types a slug that isn't a local match, pressing Enter checks it against Sentry via a CSRF-gated `/api/resolve-project` endpoint and only commits the canonical slug once verified — a scan never runs against an unverified or wrong-org project.

Highlights:
- Enter is the explicit commit that triggers resolution (never an as-typed lookup).
- Project choices are read from an org-keyed cache, so a slug from a previously selected org can't be treated as local after a free-text org switch; the stale-completion guard also compares the org captured for the request.
- A visually-hidden `aria-live` region announces checking / verified / not-found / couldn't-check state, and the resolved state is rendered before commit so screen readers hear the outcome.
- Resolution runs on the shared serial request chain and is hardened against Sentry outages and queue contention.
- Bumps `sentry-triage` to `1.1.0`.

---

## Type of Contribution

- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.

---

## Additional Notes

By submitting this pull request, I confirm that my contribution abides by the Code of Conduct and will be licensed under the MIT License.
