### PR TITLE
chore(external): bump rayfin plugin to 0.4.0

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1373,7 +1373,7 @@
     {
       "name": "rayfin",
       "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -1393,7 +1393,7 @@
       "source": {
         "source": "github",
         "repo": "microsoft/rayfin",
-        "ref": "plugin-v0.3.0"
+        "ref": "plugin-v0.4.0"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -943,7 +943,7 @@
   {
     "name": "rayfin",
     "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "author": {
       "name": "Microsoft",
       "url": "https://www.microsoft.com"
@@ -963,7 +963,7 @@
     "source": {
       "source": "github",
       "repo": "microsoft/rayfin",
-      "ref": "plugin-v0.3.0"
+      "ref": "plugin-v0.4.0"
     }
   },
   {


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [x] The file follows the required naming convention.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `main` branch for this pull request.

---

## Description

Version bump for the already-listed `rayfin` external plugin, approved in #2836. No new listing.

- `version`: `0.3.0` to `0.4.0`
- `source.ref`: `plugin-v0.3.0` to `plugin-v0.4.0`

The new tag points at [`0b06bcf`](https://github.com/microsoft/rayfin/commit/0b06bcf3418d806e49216bce0b486769faf07e4b) on `microsoft/rayfin`'s default branch.

Two user-facing fixes ship in `0.4.0`, both reported by a reviewer against the listed `0.3.0`:

1. The getting-started skill now sources its default template from the [`microsoft/awesome-rayfin`](https://github.com/microsoft/awesome-rayfin) gallery instead of a personal repository, so the template it points users at is governed and carries its own license.
2. The documented scaffold command is back on a single line. It previously used a trailing `\` line continuation, which is a bash construct that PowerShell does not honor: the line fails to parse with `Missing expression after unary operator '--'`, so the command died before `npx` ran for anyone on Windows.

The bundled getting-started skill also moves `0.1.0` to `0.2.0`, since its documented behavior changed.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

## Additional Notes

`plugins/external.json` is the only hand-edited file. `.github/plugin/marketplace.json` is regenerated output from `npm run build`, not a manual edit.

`npm run plugin:validate` passes: `external.json is valid (50 external plugins)`, `All 99 plugins and the external catalog are valid`.

The diff is four lines, two per file, all within the `rayfin` entry. Worth noting for review that `"version": "0.3.0"` appears three times in `external.json` across unrelated listings, so the edit was scoped to the `rayfin` entry rather than applied as a file-wide replacement.

`plugin-v0.4.0` is a lightweight tag on a commit, matching how `plugin-v0.3.0` was cut.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.
