### PR TITLE
Fix external canvas extension validation

### DIFF
--- a/eng/external-plugin-intake.mjs
+++ b/eng/external-plugin-intake.mjs
@@ -65,6 +65,7 @@ const EXTERNAL_CANVAS_PREVIEW_PATH = "assets/preview.png";
 // files live under the client's own namespace directory rather than the repository-local
 // "com.github.awesome-copilot" namespace used to materialize plugins that live in this repo.
 const COPILOT_CLIENT_NAMESPACE = "com.github.copilot";
+const COPILOT_EXTENSIONS_DIRECTORY = "extensions";
 const HOMEPAGE_FETCH_TIMEOUT_MS = 10_000;
 const HOMEPAGE_MAX_BYTES = 512_000;
 const HOMEPAGE_MAX_REDIRECTS = 5;
@@ -750,8 +751,9 @@ async function resolveDirectoryTreeSha(repo, treeish, segments, token) {
 
 // Inspect the (recursively fetched) "com.github.copilot" subtree for the plugin's canvas
 // extension entry point. Paths are relative to "com.github.copilot/" and must use the
-// "<extension-name>/extension.mjs" layout. Scoping the recursive fetch to this subtree keeps
-// the lookup complete without depending on the size of the rest of the repository.
+// "extensions/<extension-name>/extension.mjs" layout used by the Copilot app. Scoping the
+// recursive fetch to this subtree keeps the lookup complete without depending on the size of
+// the rest of the repository.
 function analyzeCanvasExtensionSubtree(subtreeEntries) {
   let nestedEntryPath = null;
   let nestedEntryIsNotFile = false;
@@ -763,7 +765,7 @@ function analyzeCanvasExtensionSubtree(subtreeEntries) {
     }
 
     const segments = entryPath.split("/");
-    if (segments.length === 2 && segments[1] === "extension.mjs") {
+    if (segments.length === 3 && segments[0] === COPILOT_EXTENSIONS_DIRECTORY && segments[2] === "extension.mjs") {
       if (entry.type === "blob") {
         nestedEntryPath = nestedEntryPath ?? `${COPILOT_CLIENT_NAMESPACE}/${entryPath}`;
       } else {
@@ -902,11 +904,11 @@ export async function validateCanvasPluginMetadata(plugin, errors, warnings, tok
         warnings.push(unverifiableEntryPointWarning);
       } else if (canvasStructure.status === "notFile") {
         errors.push(
-          `submission: "${COPILOT_CLIENT_NAMESPACE}/<extension>/extension.mjs" must be a file in ${releaseLocatorDescription}`,
+          `submission: "${COPILOT_CLIENT_NAMESPACE}/${COPILOT_EXTENSIONS_DIRECTORY}/<extension>/extension.mjs" must be a file in ${releaseLocatorDescription}`,
         );
       } else {
         errors.push(
-          `submission: plugins tagged with "canvas" must include a canvas extension entry point at "${COPILOT_CLIENT_NAMESPACE}/<extension>/extension.mjs" at ${releaseLocatorDescription}`,
+          `submission: plugins tagged with "canvas" must include a canvas extension entry point at "${COPILOT_CLIENT_NAMESPACE}/${COPILOT_EXTENSIONS_DIRECTORY}/<extension>/extension.mjs" at ${releaseLocatorDescription}`,
         );
       }
     }

--- a/eng/external-plugin-intake.mjs
+++ b/eng/external-plugin-intake.mjs
@@ -749,15 +749,12 @@ async function resolveDirectoryTreeSha(repo, treeish, segments, token) {
 }
 
 // Inspect the (recursively fetched) "com.github.copilot" subtree for the plugin's canvas
-// extension entry point. Paths are relative to "com.github.copilot/", so the flat form is
-// "extension.mjs" and a nested form is "<...>/extension.mjs" at any depth — e.g. this repo's own
-// materialized plugins nest at "extensions/<name>/extension.mjs" (two levels), so the search
-// cannot be limited to a single path segment. Scoping the recursive fetch to this subtree keeps
+// extension entry point. Paths are relative to "com.github.copilot/" and must use the
+// "<extension-name>/extension.mjs" layout. Scoping the recursive fetch to this subtree keeps
 // the lookup complete without depending on the size of the rest of the repository.
 function analyzeCanvasExtensionSubtree(subtreeEntries) {
-  let flatIsBlob = false;
-  let flatIsTree = false;
   let nestedEntryPath = null;
+  let nestedEntryIsNotFile = false;
 
   for (const entry of subtreeEntries) {
     const entryPath = entry?.path;
@@ -765,27 +762,20 @@ function analyzeCanvasExtensionSubtree(subtreeEntries) {
       continue;
     }
 
-    if (entryPath === "extension.mjs") {
+    const segments = entryPath.split("/");
+    if (segments.length === 2 && segments[1] === "extension.mjs") {
       if (entry.type === "blob") {
-        flatIsBlob = true;
-      } else if (entry.type === "tree") {
-        flatIsTree = true;
+        nestedEntryPath = nestedEntryPath ?? `${COPILOT_CLIENT_NAMESPACE}/${entryPath}`;
+      } else {
+        nestedEntryIsNotFile = true;
       }
-      continue;
-    }
-
-    if (entryPath.endsWith("/extension.mjs") && entry.type === "blob") {
-      nestedEntryPath = nestedEntryPath ?? `${COPILOT_CLIENT_NAMESPACE}/${entryPath}`;
     }
   }
 
-  if (flatIsBlob) {
-    return { status: "found", entryPath: `${COPILOT_CLIENT_NAMESPACE}/extension.mjs` };
-  }
   if (nestedEntryPath) {
     return { status: "found", entryPath: nestedEntryPath };
   }
-  if (flatIsTree) {
+  if (nestedEntryIsNotFile) {
     return { status: "notFile" };
   }
   return { status: "notFound" };
@@ -904,7 +894,7 @@ export async function validateCanvasPluginMetadata(plugin, errors, warnings, tok
     } else {
       const canvasStructure = analyzeCanvasExtensionSubtree(subtreeResponse.data.tree);
       if (canvasStructure.status === "found") {
-        // Entry point located (flat or nested); nothing to report.
+        // Entry point located in the required named extension directory.
       } else if (subtreeResponse.data.truncated) {
         // Absence is only inconclusive if the (already namespace-scoped) subtree itself is
         // truncated, which would take an implausibly large extension directory; flag it as
@@ -912,11 +902,11 @@ export async function validateCanvasPluginMetadata(plugin, errors, warnings, tok
         warnings.push(unverifiableEntryPointWarning);
       } else if (canvasStructure.status === "notFile") {
         errors.push(
-          `submission: "${COPILOT_CLIENT_NAMESPACE}/extension.mjs" must be a file in ${releaseLocatorDescription}`,
+          `submission: "${COPILOT_CLIENT_NAMESPACE}/<extension>/extension.mjs" must be a file in ${releaseLocatorDescription}`,
         );
       } else {
         errors.push(
-          `submission: plugins tagged with "canvas" must include a canvas extension entry point at "${COPILOT_CLIENT_NAMESPACE}/extension.mjs" or "${COPILOT_CLIENT_NAMESPACE}/<extension>/extension.mjs" at ${releaseLocatorDescription}`,
+          `submission: plugins tagged with "canvas" must include a canvas extension entry point at "${COPILOT_CLIENT_NAMESPACE}/<extension>/extension.mjs" at ${releaseLocatorDescription}`,
         );
       }
     }

--- a/eng/external-plugin-intake.mjs
+++ b/eng/external-plugin-intake.mjs
@@ -61,6 +61,10 @@ const LEGACY_FIELD_TITLES = Object.freeze({
 });
 const EXTERNAL_CANVAS_KEYWORD = "canvas";
 const EXTERNAL_CANVAS_PREVIEW_PATH = "assets/preview.png";
+// External plugins target the Copilot app client harness directly, so their canvas extension
+// files live under the client's own namespace directory rather than the repository-local
+// "com.github.awesome-copilot" namespace used to materialize plugins that live in this repo.
+const COPILOT_CLIENT_NAMESPACE = "com.github.copilot";
 const HOMEPAGE_FETCH_TIMEOUT_MS = 10_000;
 const HOMEPAGE_MAX_BYTES = 512_000;
 const HOMEPAGE_MAX_REDIRECTS = 5;
@@ -744,10 +748,12 @@ async function resolveDirectoryTreeSha(repo, treeish, segments, token) {
   return { status: "found", treeSha: currentTreeish };
 }
 
-// Inspect the (recursively fetched) "extensions" subtree for the plugin's canvas extension
-// entry point. Paths are relative to "extensions/", so the flat form is "extension.mjs" and a
-// nested form is "<name>/extension.mjs". Scoping the recursive fetch to this subtree keeps the
-// lookup complete without depending on the size of the rest of the repository.
+// Inspect the (recursively fetched) "com.github.copilot" subtree for the plugin's canvas
+// extension entry point. Paths are relative to "com.github.copilot/", so the flat form is
+// "extension.mjs" and a nested form is "<...>/extension.mjs" at any depth — e.g. this repo's own
+// materialized plugins nest at "extensions/<name>/extension.mjs" (two levels), so the search
+// cannot be limited to a single path segment. Scoping the recursive fetch to this subtree keeps
+// the lookup complete without depending on the size of the rest of the repository.
 function analyzeCanvasExtensionSubtree(subtreeEntries) {
   let flatIsBlob = false;
   let flatIsTree = false;
@@ -768,14 +774,13 @@ function analyzeCanvasExtensionSubtree(subtreeEntries) {
       continue;
     }
 
-    const segments = entryPath.split("/");
-    if (segments.length === 2 && segments[1] === "extension.mjs" && entry.type === "blob") {
-      nestedEntryPath = nestedEntryPath ?? `extensions/${entryPath}`;
+    if (entryPath.endsWith("/extension.mjs") && entry.type === "blob") {
+      nestedEntryPath = nestedEntryPath ?? `${COPILOT_CLIENT_NAMESPACE}/${entryPath}`;
     }
   }
 
   if (flatIsBlob) {
-    return { status: "found", entryPath: "extensions/extension.mjs" };
+    return { status: "found", entryPath: `${COPILOT_CLIENT_NAMESPACE}/extension.mjs` };
   }
   if (nestedEntryPath) {
     return { status: "found", entryPath: nestedEntryPath };
@@ -859,46 +864,39 @@ export async function validateCanvasPluginMetadata(plugin, errors, warnings, tok
     return;
   }
 
-  if (manifest.logo !== EXTERNAL_CANVAS_PREVIEW_PATH) {
+  const copilotNamespace = manifest.extensions?.[COPILOT_CLIENT_NAMESPACE];
+  if (!copilotNamespace || typeof copilotNamespace !== "object" || Array.isArray(copilotNamespace)) {
     errors.push(
-      `submission: plugins tagged with "canvas" must set "logo" to "${EXTERNAL_CANVAS_PREVIEW_PATH}" in "${manifestPath}"`,
+      `submission: plugins tagged with "canvas" must set "extensions.${COPILOT_CLIENT_NAMESPACE}.logo" to "${EXTERNAL_CANVAS_PREVIEW_PATH}" in "${manifestPath}"`,
     );
-  }
-
-  if (manifest.extenions !== undefined) {
+  } else if (copilotNamespace.logo !== EXTERNAL_CANVAS_PREVIEW_PATH) {
     errors.push(
-      `submission: plugins tagged with "canvas" must use "extensions" (found misspelled key "extenions") in "${manifestPath}"`,
-    );
-  }
-
-  if (manifest.extensions !== undefined && manifest.extensions !== "extensions") {
-    errors.push(
-      `submission: plugins tagged with "canvas" may omit "extensions", but if provided it must be "extensions" in "${manifestPath}"`,
+      `submission: plugins tagged with "canvas" must set "logo" to "${EXTERNAL_CANVAS_PREVIEW_PATH}" in "extensions.${COPILOT_CLIENT_NAMESPACE}" of "${manifestPath}"`,
     );
   }
 
   const unverifiableEntryPointWarning =
     `submission: could not verify the canvas extension entry point in GitHub repository "${repo}" at ${releaseLocatorDescription}; a maintainer should re-run intake`;
-  const extensionsSegments = [...(pluginRoot ? pluginRoot.split("/") : []), "extensions"];
-  const extensionsTree = await resolveDirectoryTreeSha(
+  const namespaceSegments = [...(pluginRoot ? pluginRoot.split("/") : []), COPILOT_CLIENT_NAMESPACE];
+  const namespaceTree = await resolveDirectoryTreeSha(
     repo,
     normalizeTreeish(releaseLocator),
-    extensionsSegments,
+    namespaceSegments,
     token,
   );
-  if (extensionsTree.status === "apiError") {
+  if (namespaceTree.status === "apiError") {
     warnings.push(unverifiableEntryPointWarning);
-  } else if (extensionsTree.status === "missing") {
+  } else if (namespaceTree.status === "missing") {
     errors.push(
-      `submission: plugins tagged with "canvas" must include an "extensions" directory at ${releaseLocatorDescription}`,
+      `submission: plugins tagged with "canvas" must include a "${COPILOT_CLIENT_NAMESPACE}" directory at ${releaseLocatorDescription}`,
     );
-  } else if (extensionsTree.status === "notDirectory") {
+  } else if (namespaceTree.status === "notDirectory") {
     errors.push(
-      `submission: "extensions" must be a directory in ${releaseLocatorDescription}`,
+      `submission: "${COPILOT_CLIENT_NAMESPACE}" must be a directory in ${releaseLocatorDescription}`,
     );
   } else {
     const subtreeResponse = await fetchGitHubJson(
-      buildGitTreePath(repo, extensionsTree.treeSha, { recursive: true }),
+      buildGitTreePath(repo, namespaceTree.treeSha, { recursive: true }),
       token,
     );
     if (subtreeResponse.kind !== "found" || !Array.isArray(subtreeResponse.data?.tree)) {
@@ -908,17 +906,17 @@ export async function validateCanvasPluginMetadata(plugin, errors, warnings, tok
       if (canvasStructure.status === "found") {
         // Entry point located (flat or nested); nothing to report.
       } else if (subtreeResponse.data.truncated) {
-        // Absence is only inconclusive if the (already extensions-scoped) subtree itself is
-        // truncated, which would take an implausibly large extensions directory; flag it as
+        // Absence is only inconclusive if the (already namespace-scoped) subtree itself is
+        // truncated, which would take an implausibly large extension directory; flag it as
         // unverifiable rather than falsely rejecting.
         warnings.push(unverifiableEntryPointWarning);
       } else if (canvasStructure.status === "notFile") {
         errors.push(
-          `submission: "extensions/extension.mjs" must be a file in ${releaseLocatorDescription}`,
+          `submission: "${COPILOT_CLIENT_NAMESPACE}/extension.mjs" must be a file in ${releaseLocatorDescription}`,
         );
       } else {
         errors.push(
-          `submission: plugins tagged with "canvas" must include a canvas extension entry point at "extensions/extension.mjs" or "extensions/<extension>/extension.mjs" at ${releaseLocatorDescription}`,
+          `submission: plugins tagged with "canvas" must include a canvas extension entry point at "${COPILOT_CLIENT_NAMESPACE}/extension.mjs" or "${COPILOT_CLIENT_NAMESPACE}/<extension>/extension.mjs" at ${releaseLocatorDescription}`,
         );
       }
     }

--- a/eng/external-plugin-intake.test.mjs
+++ b/eng/external-plugin-intake.test.mjs
@@ -71,7 +71,11 @@ const canvasManifest = fileNode(
     name: "upgrade-agent",
     version: "1.0.0",
     description: "Canvas plugin",
-    logo: "assets/preview.png",
+    extensions: {
+      "com.github.copilot": {
+        logo: "assets/preview.png",
+      },
+    },
   }),
 );
 
@@ -83,19 +87,19 @@ function baseContents(extra) {
   };
 }
 
-// Wires up the directory-walk that resolves plugins/upgrade-agent/extensions to a tree SHA.
-// `extensionsEntry` controls what the walk finds at the final ".../extensions" step, and
-// `extensionsSubtree` is the recursive listing returned for that resolved tree SHA.
-function buildTrees({ extensionsEntry, extensionsSubtree, overrides } = {}) {
+// Wires up the directory-walk that resolves plugins/upgrade-agent/com.github.copilot to a tree
+// SHA. `namespaceEntry` controls what the walk finds at the final ".../com.github.copilot" step,
+// and `namespaceSubtree` is the recursive listing returned for that resolved tree SHA.
+function buildTrees({ namespaceEntry, namespaceSubtree, overrides } = {}) {
   const trees = {
     [SHA]: treeResponse([treeEntry("plugins", "tree", TREE_PLUGINS)]),
     [TREE_PLUGINS]: treeResponse([treeEntry("upgrade-agent", "tree", TREE_UPGRADE_AGENT)]),
     [TREE_UPGRADE_AGENT]: treeResponse([
-      extensionsEntry ?? treeEntry("extensions", "tree", TREE_EXTENSIONS),
+      namespaceEntry ?? treeEntry("com.github.copilot", "tree", TREE_EXTENSIONS),
     ]),
   };
-  if (extensionsSubtree) {
-    trees[TREE_EXTENSIONS] = extensionsSubtree;
+  if (namespaceSubtree) {
+    trees[TREE_EXTENSIONS] = namespaceSubtree;
   }
   return { ...trees, ...overrides };
 }
@@ -120,9 +124,26 @@ async function runValidation({ contents, trees }) {
 test("validateCanvasPluginMetadata accepts a nested extension entry point", async () => {
   const { errors, warnings } = await runValidation({
     trees: buildTrees({
-      extensionsSubtree: treeResponse([
+      namespaceSubtree: treeResponse([
         treeEntry("modernize-dashboard", "tree"),
         treeEntry("modernize-dashboard/extension.mjs", "blob"),
+      ]),
+    }),
+  });
+
+  assert.deepEqual(errors, []);
+  assert.deepEqual(warnings, []);
+});
+
+test("validateCanvasPluginMetadata accepts a doubly-nested extension entry point", async () => {
+  // Mirrors this repo's own materialized layout ("com.github.copilot/extensions/<name>/extension.mjs")
+  // and real-world external submissions that nest an "extensions/" folder inside the namespace.
+  const { errors, warnings } = await runValidation({
+    trees: buildTrees({
+      namespaceSubtree: treeResponse([
+        treeEntry("extensions", "tree"),
+        treeEntry("extensions/radius", "tree"),
+        treeEntry("extensions/radius/extension.mjs", "blob"),
       ]),
     }),
   });
@@ -134,7 +155,7 @@ test("validateCanvasPluginMetadata accepts a nested extension entry point", asyn
 test("validateCanvasPluginMetadata accepts a flat extension entry point", async () => {
   const { errors, warnings } = await runValidation({
     trees: buildTrees({
-      extensionsSubtree: treeResponse([treeEntry("extension.mjs", "blob")]),
+      namespaceSubtree: treeResponse([treeEntry("extension.mjs", "blob")]),
     }),
   });
 
@@ -145,7 +166,7 @@ test("validateCanvasPluginMetadata accepts a flat extension entry point", async 
 test("validateCanvasPluginMetadata rejects when no extension.mjs exists flat or nested", async () => {
   const { errors } = await runValidation({
     trees: buildTrees({
-      extensionsSubtree: treeResponse([
+      namespaceSubtree: treeResponse([
         treeEntry("modernize-dashboard", "tree"),
         treeEntry("modernize-dashboard/index.mjs", "blob"),
       ]),
@@ -158,36 +179,36 @@ test("validateCanvasPluginMetadata rejects when no extension.mjs exists flat or 
   );
 });
 
-test("validateCanvasPluginMetadata rejects when the extensions directory is missing", async () => {
+test("validateCanvasPluginMetadata rejects when the com.github.copilot directory is missing", async () => {
   const { errors } = await runValidation({
     trees: buildTrees({
-      extensionsEntry: treeEntry("other-dir", "tree", "tree-other"),
+      namespaceEntry: treeEntry("other-dir", "tree", "tree-other"),
     }),
   });
 
   assert.equal(
-    errors.some((message) => /must include an "extensions" directory/.test(message)),
+    errors.some((message) => /must include a "com\.github\.copilot" directory/.test(message)),
     true,
   );
 });
 
-test("validateCanvasPluginMetadata rejects when extensions is a file rather than a directory", async () => {
+test("validateCanvasPluginMetadata rejects when com.github.copilot is a file rather than a directory", async () => {
   const { errors } = await runValidation({
     trees: buildTrees({
-      extensionsEntry: treeEntry("extensions", "blob", "blob-extensions"),
+      namespaceEntry: treeEntry("com.github.copilot", "blob", "blob-extensions"),
     }),
   });
 
   assert.equal(
-    errors.some((message) => /"extensions" must be a directory/.test(message)),
+    errors.some((message) => /"com\.github\.copilot" must be a directory/.test(message)),
     true,
   );
 });
 
-test("validateCanvasPluginMetadata rejects when extensions/extension.mjs is a directory", async () => {
+test("validateCanvasPluginMetadata rejects when com.github.copilot/extension.mjs is a directory", async () => {
   const { errors } = await runValidation({
     trees: buildTrees({
-      extensionsSubtree: treeResponse([
+      namespaceSubtree: treeResponse([
         treeEntry("extension.mjs", "tree"),
         treeEntry("extension.mjs/placeholder.txt", "blob"),
       ]),
@@ -195,7 +216,7 @@ test("validateCanvasPluginMetadata rejects when extensions/extension.mjs is a di
   });
 
   assert.equal(
-    errors.some((message) => /"extensions\/extension\.mjs" must be a file/.test(message)),
+    errors.some((message) => /"com\.github\.copilot\/extension\.mjs" must be a file/.test(message)),
     true,
   );
 });
@@ -219,7 +240,7 @@ test("validateCanvasPluginMetadata treats a truncated walk level as unverifiable
     trees: buildTrees({
       overrides: {
         [TREE_UPGRADE_AGENT]: treeResponse(
-          [treeEntry("extensions", "tree", TREE_EXTENSIONS)],
+          [treeEntry("com.github.copilot", "tree", TREE_EXTENSIONS)],
           { truncated: true },
         ),
       },
@@ -233,10 +254,10 @@ test("validateCanvasPluginMetadata treats a truncated walk level as unverifiable
   );
 });
 
-test("validateCanvasPluginMetadata treats a truncated extensions subtree without an entry point as unverifiable", async () => {
+test("validateCanvasPluginMetadata treats a truncated com.github.copilot subtree without an entry point as unverifiable", async () => {
   const { errors, warnings } = await runValidation({
     trees: buildTrees({
-      extensionsSubtree: treeResponse([treeEntry("modernize-dashboard", "tree")], { truncated: true }),
+      namespaceSubtree: treeResponse([treeEntry("modernize-dashboard", "tree")], { truncated: true }),
     }),
   });
 
@@ -250,7 +271,7 @@ test("validateCanvasPluginMetadata treats a truncated extensions subtree without
 test("validateCanvasPluginMetadata accepts an entry point found within a truncated subtree", async () => {
   const { errors, warnings } = await runValidation({
     trees: buildTrees({
-      extensionsSubtree: treeResponse(
+      namespaceSubtree: treeResponse(
         [
           treeEntry("modernize-dashboard", "tree"),
           treeEntry("modernize-dashboard/extension.mjs", "blob"),

--- a/eng/external-plugin-intake.test.mjs
+++ b/eng/external-plugin-intake.test.mjs
@@ -135,9 +135,7 @@ test("validateCanvasPluginMetadata accepts a nested extension entry point", asyn
   assert.deepEqual(warnings, []);
 });
 
-test("validateCanvasPluginMetadata accepts a doubly-nested extension entry point", async () => {
-  // Mirrors this repo's own materialized layout ("com.github.copilot/extensions/<name>/extension.mjs")
-  // and real-world external submissions that nest an "extensions/" folder inside the namespace.
+test("validateCanvasPluginMetadata rejects a doubly-nested extension entry point", async () => {
   const { errors, warnings } = await runValidation({
     trees: buildTrees({
       namespaceSubtree: treeResponse([
@@ -148,22 +146,28 @@ test("validateCanvasPluginMetadata accepts a doubly-nested extension entry point
     }),
   });
 
-  assert.deepEqual(errors, []);
+  assert.equal(
+    errors.some((message) => /must include a canvas extension entry point/.test(message)),
+    true,
+  );
   assert.deepEqual(warnings, []);
 });
 
-test("validateCanvasPluginMetadata accepts a flat extension entry point", async () => {
+test("validateCanvasPluginMetadata rejects a flat extension entry point", async () => {
   const { errors, warnings } = await runValidation({
     trees: buildTrees({
       namespaceSubtree: treeResponse([treeEntry("extension.mjs", "blob")]),
     }),
   });
 
-  assert.deepEqual(errors, []);
+  assert.equal(
+    errors.some((message) => /must include a canvas extension entry point/.test(message)),
+    true,
+  );
   assert.deepEqual(warnings, []);
 });
 
-test("validateCanvasPluginMetadata rejects when no extension.mjs exists flat or nested", async () => {
+test("validateCanvasPluginMetadata rejects when no named extension entry point exists", async () => {
   const { errors } = await runValidation({
     trees: buildTrees({
       namespaceSubtree: treeResponse([
@@ -205,18 +209,19 @@ test("validateCanvasPluginMetadata rejects when com.github.copilot is a file rat
   );
 });
 
-test("validateCanvasPluginMetadata rejects when com.github.copilot/extension.mjs is a directory", async () => {
+test("validateCanvasPluginMetadata rejects when a named extension.mjs is a directory", async () => {
   const { errors } = await runValidation({
     trees: buildTrees({
       namespaceSubtree: treeResponse([
-        treeEntry("extension.mjs", "tree"),
-        treeEntry("extension.mjs/placeholder.txt", "blob"),
+        treeEntry("modernize-dashboard", "tree"),
+        treeEntry("modernize-dashboard/extension.mjs", "tree"),
+        treeEntry("modernize-dashboard/extension.mjs/placeholder.txt", "blob"),
       ]),
     }),
   });
 
   assert.equal(
-    errors.some((message) => /"com\.github\.copilot\/extension\.mjs" must be a file/.test(message)),
+    errors.some((message) => /"com\.github\.copilot\/<extension>\/extension\.mjs" must be a file/.test(message)),
     true,
   );
 });

--- a/eng/external-plugin-intake.test.mjs
+++ b/eng/external-plugin-intake.test.mjs
@@ -87,6 +87,17 @@ function baseContents(extra) {
   };
 }
 
+function manifestWithExtensions(extensions) {
+  return fileNode(
+    JSON.stringify({
+      name: "upgrade-agent",
+      version: "1.0.0",
+      description: "Canvas plugin",
+      extensions,
+    }),
+  );
+}
+
 // Wires up the directory-walk that resolves plugins/upgrade-agent/com.github.copilot to a tree
 // SHA. `namespaceEntry` controls what the walk finds at the final ".../com.github.copilot" step,
 // and `namespaceSubtree` is the recursive listing returned for that resolved tree SHA.
@@ -134,6 +145,56 @@ test("validateCanvasPluginMetadata accepts a nested extension entry point", asyn
 
   assert.deepEqual(errors, []);
   assert.deepEqual(warnings, []);
+});
+
+test("validateCanvasPluginMetadata rejects a manifest missing the com.github.copilot namespace", async () => {
+  const { errors } = await runValidation({
+    contents: {
+      [`${PLUGIN_ROOT}/.github/plugin/plugin.json`]: {
+        status: 200,
+        data: manifestWithExtensions({}),
+      },
+    },
+    trees: buildTrees({
+      namespaceSubtree: treeResponse([
+        treeEntry("extensions", "tree"),
+        treeEntry("extensions/modernize-dashboard", "tree"),
+        treeEntry("extensions/modernize-dashboard/extension.mjs", "blob"),
+      ]),
+    }),
+  });
+
+  assert.equal(
+    errors.some((message) =>
+      /must set "extensions\.com\.github\.copilot\.logo" to "assets\/preview\.png"/.test(message),
+    ),
+    true,
+  );
+});
+
+test("validateCanvasPluginMetadata rejects a manifest with the wrong logo path", async () => {
+  const { errors } = await runValidation({
+    contents: {
+      [`${PLUGIN_ROOT}/.github/plugin/plugin.json`]: {
+        status: 200,
+        data: manifestWithExtensions({ "com.github.copilot": { logo: "logo.png" } }),
+      },
+    },
+    trees: buildTrees({
+      namespaceSubtree: treeResponse([
+        treeEntry("extensions", "tree"),
+        treeEntry("extensions/modernize-dashboard", "tree"),
+        treeEntry("extensions/modernize-dashboard/extension.mjs", "blob"),
+      ]),
+    }),
+  });
+
+  assert.equal(
+    errors.some((message) =>
+      /must set "logo" to "assets\/preview\.png" in "extensions\.com\.github\.copilot"/.test(message),
+    ),
+    true,
+  );
 });
 
 test("validateCanvasPluginMetadata rejects an extension entry point outside the extensions directory", async () => {

--- a/eng/external-plugin-intake.test.mjs
+++ b/eng/external-plugin-intake.test.mjs
@@ -125,8 +125,9 @@ test("validateCanvasPluginMetadata accepts a nested extension entry point", asyn
   const { errors, warnings } = await runValidation({
     trees: buildTrees({
       namespaceSubtree: treeResponse([
-        treeEntry("modernize-dashboard", "tree"),
-        treeEntry("modernize-dashboard/extension.mjs", "blob"),
+        treeEntry("extensions", "tree"),
+        treeEntry("extensions/modernize-dashboard", "tree"),
+        treeEntry("extensions/modernize-dashboard/extension.mjs", "blob"),
       ]),
     }),
   });
@@ -135,13 +136,12 @@ test("validateCanvasPluginMetadata accepts a nested extension entry point", asyn
   assert.deepEqual(warnings, []);
 });
 
-test("validateCanvasPluginMetadata rejects a doubly-nested extension entry point", async () => {
+test("validateCanvasPluginMetadata rejects an extension entry point outside the extensions directory", async () => {
   const { errors, warnings } = await runValidation({
     trees: buildTrees({
       namespaceSubtree: treeResponse([
-        treeEntry("extensions", "tree"),
-        treeEntry("extensions/radius", "tree"),
-        treeEntry("extensions/radius/extension.mjs", "blob"),
+        treeEntry("radius", "tree"),
+        treeEntry("radius/extension.mjs", "blob"),
       ]),
     }),
   });
@@ -213,15 +213,16 @@ test("validateCanvasPluginMetadata rejects when a named extension.mjs is a direc
   const { errors } = await runValidation({
     trees: buildTrees({
       namespaceSubtree: treeResponse([
-        treeEntry("modernize-dashboard", "tree"),
-        treeEntry("modernize-dashboard/extension.mjs", "tree"),
-        treeEntry("modernize-dashboard/extension.mjs/placeholder.txt", "blob"),
+        treeEntry("extensions", "tree"),
+        treeEntry("extensions/modernize-dashboard", "tree"),
+        treeEntry("extensions/modernize-dashboard/extension.mjs", "tree"),
+        treeEntry("extensions/modernize-dashboard/extension.mjs/placeholder.txt", "blob"),
       ]),
     }),
   });
 
   assert.equal(
-    errors.some((message) => /"com\.github\.copilot\/<extension>\/extension\.mjs" must be a file/.test(message)),
+    errors.some((message) => /"com\.github\.copilot\/extensions\/<extension>\/extension\.mjs" must be a file/.test(message)),
     true,
   );
 });
@@ -262,7 +263,7 @@ test("validateCanvasPluginMetadata treats a truncated walk level as unverifiable
 test("validateCanvasPluginMetadata treats a truncated com.github.copilot subtree without an entry point as unverifiable", async () => {
   const { errors, warnings } = await runValidation({
     trees: buildTrees({
-      namespaceSubtree: treeResponse([treeEntry("modernize-dashboard", "tree")], { truncated: true }),
+      namespaceSubtree: treeResponse([treeEntry("extensions", "tree")], { truncated: true }),
     }),
   });
 
@@ -278,8 +279,8 @@ test("validateCanvasPluginMetadata accepts an entry point found within a truncat
     trees: buildTrees({
       namespaceSubtree: treeResponse(
         [
-          treeEntry("modernize-dashboard", "tree"),
-          treeEntry("modernize-dashboard/extension.mjs", "blob"),
+          treeEntry("extensions/modernize-dashboard", "tree"),
+          treeEntry("extensions/modernize-dashboard/extension.mjs", "blob"),
         ],
         { truncated: true },
       ),

--- a/eng/external-plugin-quality-gates.mjs
+++ b/eng/external-plugin-quality-gates.mjs
@@ -807,10 +807,15 @@ function locateCanvasEntryPoint(repoDir, readRef, locator, extensionsDir) {
   }
 
   let nestedEntryPoint = null;
+  let nestedEntryIsNotFile = false;
   for (const entry of listing.entries) {
     const segments = entry.name.split("/");
-    if (segments.length === 2 && segments[1] === "extension.mjs" && entry.type === "blob" && !nestedEntryPoint) {
-      nestedEntryPoint = toPosixPath(extensionsDir, segments[0], "extension.mjs");
+    if (segments.length === 2 && segments[1] === "extension.mjs" && !nestedEntryPoint) {
+      if (entry.type === "blob") {
+        nestedEntryPoint = toPosixPath(extensionsDir, segments[0], "extension.mjs");
+      } else {
+        nestedEntryIsNotFile = true;
+      }
     }
   }
 
@@ -818,7 +823,7 @@ function locateCanvasEntryPoint(repoDir, readRef, locator, extensionsDir) {
     return { entryPoint: nestedEntryPoint, output: "" };
   }
 
-  return { entryPoint: null, output: "" };
+  return { entryPoint: null, output: "", kindMismatch: nestedEntryIsNotFile };
 }
 
 export function runCanvasStructureGate(repoDir, plugin, primaryFetchSpec) {
@@ -889,9 +894,15 @@ export function runCanvasStructureGate(repoDir, plugin, primaryFetchSpec) {
     }
     if (!extensionEntryCheck.entryPoint) {
       hasFailure = true;
-      messages.push(
-        `- ${locator}: missing required canvas extension entry point "${extensionsDir}/<extension>/extension.mjs".`,
-      );
+      if (extensionEntryCheck.kindMismatch) {
+        messages.push(
+          `- ${locator}: "${extensionsDir}/<extension>/extension.mjs" must be a file.`,
+        );
+      } else {
+        messages.push(
+          `- ${locator}: missing required canvas extension entry point "${extensionsDir}/<extension>/extension.mjs".`,
+        );
+      }
       continue;
     }
 

--- a/eng/external-plugin-quality-gates.mjs
+++ b/eng/external-plugin-quality-gates.mjs
@@ -25,6 +25,8 @@ const AGENT_PLUGIN_ALLOWED_TOP_LEVEL_FIELDS = new Set([
 ]);
 const AGENT_PLUGIN_NAME_PATTERN = /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
 const EXTERNAL_CANVAS_KEYWORD = "canvas";
+const COPILOT_CLIENT_NAMESPACE = "com.github.copilot";
+const COPILOT_EXTENSIONS_DIRECTORY = "extensions";
 
 const INFRA_ERROR_PATTERNS = [
   /\b401\b/,
@@ -804,33 +806,19 @@ function locateCanvasEntryPoint(repoDir, readRef, locator, extensionsDir) {
     return { entryPoint: null, output: listing.output };
   }
 
-  let flatIsBlob = false;
-  let flatIsTree = false;
   let nestedEntryPoint = null;
   for (const entry of listing.entries) {
-    if (entry.name === "extension.mjs") {
-      if (entry.type === "blob") {
-        flatIsBlob = true;
-      } else if (entry.type === "tree") {
-        flatIsTree = true;
-      }
-      continue;
-    }
-
     const segments = entry.name.split("/");
     if (segments.length === 2 && segments[1] === "extension.mjs" && entry.type === "blob" && !nestedEntryPoint) {
       nestedEntryPoint = toPosixPath(extensionsDir, segments[0], "extension.mjs");
     }
   }
 
-  if (flatIsBlob) {
-    return { entryPoint: toPosixPath(extensionsDir, "extension.mjs"), output: "" };
-  }
   if (nestedEntryPoint) {
     return { entryPoint: nestedEntryPoint, output: "" };
   }
 
-  return { entryPoint: null, output: "", flatKindMismatch: flatIsTree };
+  return { entryPoint: null, output: "" };
 }
 
 export function runCanvasStructureGate(repoDir, plugin, primaryFetchSpec) {
@@ -854,8 +842,8 @@ export function runCanvasStructureGate(repoDir, plugin, primaryFetchSpec) {
     };
   }
 
-  const extensionsDir = toPosixPath(normalizedPluginPath, "extensions");
-  const extensionEntryPoint = toPosixPath(extensionsDir, "extension.mjs");
+  const namespaceDir = toPosixPath(normalizedPluginPath, COPILOT_CLIENT_NAMESPACE);
+  const extensionsDir = toPosixPath(namespaceDir, COPILOT_EXTENSIONS_DIRECTORY);
 
   let hasFailure = false;
   let hasInfraError = false;
@@ -901,13 +889,9 @@ export function runCanvasStructureGate(repoDir, plugin, primaryFetchSpec) {
     }
     if (!extensionEntryCheck.entryPoint) {
       hasFailure = true;
-      if (extensionEntryCheck.flatKindMismatch) {
-        messages.push(`- ${locator}: "${extensionEntryPoint}" must be a file.`);
-      } else {
-        messages.push(
-          `- ${locator}: missing required canvas extension entry point "${extensionEntryPoint}" (or a nested "${extensionsDir}/<extension>/extension.mjs").`,
-        );
-      }
+      messages.push(
+        `- ${locator}: missing required canvas extension entry point "${extensionsDir}/<extension>/extension.mjs".`,
+      );
       continue;
     }
 

--- a/eng/external-plugin-quality-gates.test.mjs
+++ b/eng/external-plugin-quality-gates.test.mjs
@@ -103,7 +103,7 @@ test("runCanvasStructureGate fails when the named extension entrypoint path is a
 
   const result = runCanvasStructureGate(repoDir, plugin, sha);
   assert.equal(result.status, "fail");
-  assert.match(result.output, /missing required canvas extension entry point/);
+  assert.match(result.output, /"com\.github\.copilot\/extensions\/<extension>\/extension\.mjs" must be a file/);
 });
 
 test("runCanvasStructureGate fails when the Copilot namespace is missing", () => {

--- a/eng/external-plugin-quality-gates.test.mjs
+++ b/eng/external-plugin-quality-gates.test.mjs
@@ -38,10 +38,13 @@ function commitAll(repoDir, message) {
   return runGit(repoDir, "rev-parse", "HEAD");
 }
 
-test("runCanvasStructureGate passes when extensions/extension.mjs exists", () => {
+test("runCanvasStructureGate passes when a named extension exists", () => {
   const repoDir = createTempRepo();
-  fs.mkdirSync(path.join(repoDir, "extensions"), { recursive: true });
-  fs.writeFileSync(path.join(repoDir, "extensions", "extension.mjs"), "export default {};\n");
+  fs.mkdirSync(path.join(repoDir, "com.github.copilot", "extensions", "canvas-plugin"), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoDir, "com.github.copilot", "extensions", "canvas-plugin", "extension.mjs"),
+    "export default {};\n",
+  );
   const sha = commitAll(repoDir, "Add canvas extension container");
 
   const plugin = {
@@ -56,7 +59,7 @@ test("runCanvasStructureGate passes when extensions/extension.mjs exists", () =>
 
   const result = runCanvasStructureGate(repoDir, plugin, sha);
   assert.equal(result.status, "pass");
-  assert.match(result.output, /found "extensions"/);
+  assert.match(result.output, /found "com\.github\.copilot\/extensions"/);
 });
 
 test("runCanvasStructureGate fails when extension entrypoint is only at repo root", () => {
@@ -76,13 +79,16 @@ test("runCanvasStructureGate fails when extension entrypoint is only at repo roo
 
   const result = runCanvasStructureGate(repoDir, plugin, sha);
   assert.equal(result.status, "fail");
-  assert.match(result.output, /missing required canvas extension directory "extensions"/);
+  assert.match(result.output, /missing required canvas extension directory "com\.github\.copilot\/extensions"/);
 });
 
-test("runCanvasStructureGate fails when extension entrypoint path is a directory", () => {
+test("runCanvasStructureGate fails when the named extension entrypoint path is a directory", () => {
   const repoDir = createTempRepo();
-  fs.mkdirSync(path.join(repoDir, "extensions", "extension.mjs"), { recursive: true });
-  fs.writeFileSync(path.join(repoDir, "extensions", "extension.mjs", "placeholder.txt"), "not-a-module\n");
+  fs.mkdirSync(path.join(repoDir, "com.github.copilot", "extensions", "canvas-plugin", "extension.mjs"), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoDir, "com.github.copilot", "extensions", "canvas-plugin", "extension.mjs", "placeholder.txt"),
+    "not-a-module\n",
+  );
   const sha = commitAll(repoDir, "Add invalid extension entrypoint directory");
 
   const plugin = {
@@ -97,17 +103,14 @@ test("runCanvasStructureGate fails when extension entrypoint path is a directory
 
   const result = runCanvasStructureGate(repoDir, plugin, sha);
   assert.equal(result.status, "fail");
-  assert.match(result.output, /"extensions\/extension\.mjs" must be a file/);
+  assert.match(result.output, /missing required canvas extension entry point/);
 });
 
-test("runCanvasStructureGate passes when extension lives in a nested subfolder", () => {
+test("runCanvasStructureGate fails when the Copilot namespace is missing", () => {
   const repoDir = createTempRepo();
   fs.mkdirSync(path.join(repoDir, "extensions", "modernize-dashboard"), { recursive: true });
-  fs.writeFileSync(
-    path.join(repoDir, "extensions", "modernize-dashboard", "extension.mjs"),
-    "export default {};\n",
-  );
-  const sha = commitAll(repoDir, "Add nested canvas extension");
+  fs.writeFileSync(path.join(repoDir, "extensions", "modernize-dashboard", "extension.mjs"), "export default {};\n");
+  const sha = commitAll(repoDir, "Add extension outside Copilot namespace");
 
   const plugin = {
     name: "canvas-plugin",
@@ -120,15 +123,15 @@ test("runCanvasStructureGate passes when extension lives in a nested subfolder",
   };
 
   const result = runCanvasStructureGate(repoDir, plugin, sha);
-  assert.equal(result.status, "pass");
-  assert.match(result.output, /entry point "extensions\/modernize-dashboard\/extension\.mjs"/);
+  assert.equal(result.status, "fail");
+  assert.match(result.output, /missing required canvas extension directory "com\.github\.copilot\/extensions"/);
 });
 
-test("runCanvasStructureGate fails when no extension.mjs exists flat or nested", () => {
+test("runCanvasStructureGate fails when no extension.mjs exists in a named directory", () => {
   const repoDir = createTempRepo();
-  fs.mkdirSync(path.join(repoDir, "extensions", "modernize-dashboard"), { recursive: true });
+  fs.mkdirSync(path.join(repoDir, "com.github.copilot", "extensions", "modernize-dashboard"), { recursive: true });
   fs.writeFileSync(
-    path.join(repoDir, "extensions", "modernize-dashboard", "index.mjs"),
+    path.join(repoDir, "com.github.copilot", "extensions", "modernize-dashboard", "index.mjs"),
     "export default {};\n",
   );
   const sha = commitAll(repoDir, "Add extensions directory without entry point");
@@ -156,15 +159,16 @@ test("runCanvasStructureGate finds a nested extension listed past the legacy out
   for (let index = 0; index < 160; index += 1) {
     const filler = path.join(
       repoDir,
+      "com.github.copilot",
       "extensions",
       `filler-directory-that-pads-the-tree-listing-${String(index).padStart(4, "0")}`,
     );
     fs.mkdirSync(filler, { recursive: true });
     fs.writeFileSync(path.join(filler, "readme.txt"), "filler\n");
   }
-  fs.mkdirSync(path.join(repoDir, "extensions", "zzz-real-extension"), { recursive: true });
+  fs.mkdirSync(path.join(repoDir, "com.github.copilot", "extensions", "zzz-real-extension"), { recursive: true });
   fs.writeFileSync(
-    path.join(repoDir, "extensions", "zzz-real-extension", "extension.mjs"),
+    path.join(repoDir, "com.github.copilot", "extensions", "zzz-real-extension", "extension.mjs"),
     "export default {};\n",
   );
   const sha = commitAll(repoDir, "Add nested extension after many siblings");
@@ -181,7 +185,7 @@ test("runCanvasStructureGate finds a nested extension listed past the legacy out
 
   const result = runCanvasStructureGate(repoDir, plugin, sha);
   assert.equal(result.status, "pass");
-  assert.match(result.output, /entry point "extensions\/zzz-real-extension\/extension\.mjs"/);
+  assert.match(result.output, /entry point "com\.github\.copilot\/extensions\/zzz-real-extension\/extension\.mjs"/);
 });
 
 // Regression tests for issue #2397: a tag-name locator (e.g. "v1.0.0") must be
@@ -207,8 +211,11 @@ function writeValidPluginContent(repoDir) {
     path.join(repoDir, ".github", "plugin", "plugin.json"),
     `${JSON.stringify({ name: "tag-plugin", version: "1.0.0" }, null, 2)}\n`,
   );
-  fs.mkdirSync(path.join(repoDir, "extensions"), { recursive: true });
-  fs.writeFileSync(path.join(repoDir, "extensions", "extension.mjs"), "export default {};\n");
+  fs.mkdirSync(path.join(repoDir, "com.github.copilot", "extensions", "tag-plugin"), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoDir, "com.github.copilot", "extensions", "tag-plugin", "extension.mjs"),
+    "export default {};\n",
+  );
 }
 
 // Mirrors cloneSubmissionRepository in external-plugin-quality-gates.mjs: fetch only the
@@ -259,8 +266,8 @@ test("runCanvasStructureGate passes for a tag ref alongside a sha", () => {
 
   const result = runCanvasStructureGate(repoDir, plugin, sha);
   assert.equal(result.status, "pass", result.output);
-  assert.match(result.output, /- v1\.0\.0: found "extensions"/);
-  assert.match(result.output, new RegExp(`- ${sha}: found "extensions"`));
+  assert.match(result.output, /- v1\.0\.0: found "com\.github\.copilot\/extensions"/);
+  assert.match(result.output, new RegExp(`- ${sha}: found "com\\.github\\.copilot/extensions"`));
 });
 
 test("runVersionMatchGate passes when the primary locator is a tag ref", () => {
@@ -296,7 +303,7 @@ test("runCanvasStructureGate passes when the primary locator is a tag ref", () =
 
   const result = runCanvasStructureGate(repoDir, plugin, "v1.0.0");
   assert.equal(result.status, "pass", result.output);
-  assert.match(result.output, /- v1\.0\.0: found "extensions"/);
+  assert.match(result.output, /- v1\.0\.0: found "com\.github\.copilot\/extensions"/);
 });
 
 test("runRefShaConsistencyGate fails when ref and sha point to different commits", () => {


### PR DESCRIPTION
## Pull Request Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, skill, workflow, or canvas extension with GitHub Copilot.
- [ ] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `main` branch for this pull request.

---

## Description

External canvas plugins use the spec-defined `com.github.copilot` namespace, while the github-app runtime discovers canvases from `com.github.copilot/extensions/<extension-name>/extension.mjs`. The intake validator and downstream quality gate now enforce that canonical layout, including the required preview logo metadata.

Regression coverage verifies accepted named extensions and rejects flat, unnamespaced, and incorrectly nested entry points. The validator also preserves its explicit handling for incomplete or truncated GitHub tree responses.

Fixes: #2778

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

## Additional Notes

The validator distinguishes external plugin client extensions (`com.github.copilot`) from this repository's build-time composition namespace (`com.github.awesome-copilot`).

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.