### PR TITLE
chore: bump keep-the-why to 0.15.0

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1008,7 +1008,7 @@
     {
       "name": "keep-the-why",
       "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "author": {
         "name": "Oliver Zehentleitner",
         "url": "https://github.com/oliver-zehentleitner"
@@ -1027,7 +1027,7 @@
       "source": {
         "source": "github",
         "repo": "oliver-zehentleitner/keep-the-why",
-        "ref": "v0.14.0"
+        "ref": "v0.14.1"
       }
     },
     {

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1008,7 +1008,7 @@
     {
       "name": "keep-the-why",
       "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-      "version": "0.13.3",
+      "version": "0.14.0",
       "author": {
         "name": "Oliver Zehentleitner",
         "url": "https://github.com/oliver-zehentleitner"
@@ -1027,7 +1027,7 @@
       "source": {
         "source": "github",
         "repo": "oliver-zehentleitner/keep-the-why",
-        "ref": "v0.13.3"
+        "ref": "v0.14.0"
       }
     },
     {

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1008,7 +1008,7 @@
     {
       "name": "keep-the-why",
       "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "author": {
         "name": "Oliver Zehentleitner",
         "url": "https://github.com/oliver-zehentleitner"
@@ -1027,7 +1027,7 @@
       "source": {
         "source": "github",
         "repo": "oliver-zehentleitner/keep-the-why",
-        "ref": "v0.14.1"
+        "ref": "v0.15.0"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -716,7 +716,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.14.0",
+    "version": "0.14.1",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"
@@ -735,7 +735,7 @@
     "source": {
       "source": "github",
       "repo": "oliver-zehentleitner/keep-the-why",
-      "ref": "v0.14.0"
+      "ref": "v0.14.1"
     }
   },
   {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -716,7 +716,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.13.3",
+    "version": "0.14.0",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"
@@ -735,7 +735,7 @@
     "source": {
       "source": "github",
       "repo": "oliver-zehentleitner/keep-the-why",
-      "ref": "v0.13.3"
+      "ref": "v0.14.0"
     }
   },
   {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -716,7 +716,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.14.1",
+    "version": "0.15.0",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"
@@ -735,7 +735,7 @@
     "source": {
       "source": "github",
       "repo": "oliver-zehentleitner/keep-the-why",
-      "ref": "v0.14.1"
+      "ref": "v0.15.0"
     }
   },
   {


### PR DESCRIPTION
Bumps the external plugin `keep-the-why` from 0.13.3 to 0.15.0 (`version` and `source.ref` in `plugins/external.json`), and regenerates `.github/plugin/marketplace.json` with `npm run plugin:generate-marketplace`. (Opened for 0.14.0; 0.14.1 and 0.15.0 followed the same day and the PR was updated in place.)

Releases: https://github.com/oliver-zehentleitner/keep-the-why/releases/tag/v0.15.0