### PR TITLE
chore: bump keep-the-why to 0.12.0

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -979,7 +979,7 @@
     {
       "name": "keep-the-why",
       "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-      "version": "0.10.1",
+      "version": "0.12.0",
       "author": {
         "name": "Oliver Zehentleitner",
         "url": "https://github.com/oliver-zehentleitner"
@@ -998,7 +998,7 @@
       "source": {
         "source": "github",
         "repo": "oliver-zehentleitner/keep-the-why",
-        "ref": "v0.10.1"
+        "ref": "v0.12.0"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -687,7 +687,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.10.1",
+    "version": "0.12.0",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"
@@ -706,7 +706,7 @@
     "source": {
       "source": "github",
       "repo": "oliver-zehentleitner/keep-the-why",
-      "ref": "v0.10.1"
+      "ref": "v0.12.0"
     }
   },
   {


### PR DESCRIPTION
Bumps the `keep-the-why` external plugin from 0.10.1 to 0.12.0 (`version` and `source.ref` → `v0.12.0`), `marketplace.json` regenerated with `npm run plugin:generate-marketplace`. Rebased on current `main`; this PR previously targeted 0.11.0, which was superseded before it was merged.

Release: https://github.com/oliver-zehentleitner/keep-the-why/releases/tag/v0.12.0 — changelog: https://github.com/oliver-zehentleitner/keep-the-why/blob/v0.12.0/CHANGELOG.md