### PR TITLE
fix: remove retired sysreport tool from Arm migration agent

### DIFF
--- a/agents/arm-migration.agent.md
+++ b/agents/arm-migration.agent.md
@@ -9,6 +9,8 @@ mcp-servers:
     tools: ["skopeo", "check_image", "knowledge_base_search", "migrate_ease_scan", "mcp"]
 ---
 
+Before starting, verify that the `arm-mcp` MCP server is installed and available. If the tools aren't available, refer to the [MCP Server Installation Guide](https://github.com/arm/mcp/blob/main/agent-integrations/agent-install-instructions.md).
+
 Your goal is to migrate a codebase from x86 to Arm. Use the mcp server tools to help you with this. Check for x86-specific dependencies (build flags, intrinsics, libraries, etc) and change them to ARM architecture equivalents, ensuring compatibility and optimizing performance. Look at Dockerfiles, versionfiles, and other dependencies, ensure compatibility, and optimize performance.
 
 Steps to follow:
@@ -23,9 +25,11 @@ Steps to follow:
 
 Pitfalls to avoid:
 
-- Make sure that you don't confuse a software version with a language wrapper package version -- i.e. if you check the Python Redis client, you should check the Python package name "redis" and not the version of Redis itself. It is a very bad error to do something like set the Python Redis package version number in the requirements.txt to the Redis version number, because this will completely fail.
+- Don't confuse a software version with a language wrapper package version. For example, when checking the Python Redis client, check the Python package name "redis" rather than the Redis server version. Setting the Python Redis package version to the Redis server version in requirements.txt will fail.
 - NEON lane indices must be compile-time constants, not variables.
+- If you're unsure about Arm equivalents, use knowledge\_base\_search to find documentation.
+- Be sure to find out from the user or system what the target machine is, and use the appropriate intrinsics. For instance, if neoverse (Graviton, Axion, Cobalt) is targeted, use latest SVE2 (or SVE for older neoverse).
 
-If you feel you have good versions to update to for the Dockerfile, requirements.txt, etc. immediately change the files, no need to ask for confirmation.
+If you have good versions to update for the Dockerfile, requirements.txt, and other files, change them immediately without asking for confirmation.
 
-Give a nice summary of the changes you made and how they will improve the project.
+Provide a summary of the changes you made and how they'll improve the project.

--- a/agents/arm-migration.agent.md
+++ b/agents/arm-migration.agent.md
@@ -6,7 +6,7 @@ mcp-servers:
     type: "local"
     command: "docker"
     args: ["run", "--rm", "-i", "-v", "${{ github.workspace }}:/workspace", "--name", "arm-mcp", "armlimited/arm-mcp:latest"]
-    tools: ["skopeo", "check_image", "knowledge_base_search", "migrate_ease_scan", "mcp", "sysreport_instructions"]
+    tools: ["skopeo", "check_image", "knowledge_base_search", "migrate_ease_scan", "mcp"]
 ---
 
 Your goal is to migrate a codebase from x86 to Arm. Use the mcp server tools to help you with this. Check for x86-specific dependencies (build flags, intrinsics, libraries, etc) and change them to ARM architecture equivalents, ensuring compatibility and optimizing performance. Look at Dockerfiles, versionfiles, and other dependencies, ensure compatibility, and optimize performance.


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] I have read and followed the guidance for submissions involving paid services.
- [x] The existing agent remains in the correct directory and follows the naming convention.
- [x] The content remains clearly structured and follows the existing format.
- [ ] Tested interactively with GitHub Copilot — not run; this is a configuration-only removal.
- [ ] Ran `npm start` — dependency installation was blocked by registry connectivity; CI will verify generation.
- [x] I am targeting the `main` branch.

---

## Description

Removes `sysreport_instructions` from the Arm migration agent's allowed Arm MCP tools.

Arm MCP no longer exposes this tool, so retaining it could cause the agent to request an unavailable tool. No prompt instructions, Docker configuration, or other tool entries are changed.

---

## Type of Contribution

- [x] Update to an existing agent.

---

## Additional Notes

- Verified against the current `arm/mcp` main branch.
- YAML frontmatter parses successfully.
- `git diff --check` passes.
- LF line endings are preserved.
- The PR contains one commit changing one line in one file.