### PR TITLE
docs: fix nine dead contributor links in README

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -238,7 +238,7 @@
       "login": "danielmeppiel",
       "name": "Daniel Meppiel",
       "avatar_url": "https://avatars.githubusercontent.com/u/51440732?v=4",
-      "profile": "https://www.devprodlogs.com/",
+      "profile": "https://theainativemind.com/",
       "contributions": [
         "prompts"
       ]
@@ -364,7 +364,7 @@
       "login": "OrenMe",
       "name": "Oren Me",
       "avatar_url": "https://avatars.githubusercontent.com/u/5461862?v=4",
-      "profile": "https://www.promptboost.dev/",
+      "profile": "https://github.com/OrenMe",
       "contributions": [
         "agents",
         "instructions"
@@ -576,7 +576,7 @@
       "login": "brunoborges",
       "name": "Bruno Borges",
       "avatar_url": "https://avatars.githubusercontent.com/u/129743?v=4",
-      "profile": "http://brunoborges.io/",
+      "profile": "https://github.com/brunoborges",
       "contributions": [
         "plugins",
         "instructions"
@@ -791,7 +791,7 @@
       "login": "ricksmit3000",
       "name": "Rick Smit",
       "avatar_url": "https://avatars.githubusercontent.com/u/7207783?v=4",
-      "profile": "https://ricksm.it/",
+      "profile": "https://github.com/ricksmit3000",
       "contributions": [
         "agents"
       ]
@@ -1204,7 +1204,7 @@
       "login": "warengonzaga",
       "name": "Waren Gonzaga",
       "avatar_url": "https://avatars.githubusercontent.com/u/15052701?v=4",
-      "profile": "https://bio.warengonzaga.com/",
+      "profile": "https://waren.build",
       "contributions": [
         "agents"
       ]
@@ -1575,7 +1575,7 @@
       "login": "mehmetalierol",
       "name": "Mehmet Ali EROL",
       "avatar_url": "https://avatars.githubusercontent.com/u/16721723?v=4",
-      "profile": "http://www.mehmetalierol.com/",
+      "profile": "https://github.com/mehmetalierol",
       "contributions": [
         "agents"
       ]
@@ -1692,7 +1692,7 @@
       "login": "josephgonzales01",
       "name": "Joseph Gonzales",
       "avatar_url": "https://avatars.githubusercontent.com/u/15100839?v=4",
-      "profile": "http://www.sugbo4j.co.nz/",
+      "profile": "https://github.com/josephgonzales01",
       "contributions": [
         "instructions",
         "prompts"
@@ -1729,7 +1729,7 @@
       "login": "joe-watkins",
       "name": "Joe Watkins",
       "avatar_url": "https://avatars.githubusercontent.com/u/3695795?v=4",
-      "profile": "http://joe-watkins.io/",
+      "profile": "https://github.com/joe-watkins",
       "contributions": [
         "instructions"
       ]
@@ -3519,7 +3519,7 @@
       "login": "samipak458",
       "name": "MUHAMMAD SAMIULLAH",
       "avatar_url": "https://avatars.githubusercontent.com/u/52650290?v=4",
-      "profile": "http://msamiullah.tech/",
+      "profile": "https://msamiullah.netlify.app/",
       "contributions": [
         "ideas"
       ]

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Thanks goes to these wonderful people ([emoji key](./CONTRIBUTING.md#contributor
       <td align="center" valign="top" width="14.28%"><a href="https://delatorre.dev/"><img src="https://avatars.githubusercontent.com/u/38289677?v=4" width="100px;" alt=""/><br /><sub><b>Emerson Delatorre</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/burkeholland"><img src="https://avatars.githubusercontent.com/u/686963?v=4" width="100px;" alt=""/><br /><sub><b>Burke Holland</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://yaooqinn.github.io/"><img src="https://avatars.githubusercontent.com/u/8326978?v=4" width="100px;" alt=""/><br /><sub><b>Kent Yao</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://www.devprodlogs.com/"><img src="https://avatars.githubusercontent.com/u/51440732?v=4" width="100px;" alt=""/><br /><sub><b>Daniel Meppiel</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://theainativemind.com/"><img src="https://avatars.githubusercontent.com/u/51440732?v=4" width="100px;" alt=""/><br /><sub><b>Daniel Meppiel</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/yeelam-gordon"><img src="https://avatars.githubusercontent.com/u/73506701?v=4" width="100px;" alt=""/><br /><sub><b>Gordon Lam</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://www.madskristensen.net/"><img src="https://avatars.githubusercontent.com/u/1258877?v=4" width="100px;" alt=""/><br /><sub><b>Mads Kristensen</b></sub></a></td>
     </tr>
@@ -102,7 +102,7 @@ Thanks goes to these wonderful people ([emoji key](./CONTRIBUTING.md#contributor
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/krushideep"><img src="https://avatars.githubusercontent.com/u/174652083?v=4" width="100px;" alt=""/><br /><sub><b>krushideep</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mihsoft"><img src="https://avatars.githubusercontent.com/u/53946345?v=4" width="100px;" alt=""/><br /><sub><b>devopsfan</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://tgrall.github.io/"><img src="https://avatars.githubusercontent.com/u/541250?v=4" width="100px;" alt=""/><br /><sub><b>Tugdual Grall</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://www.promptboost.dev/"><img src="https://avatars.githubusercontent.com/u/5461862?v=4" width="100px;" alt=""/><br /><sub><b>Oren Me</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/OrenMe"><img src="https://avatars.githubusercontent.com/u/5461862?v=4" width="100px;" alt=""/><br /><sub><b>Oren Me</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mjrousos"><img src="https://avatars.githubusercontent.com/u/10077254?v=4" width="100px;" alt=""/><br /><sub><b>Mike Rousos</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://devkimchi.com/"><img src="https://avatars.githubusercontent.com/u/1538528?v=4" width="100px;" alt=""/><br /><sub><b>Justin Yoo</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/guiopen"><img src="https://avatars.githubusercontent.com/u/94094527?v=4" width="100px;" alt=""/><br /><sub><b>Guilherme do Amaral Alves </b></sub></a></td>
@@ -130,7 +130,7 @@ Thanks goes to these wonderful people ([emoji key](./CONTRIBUTING.md#contributor
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/anschnapp"><img src="https://avatars.githubusercontent.com/u/17565996?v=4" width="100px;" alt=""/><br /><sub><b>anschnapp</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/hizahizi-hizumi"><img src="https://avatars.githubusercontent.com/u/163728895?v=4" width="100px;" alt=""/><br /><sub><b>hizahizi-hizumi</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://jianminhuang.cc/"><img src="https://avatars.githubusercontent.com/u/6296280?v=4" width="100px;" alt=""/><br /><sub><b>黃健旻 Vincent Huang</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://brunoborges.io/"><img src="https://avatars.githubusercontent.com/u/129743?v=4" width="100px;" alt=""/><br /><sub><b>Bruno Borges</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/brunoborges"><img src="https://avatars.githubusercontent.com/u/129743?v=4" width="100px;" alt=""/><br /><sub><b>Bruno Borges</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://www.movinglive.ca/"><img src="https://avatars.githubusercontent.com/u/14792628?v=4" width="100px;" alt=""/><br /><sub><b>Steve Magne</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://shaneneuville.com/"><img src="https://avatars.githubusercontent.com/u/5375137?v=4" width="100px;" alt=""/><br /><sub><b>Shane Neuville</b></sub></a></td>
     </tr>
@@ -159,7 +159,7 @@ Thanks goes to these wonderful people ([emoji key](./CONTRIBUTING.md#contributor
       <td align="center" valign="top" width="14.28%"><a href="https://soderlind.no/"><img src="https://avatars.githubusercontent.com/u/1649452?v=4" width="100px;" alt=""/><br /><sub><b>Per Søderlind</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://dotneteers.net/"><img src="https://avatars.githubusercontent.com/u/28162552?v=4" width="100px;" alt=""/><br /><sub><b>Peter Smulovics</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/madvimer"><img src="https://avatars.githubusercontent.com/u/3188898?v=4" width="100px;" alt=""/><br /><sub><b>Ravish Rathod</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://ricksm.it/"><img src="https://avatars.githubusercontent.com/u/7207783?v=4" width="100px;" alt=""/><br /><sub><b>Rick Smit</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ricksmit3000"><img src="https://avatars.githubusercontent.com/u/7207783?v=4" width="100px;" alt=""/><br /><sub><b>Rick Smit</b></sub></a></td>
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/pertrai1"><img src="https://avatars.githubusercontent.com/u/442374?v=4" width="100px;" alt=""/><br /><sub><b>Rob Simpson</b></sub></a></td>
@@ -218,7 +218,7 @@ Thanks goes to these wonderful people ([emoji key](./CONTRIBUTING.md#contributor
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/yukiomoto"><img src="https://avatars.githubusercontent.com/u/38450410?v=4" width="100px;" alt=""/><br /><sub><b>Yuki Omoto</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/wschultz-boxboat"><img src="https://avatars.githubusercontent.com/u/110492948?v=4" width="100px;" alt=""/><br /><sub><b>Will Schultz</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://bio.warengonzaga.com/"><img src="https://avatars.githubusercontent.com/u/15052701?v=4" width="100px;" alt=""/><br /><sub><b>Waren Gonzaga</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://waren.build"><img src="https://avatars.githubusercontent.com/u/15052701?v=4" width="100px;" alt=""/><br /><sub><b>Waren Gonzaga</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://linktr.ee/vincentkoc"><img src="https://avatars.githubusercontent.com/u/25068?v=4" width="100px;" alt=""/><br /><sub><b>Vincent Koc</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Vaporjawn"><img src="https://avatars.githubusercontent.com/u/15694665?v=4" width="100px;" alt=""/><br /><sub><b>Victor Williams</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://vesharma.dev/"><img src="https://avatars.githubusercontent.com/u/62218708?v=4" width="100px;" alt=""/><br /><sub><b>Ve Sharma</b></sub></a></td>
@@ -271,7 +271,7 @@ Thanks goes to these wonderful people ([emoji key](./CONTRIBUTING.md#contributor
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Mike-Hanna"><img src="https://avatars.githubusercontent.com/u/50142889?v=4" width="100px;" alt=""/><br /><sub><b>Michael</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://www.mehmetalierol.com/"><img src="https://avatars.githubusercontent.com/u/16721723?v=4" width="100px;" alt=""/><br /><sub><b>Mehmet Ali EROL</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/mehmetalierol"><img src="https://avatars.githubusercontent.com/u/16721723?v=4" width="100px;" alt=""/><br /><sub><b>Mehmet Ali EROL</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://maxprilutskiy.com/"><img src="https://avatars.githubusercontent.com/u/5614659?v=4" width="100px;" alt=""/><br /><sub><b>Max Prilutskiy</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mbianchidev"><img src="https://avatars.githubusercontent.com/u/37507190?v=4" width="100px;" alt=""/><br /><sub><b>Matteo Bianchi</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://marknoble.com/"><img src="https://avatars.githubusercontent.com/u/3819700?v=4" width="100px;" alt=""/><br /><sub><b>Mark Noble</b></sub></a></td>
@@ -288,11 +288,11 @@ Thanks goes to these wonderful people ([emoji key](./CONTRIBUTING.md#contributor
       <td align="center" valign="top" width="14.28%"><a href="https://digio.es/"><img src="https://avatars.githubusercontent.com/u/173672918?v=4" width="100px;" alt=""/><br /><sub><b>José Antonio Garrido</b></sub></a></td>
     </tr>
     <tr>
-      <td align="center" valign="top" width="14.28%"><a href="http://www.sugbo4j.co.nz/"><img src="https://avatars.githubusercontent.com/u/15100839?v=4" width="100px;" alt=""/><br /><sub><b>Joseph Gonzales</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/josephgonzales01"><img src="https://avatars.githubusercontent.com/u/15100839?v=4" width="100px;" alt=""/><br /><sub><b>Joseph Gonzales</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/yortch"><img src="https://avatars.githubusercontent.com/u/4576246?v=4" width="100px;" alt=""/><br /><sub><b>Jorge Balderas</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://johnpapa.net/"><img src="https://avatars.githubusercontent.com/u/1202528?v=4" width="100px;" alt=""/><br /><sub><b>John Papa</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://www.johnlokerse.dev/"><img src="https://avatars.githubusercontent.com/u/3514513?v=4" width="100px;" alt=""/><br /><sub><b>John</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://joe-watkins.io/"><img src="https://avatars.githubusercontent.com/u/3695795?v=4" width="100px;" alt=""/><br /><sub><b>Joe Watkins</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/joe-watkins"><img src="https://avatars.githubusercontent.com/u/3695795?v=4" width="100px;" alt=""/><br /><sub><b>Joe Watkins</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://jan-v.nl/"><img src="https://avatars.githubusercontent.com/u/462356?v=4" width="100px;" alt=""/><br /><sub><b>Jan de Vries</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/nohwnd"><img src="https://avatars.githubusercontent.com/u/5735905?v=4" width="100px;" alt=""/><br /><sub><b>Jakub Jareš</b></sub></a></td>
     </tr>
@@ -535,7 +535,7 @@ Thanks goes to these wonderful people ([emoji key](./CONTRIBUTING.md#contributor
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/dawright22"><img src="https://avatars.githubusercontent.com/u/53329137?v=4" width="100px;" alt=""/><br /><sub><b>dawright22</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/alfersugo"><img src="https://avatars.githubusercontent.com/u/49598311?v=4" width="100px;" alt=""/><br /><sub><b>Alejandro Fernando Suarez Gomez</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://xquik.com/"><img src="https://avatars.githubusercontent.com/u/8755484?v=4" width="100px;" alt=""/><br /><sub><b>Burak Bayır</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://msamiullah.tech/"><img src="https://avatars.githubusercontent.com/u/52650290?v=4" width="100px;" alt=""/><br /><sub><b>MUHAMMAD SAMIULLAH</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://msamiullah.netlify.app/"><img src="https://avatars.githubusercontent.com/u/52650290?v=4" width="100px;" alt=""/><br /><sub><b>MUHAMMAD SAMIULLAH</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://metulev.com/"><img src="https://avatars.githubusercontent.com/u/711864?v=4" width="100px;" alt=""/><br /><sub><b>Nikola Metulev</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://www.colorado.edu/lab/krg"><img src="https://avatars.githubusercontent.com/u/4161712?v=4" width="100px;" alt=""/><br /><sub><b>Joseph Kasprzyk</b></sub></a></td>
     </tr>

--- a/website/src/pages/contributors.astro
+++ b/website/src/pages/contributors.astro
@@ -38,7 +38,7 @@ import PageHeader from '../components/PageHeader.astro';
       <td align="center" valign="top" width="14.28%"><a href="https://delatorre.dev/"><img src="https://avatars.githubusercontent.com/u/38289677?v=4" width="100px;" alt=""/><br /><sub><b>Emerson Delatorre</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/burkeholland"><img src="https://avatars.githubusercontent.com/u/686963?v=4" width="100px;" alt=""/><br /><sub><b>Burke Holland</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://yaooqinn.github.io/"><img src="https://avatars.githubusercontent.com/u/8326978?v=4" width="100px;" alt=""/><br /><sub><b>Kent Yao</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://www.devprodlogs.com/"><img src="https://avatars.githubusercontent.com/u/51440732?v=4" width="100px;" alt=""/><br /><sub><b>Daniel Meppiel</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://theainativemind.com/"><img src="https://avatars.githubusercontent.com/u/51440732?v=4" width="100px;" alt=""/><br /><sub><b>Daniel Meppiel</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/yeelam-gordon"><img src="https://avatars.githubusercontent.com/u/73506701?v=4" width="100px;" alt=""/><br /><sub><b>Gordon Lam</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://www.madskristensen.net/"><img src="https://avatars.githubusercontent.com/u/1258877?v=4" width="100px;" alt=""/><br /><sub><b>Mads Kristensen</b></sub></a></td>
     </tr>
@@ -55,7 +55,7 @@ import PageHeader from '../components/PageHeader.astro';
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/krushideep"><img src="https://avatars.githubusercontent.com/u/174652083?v=4" width="100px;" alt=""/><br /><sub><b>krushideep</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mihsoft"><img src="https://avatars.githubusercontent.com/u/53946345?v=4" width="100px;" alt=""/><br /><sub><b>devopsfan</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://tgrall.github.io/"><img src="https://avatars.githubusercontent.com/u/541250?v=4" width="100px;" alt=""/><br /><sub><b>Tugdual Grall</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://www.promptboost.dev/"><img src="https://avatars.githubusercontent.com/u/5461862?v=4" width="100px;" alt=""/><br /><sub><b>Oren Me</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/OrenMe"><img src="https://avatars.githubusercontent.com/u/5461862?v=4" width="100px;" alt=""/><br /><sub><b>Oren Me</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mjrousos"><img src="https://avatars.githubusercontent.com/u/10077254?v=4" width="100px;" alt=""/><br /><sub><b>Mike Rousos</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://devkimchi.com/"><img src="https://avatars.githubusercontent.com/u/1538528?v=4" width="100px;" alt=""/><br /><sub><b>Justin Yoo</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/guiopen"><img src="https://avatars.githubusercontent.com/u/94094527?v=4" width="100px;" alt=""/><br /><sub><b>Guilherme do Amaral Alves </b></sub></a></td>
@@ -83,7 +83,7 @@ import PageHeader from '../components/PageHeader.astro';
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/anschnapp"><img src="https://avatars.githubusercontent.com/u/17565996?v=4" width="100px;" alt=""/><br /><sub><b>anschnapp</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/hizahizi-hizumi"><img src="https://avatars.githubusercontent.com/u/163728895?v=4" width="100px;" alt=""/><br /><sub><b>hizahizi-hizumi</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://jianminhuang.cc/"><img src="https://avatars.githubusercontent.com/u/6296280?v=4" width="100px;" alt=""/><br /><sub><b>黃健旻 Vincent Huang</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://brunoborges.io/"><img src="https://avatars.githubusercontent.com/u/129743?v=4" width="100px;" alt=""/><br /><sub><b>Bruno Borges</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/brunoborges"><img src="https://avatars.githubusercontent.com/u/129743?v=4" width="100px;" alt=""/><br /><sub><b>Bruno Borges</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://www.movinglive.ca/"><img src="https://avatars.githubusercontent.com/u/14792628?v=4" width="100px;" alt=""/><br /><sub><b>Steve Magne</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://shaneneuville.com/"><img src="https://avatars.githubusercontent.com/u/5375137?v=4" width="100px;" alt=""/><br /><sub><b>Shane Neuville</b></sub></a></td>
     </tr>
@@ -112,7 +112,7 @@ import PageHeader from '../components/PageHeader.astro';
       <td align="center" valign="top" width="14.28%"><a href="https://soderlind.no/"><img src="https://avatars.githubusercontent.com/u/1649452?v=4" width="100px;" alt=""/><br /><sub><b>Per Søderlind</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://dotneteers.net/"><img src="https://avatars.githubusercontent.com/u/28162552?v=4" width="100px;" alt=""/><br /><sub><b>Peter Smulovics</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/madvimer"><img src="https://avatars.githubusercontent.com/u/3188898?v=4" width="100px;" alt=""/><br /><sub><b>Ravish Rathod</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://ricksm.it/"><img src="https://avatars.githubusercontent.com/u/7207783?v=4" width="100px;" alt=""/><br /><sub><b>Rick Smit</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ricksmit3000"><img src="https://avatars.githubusercontent.com/u/7207783?v=4" width="100px;" alt=""/><br /><sub><b>Rick Smit</b></sub></a></td>
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/pertrai1"><img src="https://avatars.githubusercontent.com/u/442374?v=4" width="100px;" alt=""/><br /><sub><b>Rob Simpson</b></sub></a></td>
@@ -171,7 +171,7 @@ import PageHeader from '../components/PageHeader.astro';
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/yukiomoto"><img src="https://avatars.githubusercontent.com/u/38450410?v=4" width="100px;" alt=""/><br /><sub><b>Yuki Omoto</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/wschultz-boxboat"><img src="https://avatars.githubusercontent.com/u/110492948?v=4" width="100px;" alt=""/><br /><sub><b>Will Schultz</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://bio.warengonzaga.com/"><img src="https://avatars.githubusercontent.com/u/15052701?v=4" width="100px;" alt=""/><br /><sub><b>Waren Gonzaga</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://waren.build"><img src="https://avatars.githubusercontent.com/u/15052701?v=4" width="100px;" alt=""/><br /><sub><b>Waren Gonzaga</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://linktr.ee/vincentkoc"><img src="https://avatars.githubusercontent.com/u/25068?v=4" width="100px;" alt=""/><br /><sub><b>Vincent Koc</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Vaporjawn"><img src="https://avatars.githubusercontent.com/u/15694665?v=4" width="100px;" alt=""/><br /><sub><b>Victor Williams</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://vesharma.dev/"><img src="https://avatars.githubusercontent.com/u/62218708?v=4" width="100px;" alt=""/><br /><sub><b>Ve Sharma</b></sub></a></td>
@@ -224,7 +224,7 @@ import PageHeader from '../components/PageHeader.astro';
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Mike-Hanna"><img src="https://avatars.githubusercontent.com/u/50142889?v=4" width="100px;" alt=""/><br /><sub><b>Michael</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://www.mehmetalierol.com/"><img src="https://avatars.githubusercontent.com/u/16721723?v=4" width="100px;" alt=""/><br /><sub><b>Mehmet Ali EROL</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/mehmetalierol"><img src="https://avatars.githubusercontent.com/u/16721723?v=4" width="100px;" alt=""/><br /><sub><b>Mehmet Ali EROL</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://maxprilutskiy.com/"><img src="https://avatars.githubusercontent.com/u/5614659?v=4" width="100px;" alt=""/><br /><sub><b>Max Prilutskiy</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mbianchidev"><img src="https://avatars.githubusercontent.com/u/37507190?v=4" width="100px;" alt=""/><br /><sub><b>Matteo Bianchi</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://marknoble.com/"><img src="https://avatars.githubusercontent.com/u/3819700?v=4" width="100px;" alt=""/><br /><sub><b>Mark Noble</b></sub></a></td>
@@ -241,11 +241,11 @@ import PageHeader from '../components/PageHeader.astro';
       <td align="center" valign="top" width="14.28%"><a href="https://digio.es/"><img src="https://avatars.githubusercontent.com/u/173672918?v=4" width="100px;" alt=""/><br /><sub><b>José Antonio Garrido</b></sub></a></td>
     </tr>
     <tr>
-      <td align="center" valign="top" width="14.28%"><a href="http://www.sugbo4j.co.nz/"><img src="https://avatars.githubusercontent.com/u/15100839?v=4" width="100px;" alt=""/><br /><sub><b>Joseph Gonzales</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/josephgonzales01"><img src="https://avatars.githubusercontent.com/u/15100839?v=4" width="100px;" alt=""/><br /><sub><b>Joseph Gonzales</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/yortch"><img src="https://avatars.githubusercontent.com/u/4576246?v=4" width="100px;" alt=""/><br /><sub><b>Jorge Balderas</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://johnpapa.net/"><img src="https://avatars.githubusercontent.com/u/1202528?v=4" width="100px;" alt=""/><br /><sub><b>John Papa</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://www.johnlokerse.dev/"><img src="https://avatars.githubusercontent.com/u/3514513?v=4" width="100px;" alt=""/><br /><sub><b>John</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://joe-watkins.io/"><img src="https://avatars.githubusercontent.com/u/3695795?v=4" width="100px;" alt=""/><br /><sub><b>Joe Watkins</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/joe-watkins"><img src="https://avatars.githubusercontent.com/u/3695795?v=4" width="100px;" alt=""/><br /><sub><b>Joe Watkins</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://jan-v.nl/"><img src="https://avatars.githubusercontent.com/u/462356?v=4" width="100px;" alt=""/><br /><sub><b>Jan de Vries</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/nohwnd"><img src="https://avatars.githubusercontent.com/u/5735905?v=4" width="100px;" alt=""/><br /><sub><b>Jakub Jareš</b></sub></a></td>
     </tr>
@@ -488,7 +488,7 @@ import PageHeader from '../components/PageHeader.astro';
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/dawright22"><img src="https://avatars.githubusercontent.com/u/53329137?v=4" width="100px;" alt=""/><br /><sub><b>dawright22</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/alfersugo"><img src="https://avatars.githubusercontent.com/u/49598311?v=4" width="100px;" alt=""/><br /><sub><b>Alejandro Fernando Suarez Gomez</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://xquik.com/"><img src="https://avatars.githubusercontent.com/u/8755484?v=4" width="100px;" alt=""/><br /><sub><b>Burak Bayır</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://msamiullah.tech/"><img src="https://avatars.githubusercontent.com/u/52650290?v=4" width="100px;" alt=""/><br /><sub><b>MUHAMMAD SAMIULLAH</b></sub></a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://msamiullah.netlify.app/"><img src="https://avatars.githubusercontent.com/u/52650290?v=4" width="100px;" alt=""/><br /><sub><b>MUHAMMAD SAMIULLAH</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://metulev.com/"><img src="https://avatars.githubusercontent.com/u/711864?v=4" width="100px;" alt=""/><br /><sub><b>Nikola Metulev</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://www.colorado.edu/lab/krg"><img src="https://avatars.githubusercontent.com/u/4161712?v=4" width="100px;" alt=""/><br /><sub><b>Joseph Kasprzyk</b></sub></a></td>
     </tr>
@@ -500,6 +500,8 @@ import PageHeader from '../components/PageHeader.astro';
       <td align="center" valign="top" width="14.28%"><a href="https://www.cloudblogger.eu"><img src="https://avatars.githubusercontent.com/u/53148138?v=4" width="100px;" alt=""/><br /><sub><b>Konstantinos Passadis | Azure MVP | MCT</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/alx-so"><img src="https://avatars.githubusercontent.com/u/8975621?v=4" width="100px;" alt=""/><br /><sub><b>Alex Sokol</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://blogs.gnome.org/jmatsuzawa/"><img src="https://avatars.githubusercontent.com/u/545426?v=4" width="100px;" alt=""/><br /><sub><b>Jiro Matsuzawa</b></sub></a></td>
+    </tr>
+    <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/GuoCheng24"><img src="https://avatars.githubusercontent.com/u/224264187?v=4" width="100px;" alt=""/><br /><sub><b>Guo Cheng</b></sub></a></td>
     </tr>
   </tbody>


### PR DESCRIPTION
Nine contributor links in the all-contributors table point at personal sites whose domains no longer resolve (each NXDOMAIN re-verified via public resolvers, avatar user-ids matched to GitHub logins via the API):

| Contributor | Dead link | Replacement (200) |
|---|---|---|
| Bruno Borges | brunoborges.io | github.com/brunoborges |
| Daniel Meppiel | devprodlogs.com | theainativemind.com (his current GitHub blog field) |
| Oren Me | promptboost.dev | github.com/OrenMe |
| Rick Smit | ricksm.it | github.com/ricksmit3000 |
| Waren Gonzaga | bio.warengonzaga.com | waren.build (his current GitHub blog field) |
| Mehmet Ali EROL | mehmetalierol.com | github.com/mehmetalierol |
| Joe Watkins | joe-watkins.io | github.com/joe-watkins |
| Joseph Gonzales | sugbo4j.co.nz | github.com/josephgonzales01 |
| MUHAMMAD SAMIULLAH | msamiullah.tech | msamiullah.netlify.app (his current GitHub blog field) |

Where the person's GitHub profile declares a live successor site, that site is used; otherwise the GitHub profile.
