### PR TITLE
keep-the-why: bump to 0.17.0

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1008,7 +1008,7 @@
     {
       "name": "keep-the-why",
       "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "author": {
         "name": "Oliver Zehentleitner",
         "url": "https://github.com/oliver-zehentleitner"
@@ -1027,7 +1027,7 @@
       "source": {
         "source": "github",
         "repo": "oliver-zehentleitner/keep-the-why",
-        "ref": "v0.16.0"
+        "ref": "v0.16.1"
       }
     },
     {

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1008,7 +1008,7 @@
     {
       "name": "keep-the-why",
       "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "author": {
         "name": "Oliver Zehentleitner",
         "url": "https://github.com/oliver-zehentleitner"
@@ -1027,7 +1027,7 @@
       "source": {
         "source": "github",
         "repo": "oliver-zehentleitner/keep-the-why",
-        "ref": "v0.15.0"
+        "ref": "v0.16.0"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -716,7 +716,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"
@@ -735,7 +735,7 @@
     "source": {
       "source": "github",
       "repo": "oliver-zehentleitner/keep-the-why",
-      "ref": "v0.15.0"
+      "ref": "v0.16.0"
     }
   },
   {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -716,7 +716,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.16.1",
+    "version": "0.16.2",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -716,7 +716,7 @@
   {
     "name": "keep-the-why",
     "description": "Preserves or recovers the reasoning behind a codebase — architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "author": {
       "name": "Oliver Zehentleitner",
       "url": "https://github.com/oliver-zehentleitner"
@@ -735,7 +735,7 @@
     "source": {
       "source": "github",
       "repo": "oliver-zehentleitner/keep-the-why",
-      "ref": "v0.16.0"
+      "ref": "v0.16.1"
     }
   },
   {


### PR DESCRIPTION
Bumps the external plugin `keep-the-why` to its 0.17.0 release: `version` and `source.ref` (`v0.17.0`, an immutable release tag) in `plugins/external.json`, and `.github/plugin/marketplace.json` regenerated with `npm run plugin:generate-marketplace`.

Note on `source.ref`: the previous bumps in this PR moved `version` only and left `ref` at `v0.16.1`; both now point at the same release.

Release notes: https://github.com/oliver-zehentleitner/keep-the-why/releases/tag/v0.17.0