### PR TITLE
fix(github-issues): quote array params for zsh, correct stale MCP write claim

### DIFF
--- a/skills/github-issues/SKILL.md
+++ b/skills/github-issues/SKILL.md
@@ -20,9 +20,17 @@ Manage GitHub issues using the `@modelcontextprotocol/server-github` MCP server.
 | `mcp__github__projects_get` | Get details of a project, field, item, or status update |
 | `mcp__github__projects_write` | Add/update/delete project items, create status updates |
 
+### MCP Tools (write operations)
+
+| Tool | Purpose |
+|------|---------|
+| `mcp__github__issue_write` | Create or update an issue (methods: create, update). Supports title, body, type, labels, assignees, milestone, and issue fields |
+| `mcp__github__add_issue_comment` | Add a comment or a reaction to an issue |
+| `mcp__github__sub_issue_write` | Add, remove, or reprioritize a sub-issue |
+
 ### CLI / REST API (write operations)
 
-The MCP server does not currently support creating, updating, or commenting on issues. Use `gh api` for these operations.
+`gh api` performs the same writes and is the form used in the examples below. Reach for it when the MCP server is not connected, or when you need a REST field the MCP tools do not expose.
 
 | Operation | Command |
 |-----------|---------|
@@ -61,9 +69,16 @@ Add any of these flags to the `gh api` call:
 
 ```
 -f type="Bug"                    # Issue type (Bug, Feature, Task, Epic, etc.)
--f labels[]="bug"                # Labels (repeat for multiple)
--f assignees[]="username"        # Assignees (repeat for multiple)
+-f 'labels[]=bug'                # Labels (repeat for multiple)
+-f 'assignees[]=username'        # Assignees (repeat for multiple)
 -f milestone=1                   # Milestone number
+```
+
+**Quote the whole `name[]=value` pair.** `[]` is a glob pattern in zsh, the default shell
+on macOS, so an unquoted `-f labels[]=bug` never reaches `gh`:
+
+```
+zsh: no matches found: labels[]=bug
 ```
 
 **Issue types** are organization-level metadata. To discover available types, use:
@@ -145,7 +160,7 @@ gh api repos/github/awesome-copilot/issues \
   -X POST \
   -f title="Add dark mode support" \
   -f type="Feature" \
-  -f labels[]="high-priority" \
+  -f 'labels[]=high-priority' \
   -f body="## Summary
 Add dark mode theme option for improved user experience and accessibility.
 


### PR DESCRIPTION
Two things in `skills/github-issues/SKILL.md` are wrong. Both bit me while setting the skill up.

### 1. `-f labels[]="bug"` fails on macOS

`[]` is a glob pattern in zsh, which is the default shell on macOS. The argument never reaches `gh`:

```
$ gh api repos/OWNER/REPO/issues -X POST -f title="test" -f labels[]="question"
zsh: no matches found: labels[]=question
```

Quoting the whole pair fixes it: `-f 'labels[]=question'`. Same for `assignees[]`. Anyone following the skill verbatim on a Mac hits this on their first create call.

### 2. The MCP server can write issues now

The skill says:

> The MCP server does not currently support creating, updating, or commenting on issues.

`issue_write` (create and update), `add_issue_comment`, and `sub_issue_write` all ship in github-mcp-server. They are listed in the server README under the issues toolset.

I left every `gh api` example alone. They work, and the CLI is still the right answer when the server is not connected or you need a REST field the tools do not expose. This just stops the skill asserting the MCP server cannot do something it can.

### How I checked

Created and closed a real issue against a repo of my own: `gh api ... -X POST` for the create, `issue_write` with `method: update` for the close. Both worked. The zsh failure above is copy-pasted from that session.

### One thing I did not touch

`type=` is silently dropped on user-owned repos, because issue types are org-level. The create returns 201 with `"type": null` and no warning, so it looks like it worked. The skill already notes types are org-level metadata, so I left it alone, but a sentence saying the parameter fails silently outside an org might save someone an hour.
