### PR TITLE
Update crowdstrike-falcon-fusion to v1.2.0

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -544,7 +544,7 @@
     {
       "name": "crowdstrike-falcon-fusion",
       "description": "AI coding assistant skills for building CrowdStrike Falcon Fusion workflows: action discovery, YAML authoring, deployment, execution monitoring, and best practices for triggers, conditions, loops, and HTTP Actions.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "CrowdStrike",
         "url": "https://www.crowdstrike.com"
@@ -561,8 +561,8 @@
       "source": {
         "source": "github",
         "repo": "CrowdStrike/fusion-skills",
-        "ref": "v1.1.0",
-        "sha": "8df28a78be316f619a0a5227a401b395da990c40"
+        "ref": "v1.2.0",
+        "sha": "3e15710a94b712473e87ce7cd7c43d026156a3f3"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -396,7 +396,7 @@
   {
     "name": "crowdstrike-falcon-fusion",
     "description": "AI coding assistant skills for building CrowdStrike Falcon Fusion workflows: action discovery, YAML authoring, deployment, execution monitoring, and best practices for triggers, conditions, loops, and HTTP Actions.",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "author": {
       "name": "CrowdStrike",
       "url": "https://www.crowdstrike.com"
@@ -413,8 +413,8 @@
     "source": {
       "source": "github",
       "repo": "CrowdStrike/fusion-skills",
-      "ref": "v1.1.0",
-      "sha": "8df28a78be316f619a0a5227a401b395da990c40"
+      "ref": "v1.2.0",
+      "sha": "3e15710a94b712473e87ce7cd7c43d026156a3f3"
     }
   },
   {


### PR DESCRIPTION
Version bump for the already-listed external plugin `crowdstrike-falcon-fusion`, following the "Updating listed external plugins via PR" workflow in CONTRIBUTING.md.

Updates the entry in `plugins/external.json`:

- `version`: 1.1.0 → 1.2.0
- `source.ref`: v1.1.0 → v1.2.0
- `source.sha`: 8df28a78be316f619a0a5227a401b395da990c40 → 3e15710a94b712473e87ce7cd7c43d026156a3f3

The new ref and sha point to the published [v1.2.0 release](https://github.com/CrowdStrike/fusion-skills/releases/tag/v1.2.0). Both the ref and sha are immutable. No other entries are modified.