### PR TITLE
Update upgrade-agent plugin to 1.1.485

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1809,7 +1809,7 @@
     {
       "name": "upgrade-agent",
       "description": "AI-powered upgrade assistant for upgrading and migrating applications. Helps modernize legacy code and upgrade .NET applications to current frameworks.",
-      "version": "1.1.441",
+      "version": "1.1.485",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -1828,8 +1828,8 @@
         "source": "github",
         "repo": "microsoft/upgrade-agent-plugins",
         "path": "plugins/upgrade-agent",
-        "ref": "v1.1.441",
-        "sha": "f8abab778cfb5b57a3c745d540631b7aab15d5b3"
+        "ref": "v1.1.485",
+        "sha": "de2dd654a288726652de81998fbaff7a849891dc"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -1229,7 +1229,7 @@
   {
     "name": "upgrade-agent",
     "description": "AI-powered upgrade assistant for upgrading and migrating applications. Helps modernize legacy code and upgrade .NET applications to current frameworks.",
-    "version": "1.1.441",
+    "version": "1.1.485",
     "author": {
       "name": "Microsoft",
       "url": "https://www.microsoft.com"
@@ -1248,8 +1248,8 @@
       "source": "github",
       "repo": "microsoft/upgrade-agent-plugins",
       "path": "plugins/upgrade-agent",
-      "ref": "v1.1.441",
-      "sha": "f8abab778cfb5b57a3c745d540631b7aab15d5b3"
+      "ref": "v1.1.485",
+      "sha": "de2dd654a288726652de81998fbaff7a849891dc"
     }
   },
   {


### PR DESCRIPTION
Automated version bump of the upgrade-agent external plugin entry from UpgradeAssistant build 2026-09-03-20260903.2 (version 1.1.485). Pinned to tag v1.1.485 / commit de2dd654a288726652de81998fbaff7a849891dc in microsoft/upgrade-agent-plugins.