### PR TITLE
Contributors table: keep every row at seven cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,8 @@ Thanks goes to these wonderful people ([emoji key](./CONTRIBUTING.md#contributor
       <td align="center" valign="top" width="14.28%"><a href="https://www.cloudblogger.eu"><img src="https://avatars.githubusercontent.com/u/53148138?v=4" width="100px;" alt=""/><br /><sub><b>Konstantinos Passadis | Azure MVP | MCT</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/alx-so"><img src="https://avatars.githubusercontent.com/u/8975621?v=4" width="100px;" alt=""/><br /><sub><b>Alex Sokol</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://blogs.gnome.org/jmatsuzawa/"><img src="https://avatars.githubusercontent.com/u/545426?v=4" width="100px;" alt=""/><br /><sub><b>Jiro Matsuzawa</b></sub></a></td>
+    </tr>
+    <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/GuoCheng24"><img src="https://avatars.githubusercontent.com/u/224264187?v=4" width="100px;" alt=""/><br /><sub><b>Guo Cheng</b></sub></a></td>
     </tr>
   </tbody>


### PR DESCRIPTION
The all-contributors table has 54 rows. Fifty-three carry seven `<td>` elements; the last carries **eight**.

Every cell is `width="14.28%"` — one seventh — so eight in a row sums past 100%. The result is that the final avatar renders visibly narrower than every other avatar on the page and is pushed beyond the table's edge, reachable only by scrolling the table horizontally.

Counting cells per row, before and after:

```
before:  54 rows, cells per row ∈ {7, 8}   ← one row with 8
after :  55 rows, cells per row ∈ {7, 1}   ← the 1 is the new trailing row
```

The fix moves that one cell onto its own row, which is where the next contributor would go anyway. Two added lines, no cell contents touched.

I noticed it because the eighth cell is mine, but the same thing will happen to whoever is added next unless the row is closed.