### PR TITLE
fix(website): constrain resource detail content on mobile (#2828)

### DIFF
--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -2329,6 +2329,8 @@ body:has(#main-content) {
 /* Article prose content */
 .article-content {
   max-width: 780px;
+  min-width: 0;
+  overflow-wrap: break-word;
   line-height: 1.75;
   font-size: 16px;
   color: var(--color-text);
@@ -3505,7 +3507,7 @@ header .theme-toggle-container {
 
 @media (max-width: 900px) {
   .resource-detail-page .detail-layout {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
   .resource-detail-page .detail-sidebar {
     position: static;


### PR DESCRIPTION
Closes #2828

## Root cause

On <=900px viewports the detail layout collapses to a single column declared as `grid-template-columns: 1fr`. A bare `1fr` track has an `auto` minimum, so a wide `pre`/long unbreakable text sizes the track beyond the viewport and the content is clipped at the right edge (the desktop rule already uses `minmax(0, 1fr)`, which is why only mobile is affected).

## Fix

- Mobile `.detail-layout`: `minmax(0, 1fr)` so the track can shrink and `.article-content pre`'s existing `overflow-x: auto` actually kicks in (code blocks scroll horizontally instead of clipping)
- `.article-content`: `min-width: 0` + `overflow-wrap: break-word` so long text/URLs wrap within the viewport

Applies to all resource detail pages (extensions, plugins, agents, instructions, skills) since they share `.detail-layout` / `.article-content`. No markup changes; the CI preview deploy should show the corrected mobile rendering.