### PR TITLE
Update upgrade-agent plugin to 1.1.514

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1858,7 +1858,7 @@
     {
       "name": "upgrade-agent",
       "description": "AI-powered upgrade assistant for upgrading and migrating applications. Helps modernize legacy code and upgrade .NET applications to current frameworks.",
-      "version": "1.1.485",
+      "version": "1.1.514",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -1877,8 +1877,8 @@
         "source": "github",
         "repo": "microsoft/upgrade-agent-plugins",
         "path": "plugins/upgrade-agent",
-        "ref": "v1.1.485",
-        "sha": "de2dd654a288726652de81998fbaff7a849891dc"
+        "ref": "v1.1.514",
+        "sha": "edfa6465916b5f4b9c6f8ca558b69518621ab810"
       }
     },
     {

--- a/plugins/external.json
+++ b/plugins/external.json
@@ -1278,7 +1278,7 @@
   {
     "name": "upgrade-agent",
     "description": "AI-powered upgrade assistant for upgrading and migrating applications. Helps modernize legacy code and upgrade .NET applications to current frameworks.",
-    "version": "1.1.485",
+    "version": "1.1.514",
     "author": {
       "name": "Microsoft",
       "url": "https://www.microsoft.com"
@@ -1297,8 +1297,8 @@
       "source": "github",
       "repo": "microsoft/upgrade-agent-plugins",
       "path": "plugins/upgrade-agent",
-      "ref": "v1.1.485",
-      "sha": "de2dd654a288726652de81998fbaff7a849891dc"
+      "ref": "v1.1.514",
+      "sha": "edfa6465916b5f4b9c6f8ca558b69518621ab810"
     }
   },
   {


### PR DESCRIPTION
Automated version bump of the upgrade-agent external plugin entry from UpgradeAssistant build 2026-09-09-20260909.2 (version 1.1.514). Pinned to tag v1.1.514 / commit edfa6465916b5f4b9c6f8ca558b69518621ab810 in microsoft/upgrade-agent-plugins.