### PR TITLE
Pin figma plugin to an immutable ref (v2.2.96-figquery.1)

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -744,7 +744,7 @@
     {
       "name": "figma",
       "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
-      "version": "1.0.0",
+      "version": "2.2.96",
       "author": {
         "name": "Figma",
         "url": "https://www.figma.com"
@@ -760,7 +760,8 @@
       "repository": "https://github.com/figma/mcp-server-guide",
       "source": {
         "source": "github",
-        "repo": "figma/mcp-server-guide"
+        "repo": "figma/mcp-server-guide",
+        "ref": "v2.2.96-figquery.1"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -524,7 +524,7 @@
   {
     "name": "figma",
     "description": "Plugin that includes the Figma MCP server and Skills for common workflows.",
-    "version": "1.0.0",
+    "version": "2.2.96",
     "author": {
       "name": "Figma",
       "url": "https://www.figma.com"
@@ -540,7 +540,8 @@
     "repository": "https://github.com/figma/mcp-server-guide",
     "source": {
       "source": "github",
-      "repo": "figma/mcp-server-guide"
+      "repo": "figma/mcp-server-guide",
+      "ref": "v2.2.96-figquery.1"
     }
   },
   {


### PR DESCRIPTION
## What changed

Updates the already-listed `figma` entry in `plugins/external.json`:

- adds `source.ref: "v2.2.96-figquery.1"`, an annotated tag in `figma/mcp-server-guide`
- updates `version` from `1.0.0` to `2.2.96`, matching `.github/plugin/plugin.json` on that tag

`.github/plugin/marketplace.json` is regenerated via `node ./eng/generate-marketplace.mjs`.

## Why

The entry had no `ref`, so it tracked the repository's default branch and installs were not reproducible. `eng/external-plugin-validation.mjs` warns on marketplace entries whose `source` omits an immutable `ref`/`sha` locator; pinning the tag clears that warning.

The listed `version` had been `1.0.0` since the entry was added in #1143 while the plugin itself moved to `2.2.96`. Because `runVersionMatchGate` returns `not_run` when neither `source.ref` nor `source.sha` is present, that drift was never visible to CI. Pinning the ref makes the gate runnable, so the version is corrected here in the same change.

## Notes for reviewers

- The tag is annotated and points at a commit already on the repository, so the ref is immutable.
- Validation was run locally against the edited entry with the `marketplace` policy: no errors, no warnings.
- The plugin repository is public: https://github.com/figma/mcp-server-guide
- `vally lint` reports 95 findings against this plugin's skills: 94 `outside-skill-dir` references and 1 file-length violation. The file-length finding and 91 of the reference findings are present verbatim on the currently-served default branch. They surface now only because the quality gate first becomes runnable once a ref exists. Eight reference findings are new at this ref and four present on the default branch are gone, a net change of +3. Four of the eight involve `references/fig-builder.md`, a file this ref adds: three point at it and one comes from it. One is a genuine dead link: `figma-generate-design/SKILL.md` points to `../figma-implement-design/SKILL.md`, which does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
