### PR TITLE
chore: bump keep-the-why to 0.10.1

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -952,7 +952,7 @@
     {
       "name": "keep-the-why",
       "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "author": {
         "name": "Oliver Zehentleitner",
         "url": "https://github.com/oliver-zehentleitner"
@@ -971,7 +971,7 @@
       "source": {
         "source": "github",
         "repo": "oliver-zehentleitner/keep-the-why",
-        "ref": "v0.10.0"
+        "ref": "v0.10.1"
       }
     },
     {

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -952,7 +952,7 @@
     {
       "name": "keep-the-why",
       "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "author": {
         "name": "Oliver Zehentleitner",
         "url": "https://github.com/oliver-zehentleitner"
@@ -971,7 +971,7 @@
       "source": {
         "source": "github",
         "repo": "oliver-zehentleitner/keep-the-why",
-        "ref": "v0.9.2"
+        "ref": "v0.10.0"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -660,7 +660,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.9.2",
+    "version": "0.10.0",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"
@@ -679,7 +679,7 @@
     "source": {
       "source": "github",
       "repo": "oliver-zehentleitner/keep-the-why",
-      "ref": "v0.9.2"
+      "ref": "v0.10.0"
     }
   },
   {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -660,7 +660,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"
@@ -679,7 +679,7 @@
     "source": {
       "source": "github",
       "repo": "oliver-zehentleitner/keep-the-why",
-      "ref": "v0.10.0"
+      "ref": "v0.10.1"
     }
   },
   {


### PR DESCRIPTION
Bumps the `keep-the-why` external plugin listing's `version`/`source.ref` to the newly released `v0.10.1`, and regenerates `.github/plugin/marketplace.json` via `npm run plugin:generate-marketplace` in the same commit, per this repo's external-plugin update process.

(Originally opened for `v0.10.0`; 0.10.1 released shortly after, so this now targets that instead.)

Release: https://github.com/oliver-zehentleitner/keep-the-why/releases/tag/v0.10.1