### PR TITLE
Require new submissions after external plugin rejection

### DIFF
--- a/.github/workflows/external-plugin-command-router.yml
+++ b/.github/workflows/external-plugin-command-router.yml
@@ -441,7 +441,7 @@ jobs:
               '',
               reason,
               '',
-              'If you address the feedback, edit this issue with the updated details and have the issue author or a maintainer comment `/rerun-intake` to re-run automated intake.'
+              'This issue is now closed and `/rerun-intake` will no longer reopen it. If you address the feedback, please open a new external plugin submission issue.'
             ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({
@@ -660,6 +660,21 @@ jobs:
               return;
             }
 
+            if (labelNames.has('rejected')) {
+              core.info('Ignoring /rerun-intake because the issue was rejected by a maintainer.');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  '`/rerun-intake` cannot reopen a maintainer-rejected submission.',
+                  '',
+                  'This issue was rejected and closed, so it is no longer eligible for another intake pass. If you believe the concerns raised in the rejection have been fully addressed, please open a new external plugin submission issue instead.'
+                ].join('\n')
+              });
+              return;
+            }
+
             const issueAuthor = currentIssue.user?.login;
             const isIssueAuthor = Boolean(issueAuthor && commentAuthor === issueAuthor);
 
@@ -678,9 +693,8 @@ jobs:
               return;
             }
 
-            const canRerunFromCurrentState = currentIssue.state === 'open' || labelNames.has('rejected');
-            if (!canRerunFromCurrentState) {
-              core.info('Ignoring /rerun-intake because the issue is closed outside the intake/rejection flow.');
+            if (currentIssue.state !== 'open') {
+              core.info('Ignoring /rerun-intake because the issue is closed.');
               return;
             }
 

--- a/.github/workflows/external-plugin-command-router.yml
+++ b/.github/workflows/external-plugin-command-router.yml
@@ -660,21 +660,6 @@ jobs:
               return;
             }
 
-            if (labelNames.has('rejected')) {
-              core.info('Ignoring /rerun-intake because the issue was rejected by a maintainer.');
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: [
-                  '`/rerun-intake` cannot reopen a maintainer-rejected submission.',
-                  '',
-                  'This issue was rejected and closed, so it is no longer eligible for another intake pass. If you believe the concerns raised in the rejection have been fully addressed, please open a new external plugin submission issue instead.'
-                ].join('\n')
-              });
-              return;
-            }
-
             const issueAuthor = currentIssue.user?.login;
             const isIssueAuthor = Boolean(issueAuthor && commentAuthor === issueAuthor);
 
@@ -690,6 +675,43 @@ jobs:
 
             if (!isIssueAuthor && !hasWriteAccess) {
               core.info(`Ignoring /rerun-intake because ${commentAuthor} is neither the issue author nor a maintainer.`);
+              return;
+            }
+
+            if (labelNames.has('rejected')) {
+              core.info('Ignoring /rerun-intake because the issue was rejected by a maintainer.');
+              const marker = '<!-- external-plugin-rerun-rejected -->';
+              const body = [
+                marker,
+                '`/rerun-intake` cannot reopen a maintainer-rejected submission.',
+                '',
+                'This issue was rejected and closed, so it is no longer eligible for another intake pass. If you believe the concerns raised in the rejection have been fully addressed, please open a new external plugin submission issue instead.'
+              ].join('\n');
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100
+              });
+              const existingComment = comments.find((comment) =>
+                comment.user?.login === 'github-actions[bot]' &&
+                comment.body?.includes(marker)
+              );
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                  body
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body
+                });
+              }
               return;
             }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,7 @@ To bundle an extension into another plugin without making a second source copy, 
 3. In v1, only GitHub-hosted plugins are accepted for public submission, using a public repo plus an immutable `ref`, `sha`, or both
 4. The shared validator in `eng/external-plugin-validation.mjs` is the canonical source of truth for external plugin data rules; reuse it instead of duplicating checks in scripts or workflows
 5. Submission issues move through `external-plugin` + `awaiting-review` and then either `ready-for-review` or `requires-submitter-fixes` based on automated quality gates
-6. After issue edits, the issue author or a maintainer can comment `/rerun-intake` to re-run automated intake and quality gates without opening a new submission issue
+6. While a submission issue is open, the issue author or a maintainer can comment `/rerun-intake` to re-run automated intake and quality gates. Maintainer-rejected issues are terminal; contributors who address the rejection feedback must open a new submission issue
 7. Maintainers can explicitly override a quality-gate blocker with `/mark-ready-for-review [optional reason]`, which moves the issue to `ready-for-review`
 8. Maintainers make the decision with `/approve` or `/reject <reason>` issue comments once the issue is in `ready-for-review`; approved issues are closed and used as the six-month re-review anchor
 9. Approval automation creates or updates the PR against `main`, updates `plugins/external.json`, and regenerates marketplace outputs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,11 +257,11 @@ The public-submission policy builds on those rules and also requires `license` p
    - install smoke test via Copilot CLI against an ephemeral marketplace entry generated from the submission
 4. **Ready for maintainer review**: if metadata validation and quality gates pass, automation removes `awaiting-review` and adds `ready-for-review`.
 5. **Submitter-fix blocker**: if metadata is valid but quality gates fail, automation applies `requires-submitter-fixes` instead of advancing to human review.
-6. **Requesting another intake pass**: after updating the issue body or source plugin, the issue author or a maintainer can comment `/rerun-intake` to re-run automated intake and quality gates on demand. Open issues re-trigger intake automatically on edit; closed maintainer-rejected issues need `/rerun-intake`. When the rerun is accepted, automation reacts to the command comment with 👀 so it is visible that processing started.
+6. **Requesting another intake pass**: after updating the issue body or source plugin, the issue author or a maintainer can comment `/rerun-intake` to re-run automated intake and quality gates on demand while the issue is still open. Open issues re-trigger intake automatically on edit. When the rerun is accepted, automation reacts to the command comment with 👀 so it is visible that processing started.
 7. **Maintainer override path**: a maintainer with write access can comment `/mark-ready-for-review [optional reason]` to explicitly move a `requires-submitter-fixes` issue to `ready-for-review`.
 8. **Maintainer decision**: once in `ready-for-review`, a maintainer with write access performs the manual review, then comments `/approve` or `/reject <reason>` on the issue. Commands from non-maintainers are ignored.
 9. **Approval path**: on `/approve`, automation removes `ready-for-review`, adds `approved`, closes the issue, and opens or updates a PR against `main` that updates `plugins/external.json` and generated marketplace outputs.
-10. **Rejection path**: on `/reject <reason>`, automation removes `ready-for-review`, adds `rejected`, closes the issue, and records the reason in an issue comment. After addressing the feedback, update the same issue and use `/rerun-intake` to re-queue intake.
+10. **Rejection path**: on `/reject <reason>`, automation removes `ready-for-review`, adds `rejected`, closes the issue, and records the reason in an issue comment. Rejected issues are terminal: `/rerun-intake` no longer reopens them, so a submitter who believes the concerns are fully addressed must open a new external plugin submission issue.
 
 ##### Updating listed external plugins via PR
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [ ] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory. N/A - this updates an existing workflow and its documentation.
- [ ] The file follows the required naming convention. N/A - no new resource file was added.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested my instructions, prompt, agent, skill, or canvas extension with GitHub Copilot. N/A - this change updates workflow behavior rather than a Copilot resource.
- [ ] I have run `npm start` and verified that `README.md` is up to date. N/A - README generation is not affected.
- [x] I am targeting the `main` branch for this pull request.

---

## Description

Maintainer-rejected external plugin submissions should be terminal. Previously, `/rerun-intake` could reopen a rejected issue, even though a submitter who fully addresses the rejection concerns is effectively making a new submission.

This change blocks `/rerun-intake` on rejected issues, posts guidance to open a new external plugin submission issue, and updates the rejection comment and contributor documentation to describe the new flow.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

## Additional Notes

The workflow YAML was parsed successfully after the change. No generated README updates are needed because this only changes an existing workflow and related documentation.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](../CODE_OF_CONDUCT.md) and will be licensed under the MIT License.