### PR TITLE
docs(gem-team): fix dead LICENSE link in plugin README

### DIFF
--- a/plugins/gem-team/README.md
+++ b/plugins/gem-team/README.md
@@ -230,7 +230,7 @@ handoff:
 
 - [Documentation](https://mubaidr.github.io/gem-team/)
 - [Contributing](https://mubaidr.github.io/gem-team/5.resources/2.contributing.html)
-- [License](LICENSE)
+- [License](https://github.com/mubaidr/gem-team/blob/main/LICENSE)
 
 ## Support
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [CONTRIBUTING.md](https://github.com/github/awesome-copilot/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have read and followed the [Guidance for submissions involving paid services](https://github.com/github/awesome-copilot/discussions/968).
- [ ] My contribution adds a new instruction, prompt, agent, skill, workflow, or canvas extension file in the correct directory.
- [ ] The file follows the required naming convention.
- [ ] The content is clearly structured and follows the example format.
- [ ] I have tested my instructions, prompt, agent, skill, workflow, or canvas extension with GitHub Copilot.
- [x] I have run `npm start` and verified that `README.md` is up to date.
- [x] I am targeting the `main` branch for this pull request.

---

## Description

The Learn More section in `plugins/gem-team/README.md` linked to a local `LICENSE` file that does not exist in that directory, leading to a 404 when followed on GitHub. This updates the link to point to the license file in the plugin's upstream repository (`mubaidr/gem-team`), matching the pattern used by the adjacent Documentation and Contributing links.

---

## Type of Contribution

- [x] Update to existing instruction, prompt, agent, plugin, skill, workflow, or canvas extension.

---

## Additional Notes

Before this change, the relative link resolved to a non-existent path in this repository and produced a 404 error. The updated target resolves to the upstream license with HTTP 200.

<details>
<summary>Raw logs</summary>

```console
$ curl -sSL -o /dev/null -w '%{http_code}\n' https://raw.githubusercontent.com/github/awesome-copilot/main/plugins/gem-team/LICENSE
404
$ curl -sSL -o /dev/null -w '%{http_code}\n' https://raw.githubusercontent.com/mubaidr/gem-team/main/LICENSE
200
```

</details>

`npm run plugin:validate` passes.
