### PR TITLE
chore: bump keep-the-why to 0.13.3

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -979,7 +979,7 @@
     {
       "name": "keep-the-why",
       "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "author": {
         "name": "Oliver Zehentleitner",
         "url": "https://github.com/oliver-zehentleitner"
@@ -998,7 +998,7 @@
       "source": {
         "source": "github",
         "repo": "oliver-zehentleitner/keep-the-why",
-        "ref": "v0.12.0"
+        "ref": "v0.13.0"
       }
     },
     {

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -979,7 +979,7 @@
     {
       "name": "keep-the-why",
       "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "author": {
         "name": "Oliver Zehentleitner",
         "url": "https://github.com/oliver-zehentleitner"
@@ -998,7 +998,7 @@
       "source": {
         "source": "github",
         "repo": "oliver-zehentleitner/keep-the-why",
-        "ref": "v0.13.2"
+        "ref": "v0.13.3"
       }
     },
     {

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -979,7 +979,7 @@
     {
       "name": "keep-the-why",
       "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "author": {
         "name": "Oliver Zehentleitner",
         "url": "https://github.com/oliver-zehentleitner"
@@ -998,7 +998,7 @@
       "source": {
         "source": "github",
         "repo": "oliver-zehentleitner/keep-the-why",
-        "ref": "v0.13.0"
+        "ref": "v0.13.1"
       }
     },
     {

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -979,7 +979,7 @@
     {
       "name": "keep-the-why",
       "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "author": {
         "name": "Oliver Zehentleitner",
         "url": "https://github.com/oliver-zehentleitner"
@@ -998,7 +998,7 @@
       "source": {
         "source": "github",
         "repo": "oliver-zehentleitner/keep-the-why",
-        "ref": "v0.13.1"
+        "ref": "v0.13.2"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -687,7 +687,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"
@@ -706,7 +706,7 @@
     "source": {
       "source": "github",
       "repo": "oliver-zehentleitner/keep-the-why",
-      "ref": "v0.12.0"
+      "ref": "v0.13.0"
     }
   },
   {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -687,7 +687,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"
@@ -706,7 +706,7 @@
     "source": {
       "source": "github",
       "repo": "oliver-zehentleitner/keep-the-why",
-      "ref": "v0.13.0"
+      "ref": "v0.13.1"
     }
   },
   {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -687,7 +687,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"
@@ -706,7 +706,7 @@
     "source": {
       "source": "github",
       "repo": "oliver-zehentleitner/keep-the-why",
-      "ref": "v0.13.1"
+      "ref": "v0.13.2"
     }
   },
   {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -687,7 +687,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.13.2",
+    "version": "0.13.3",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"
@@ -706,7 +706,7 @@
     "source": {
       "source": "github",
       "repo": "oliver-zehentleitner/keep-the-why",
-      "ref": "v0.13.2"
+      "ref": "v0.13.3"
     }
   },
   {


### PR DESCRIPTION
Bumps the external plugin `keep-the-why` to 0.13.3 in `plugins/external.json` (`version` and `source.ref`) and updates its `description` to the plugin manifest's current text, with `.github/plugin/marketplace.json` regenerated via `npm run plugin:generate-marketplace`.

Release notes: https://github.com/oliver-zehentleitner/keep-the-why/releases/tag/v0.13.3