### PR TITLE
Upgrade microsoft-foundry plugin to 1.0.12

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1068,7 +1068,7 @@
     {
       "name": "microsoft-foundry",
       "description": "Skills and interactive Copilot canvas for designing, configuring, testing and deploying agents to Microsoft Foundry.",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -1089,7 +1089,7 @@
         "source": "github",
         "repo": "microsoft/foundry-dev-tools",
         "path": "microsoft-foundry",
-        "sha": "553365e9b0193a740daa293e6716415939f804e7"
+        "sha": "c6e140164b4c2d3d6c6baa5b63c65120fd994278"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -764,7 +764,7 @@
   {
     "name": "microsoft-foundry",
     "description": "Skills and interactive Copilot canvas for designing, configuring, testing and deploying agents to Microsoft Foundry.",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "author": {
       "name": "Microsoft",
       "url": "https://www.microsoft.com"
@@ -785,7 +785,7 @@
       "source": "github",
       "repo": "microsoft/foundry-dev-tools",
       "path": "microsoft-foundry",
-      "sha": "553365e9b0193a740daa293e6716415939f804e7"
+      "sha": "c6e140164b4c2d3d6c6baa5b63c65120fd994278"
     }
   },
   {


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [x] N/A - This contribution updates an existing external plugin listing rather than adding a new instruction, prompt, agent, skill, workflow, or canvas extension file.
- [x] N/A - No new resource file is introduced, so the file naming convention does not apply.
- [x] The content is clearly structured and follows the example format.
- [x] I have tested the plugin with GitHub Copilot through the automated external-plugin install smoke test; the canvas-structure quality gate is blocked on the upstream Agent Plugins migration.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `main` branch for this pull request.

---

## Description

Upgrades the external `microsoft-foundry` plugin from version `1.0.11` to `1.0.12` using source commit [`c6e140164b4c2d3d6c6baa5b63c65120fd994278`](https://github.com/microsoft/foundry-dev-tools/commit/c6e140164b4c2d3d6c6baa5b63c65120fd994278).

Regenerates `.github/plugin/marketplace.json` from the updated external plugin catalog.

---

## Type of Contribution

- [ ] New instruction file.
- [ ] New prompt file.
- [ ] New agent file.
- [ ] New plugin.
- [ ] New skill file.
- [ ] New agentic workflow.
- [ ] New canvas extension.
- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.
- [ ] Other (please specify):

---

## Validation

- Verified the source manifest at the pinned commit declares version `1.0.12`.
- `npm start`
- `bash eng/fix-line-endings.sh`
- `npm run plugin:validate`
- `git diff --check`
- Automated external-plugin install smoke test and `vally lint` passed.
- Canvas structure gate failed because the pinned source uses the legacy `extensions/` layout instead of `com.github.copilot/extensions/`.

---

## Additional Notes

This updates a previously approved external plugin listing. The source repository remains `microsoft/foundry-dev-tools`, and the plugin path remains `microsoft-foundry`.

The current 1.0.12 source commit still uses the legacy canvas layout. [microsoft/foundry-dev-tools#681](https://github.com/microsoft/foundry-dev-tools/pull/681) contains the required Agent Plugins 1.0 migration, but it is not merged and currently declares version 1.0.11. This PR will require a new compliant 1.0.12 source commit before it can become ready for review.

---

By submitting this pull request, I confirm that my contribution abides by the [Code of Conduct](https://github.com/github/awesome-copilot/blob/main/CODE_OF_CONDUCT.md) and will be licensed under the MIT License.

